### PR TITLE
Use reflection to find RunSummary property

### DIFF
--- a/test/Telegram.Bot.Tests.Integ/Framework/XunitExtensions/XunitTestAssemblyRunnerWithAssemblyFixture.cs
+++ b/test/Telegram.Bot.Tests.Integ/Framework/XunitExtensions/XunitTestAssemblyRunnerWithAssemblyFixture.cs
@@ -58,8 +58,14 @@ namespace Telegram.Bot.Tests.Integ.Framework.XunitExtensions
                 .RunAsync()
                 .ContinueWith(t =>
                     {
-                        var fixture = (TestsFixture)_assemblyFixtureMappings.Single().Value;
-                        fixture.RunSummary.Aggregate(t.Result);
+                        foreach (var (fixtureType, fixture) in _assemblyFixtureMappings)
+                        {
+                            var rsProperty = fixtureType
+                                .GetProperties()
+                                .SingleOrDefault(p => p.PropertyType == typeof(RunSummary));
+
+                            ((RunSummary)rsProperty?.GetValue(fixture, null))?.Aggregate(t.Result);
+                        }
                         return t.Result;
                     })
                 ;


### PR DESCRIPTION
Use reflection on fixture class instead of explicit casting to TestsFixture class. This would allow to have multiple Assembly Fixtures and to not rely on RunSummary property naming