### PR TITLE
Added long and int implicit operator to chatID

### DIFF
--- a/src/Telegram.Bot/Types/ChatId.cs
+++ b/src/Telegram.Bot/Types/ChatId.cs
@@ -75,8 +75,7 @@ namespace Telegram.Bot.Types
         {
             try
             {
-                 int intChatId = (int) chatid.Identifier;
-                 return intChatId;
+                 return Convert.ToInt32(chatid.Identifier)
             }
             catch(OverflowException)
             {

--- a/src/Telegram.Bot/Types/ChatId.cs
+++ b/src/Telegram.Bot/Types/ChatId.cs
@@ -75,7 +75,7 @@ namespace Telegram.Bot.Types
         {
             try
             {
-                 return Convert.ToInt32(chatid.Identifier)
+                 return Convert.ToInt32(chatid.Identifier);
             }
             catch(OverflowException)
             {

--- a/src/Telegram.Bot/Types/ChatId.cs
+++ b/src/Telegram.Bot/Types/ChatId.cs
@@ -71,7 +71,18 @@ namespace Telegram.Bot.Types
         /// Create a <c>int</c> out of a <see cref="ChatId"/>
         /// </summary>
         /// <param name="chatid">The <see cref="ChatId"/></param>
-        public static implicit operator int(ChatId chatid) => checked((int) chatid.Identifier);
+        public static implicit operator int(ChatId chatid)
+        {
+            try
+            {
+                 int intChatId = (int) chatid.Identifier;
+                 return intChatId;
+            }
+            catch(OverflowException)
+            {
+                throw;
+            }
+        }
 
         /// <summary>
         /// Create a <c>string</c> out of a <see cref="ChatId"/>

--- a/src/Telegram.Bot/Types/ChatId.cs
+++ b/src/Telegram.Bot/Types/ChatId.cs
@@ -71,17 +71,7 @@ namespace Telegram.Bot.Types
         /// Create a <c>int</c> out of a <see cref="ChatId"/>
         /// </summary>
         /// <param name="chatid">The <see cref="ChatId"/></param>
-        public static implicit operator int(ChatId chatid)
-        {
-            try
-            {
-                 return Convert.ToInt32(chatid.Identifier);
-            }
-            catch(OverflowException)
-            {
-                throw;
-            }
-        }
+        public static implicit operator int(ChatId chatid) => return Convert.ToInt32(chatId.Identifier);
 
         /// <summary>
         /// Create a <c>string</c> out of a <see cref="ChatId"/>

--- a/src/Telegram.Bot/Types/ChatId.cs
+++ b/src/Telegram.Bot/Types/ChatId.cs
@@ -1,4 +1,5 @@
-﻿using Newtonsoft.Json;
+﻿using System;
+using Newtonsoft.Json;
 using Telegram.Bot.Converters;
 
 namespace Telegram.Bot.Types
@@ -11,6 +12,7 @@ namespace Telegram.Bot.Types
     {
         internal long Identifier;
         internal string Username;
+
 
         /// <summary>
         /// Create a <see cref="ChatId"/> using an identifier
@@ -58,6 +60,18 @@ namespace Telegram.Bot.Types
         /// </summary>
         /// <param name="username">The user name</param>
         public static implicit operator ChatId(string username) => new ChatId(username);
+
+        /// <summary>
+        /// Create a <c>long</c> out of a <see cref="ChatId"/>
+        /// </summary>
+        /// <param name="chatid">The <see cref="ChatId"/></param>
+        public static implicit operator long(ChatId chatid) => chatid.Identifier;
+
+        /// <summary>
+        /// Create a <c>int</c> out of a <see cref="ChatId"/>
+        /// </summary>
+        /// <param name="chatid">The <see cref="ChatId"/></param>
+        public static implicit operator int(ChatId chatid) => checked((int) chatid.Identifier);
 
         /// <summary>
         /// Create a <c>string</c> out of a <see cref="ChatId"/>


### PR DESCRIPTION
Added implicit operator for long and int in Telegram.Bot.Types.ChatId to improve backwards compatibility with older projects who are expecting int or long to be returned by chat ID. 