### PR TITLE
Add currency and prices test configuration

### DIFF
--- a/test/Telegram.Bot.Tests.Integ/Common/ConfigurationProvider.cs
+++ b/test/Telegram.Bot.Tests.Integ/Common/ConfigurationProvider.cs
@@ -27,6 +27,8 @@ namespace Telegram.Bot.Tests.Integ.Common
                 ChannelChatId = configuration[nameof(TestConfigurations.ChannelChatId)],
 
                 PaymentProviderToken = configuration[nameof(TestConfigurations.PaymentProviderToken)],
+                Currency = configuration[nameof(TestConfigurations.Currency)],
+                Prices = configuration[nameof(TestConfigurations.Prices)],
                 TesterPrivateChatId = long.Parse(configuration[nameof(TestConfigurations.TesterPrivateChatId)]),
 
                 StickerOwnerUserId = int.Parse(configuration[nameof(TestConfigurations.StickerOwnerUserId)]),

--- a/test/Telegram.Bot.Tests.Integ/Common/TestConfigurations.cs
+++ b/test/Telegram.Bot.Tests.Integ/Common/TestConfigurations.cs
@@ -32,6 +32,25 @@ namespace Telegram.Bot.Tests.Integ.Common
 
         public long? TesterPrivateChatId { get; set; }
 
+        public string Currency { get; set; }
+
+        public string Prices { get; set; }
+
+        public int[] PricesArray {
+            get
+            {
+                if (_prices == null)
+                {
+                    _prices = Prices
+                        .Split(",".ToCharArray(), StringSplitOptions.RemoveEmptyEntries)
+                        .Select(price => int.Parse(price.Trim()))
+                        .ToArray();
+                }
+
+                return _prices;
+            }
+        }
+
         public int? StickerOwnerUserId { get; set; }
 
         public string RegularMemberUserId { get; set; }
@@ -41,5 +60,7 @@ namespace Telegram.Bot.Tests.Integ.Common
         public string RegularMemberPrivateChatId { get; set; }
 
         private string[] _allowedUsers;
+
+        private int[] _prices;
     }
 }

--- a/test/Telegram.Bot.Tests.Integ/Payment/PaymentTests.cs
+++ b/test/Telegram.Bot.Tests.Integ/Payment/PaymentTests.cs
@@ -35,15 +35,14 @@ namespace Telegram.Bot.Tests.Integ.Payment
 
             const string payload = "my-payload";
 
-            LabeledPrice[] prices =
-            {
-                new LabeledPrice() {Amount = 150, Label = "One dollar 50 cents"},
-                new LabeledPrice() {Amount = 2029, Label = "20 dollars 29 cents"},
-            };
+            LabeledPrice[] prices = _classFixture.Prices
+                .Select(price => new LabeledPrice {Amount = price, Label = $"{price}"})
+                .ToArray();
+
             Invoice invoice = new Invoice
             {
                 Title = "PRODUCT_TITLE",
-                Currency = "CAD",
+                Currency = _classFixture.Currency,
                 StartParameter = "start_param",
                 TotalAmount = prices.Sum(p => p.Amount),
                 Description = "PRODUCT_DESCRIPTION",
@@ -78,25 +77,36 @@ namespace Telegram.Bot.Tests.Integ.Payment
 
             const string payload = "shippingquery-ok-payload";
 
-            LabeledPrice[] productPrices =
-            {
-                new LabeledPrice {Amount = 150, Label = "One dollar 50 cents"},
-                new LabeledPrice {Amount = 2029, Label = "20 dollars 29 cents"},
-            };
+            LabeledPrice[] productPrices = _classFixture.Prices
+                .Select(price => new LabeledPrice {Amount = price, Label = $"{price}"})
+                .ToArray();
+
             Invoice invoice = new Invoice
             {
                 Title = "PRODUCT_TITLE",
-                Currency = "CAD",
+                Currency = _classFixture.Currency,
                 StartParameter = "start_param",
                 TotalAmount = productPrices.Sum(p => p.Amount),
                 Description = "PRODUCT_DESCRIPTION",
             };
 
-            LabeledPrice[] shippingPrices =
-            {
-                new LabeledPrice {Amount = 500, Label = "SHIPPING1: 500"},
-                new LabeledPrice {Amount = 299, Label = "SHIPPING2: 299"},
-            };
+
+
+//            LabeledPrice[] shippingPrices =
+//            {
+//                new LabeledPrice {Amount = 500, Label = "SHIPPING1: 500"},
+//                new LabeledPrice {Amount = 299, Label = "SHIPPING2: 299"},
+//            };
+
+
+
+            LabeledPrice[] shippingPrices = _classFixture.Prices
+                .Select((price, index) => new LabeledPrice {Amount = price, Label = $"SHIPPING{index}: {price}"})
+                .ToArray();
+
+
+
+
 
             ShippingOption[] shippingOptions =
             {
@@ -151,15 +161,21 @@ namespace Telegram.Bot.Tests.Integ.Payment
 
             const string payload = "precheckout-ok-payload";
 
-            LabeledPrice[] productPrices =
-            {
-                new LabeledPrice {Amount = 150, Label = "One dollar 50 cents"},
-                new LabeledPrice {Amount = 2029, Label = "20 dollars 29 cents"},
-            };
+//            LabeledPrice[] productPrices =
+//            {
+//                new LabeledPrice {Amount = 150, Label = "One dollar 50 cents"},
+//                new LabeledPrice {Amount = 2029, Label = "20 dollars 29 cents"},
+//            };
+            LabeledPrice[] productPrices = _classFixture.Prices
+                .Select(price => new LabeledPrice {Amount = price, Label = $"{price}"})
+                .ToArray();
+
+
+
             Invoice invoice = new Invoice
             {
                 Title = "PRODUCT_TITLE",
-                Currency = "USD",
+                Currency = _classFixture.Currency,
                 StartParameter = "start_param",
                 TotalAmount = productPrices.Sum(p => p.Amount),
                 Description = "PRODUCT_DESCRIPTION",
@@ -202,16 +218,22 @@ namespace Telegram.Bot.Tests.Integ.Payment
             await _classFixture.SendTestCaseNotificationAsync(FactTitles.ShouldThrowWhenSendInvoiceInvalidJson);
 
             const string payload = "my-payload";
+//
+//            LabeledPrice[] prices =
+//            {
+//                new LabeledPrice {Amount = 150, Label = "One dollar 50 cents"},
+//                new LabeledPrice {Amount = 2029, Label = "20 dollars 29 cents"},
+//            };
 
-            LabeledPrice[] prices =
-            {
-                new LabeledPrice {Amount = 150, Label = "One dollar 50 cents"},
-                new LabeledPrice {Amount = 2029, Label = "20 dollars 29 cents"},
-            };
+            LabeledPrice[] prices = _classFixture.Prices
+                .Select(price => new LabeledPrice {Amount = price, Label = $"{price}"})
+                .ToArray();
+
+
             Invoice invoice = new Invoice
             {
                 Title = "PRODUCT_TITLE",
-                Currency = "CAD",
+                Currency = _classFixture.Currency,
                 StartParameter = "start_param",
                 TotalAmount = prices.Sum(p => p.Amount),
                 Description = "PRODUCT_DESCRIPTION",

--- a/test/Telegram.Bot.Tests.Integ/Payment/PaymentTestsFixture.cs
+++ b/test/Telegram.Bot.Tests.Integ/Payment/PaymentTestsFixture.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Linq;
 using System.Threading.Tasks;
 using Telegram.Bot.Tests.Integ.Common;
 using Telegram.Bot.Types;
@@ -14,6 +15,10 @@ namespace Telegram.Bot.Tests.Integ.Payment
 
         public string PaymentProviderToken { get; }
 
+        public string Currency { get; set; }
+
+        public int[] Prices { get; set; }
+
         public PaymentTestsFixture(TestsFixture testsFixture)
         {
             TestsFixture = testsFixture;
@@ -28,6 +33,29 @@ namespace Telegram.Bot.Tests.Integ.Payment
             if (PaymentProviderToken.Length < 15)
             {
                 throw new ArgumentException("Payment provider token is too short.", nameof(PaymentProviderToken));
+            }
+
+            Currency = ConfigurationProvider.TestConfigurations.Currency;
+            if (string.IsNullOrWhiteSpace(Currency))
+            {
+                throw new ArgumentNullException(nameof(Currency),
+                    "Currency is not provided or is empty.");
+            }
+
+            if (Currency.Length > 3)
+            {
+                throw new ArgumentException("Currency is too long. It should consist of 3 letters.", nameof(Currency));
+            }
+
+            Prices = ConfigurationProvider.TestConfigurations.PricesArray;
+            if (!Prices.Any())
+            {
+                throw new ArgumentException("There is no prices in configuration. Provide at least one price.", nameof(Prices));
+            }
+
+            if (Currency.Length > 3)
+            {
+                throw new ArgumentException("Currency is too long. It should consist of 3 letters.", nameof(Currency));
             }
 
             var privateChatId = ConfigurationProvider.TestConfigurations.TesterPrivateChatId;

--- a/test/Telegram.Bot.Tests.Integ/appsettings.json
+++ b/test/Telegram.Bot.Tests.Integ/appsettings.json
@@ -7,6 +7,8 @@
 
   "PaymentProviderToken": "",
   "TesterPrivateChatId": "",
+  "Currency": "",
+  "Prices": "",
 
   "StickerOwnerUserId": "",
 


### PR DESCRIPTION
This PR will add configuration for a currency and a list of prices. They are needed because not every payments provider support every currency and every currency have a minimal total sum.