### PR TITLE
Fix "Bad Request: file must be non-empty" error when use stream as a source for SendPhotoAsync

### DIFF
--- a/src/Telegram.Bot/Types/FileToSend.cs
+++ b/src/Telegram.Bot/Types/FileToSend.cs
@@ -54,6 +54,7 @@ namespace Telegram.Bot.Types
         {
             Filename = filename;
             Content = content;
+            Content.Position = 0;	 
 
             Url = null;
             FileId = null;


### PR DESCRIPTION
When you generates image on the fly (i use OxyPlot to generate charts) and send it using SendPhotoAsync, you will get an error: Bad Request: file must be non-empty.
To avoid this situation you need to set Position property of that stream to 0.
I am proposing to add this to the FileToSend constructor.
It should not affect any other cases e.g. when you reading stream from the file on the disk.
