### PR TITLE
Make parameterless constructors for InlineQueryResults private and other changes

### DIFF
--- a/src/Telegram.Bot/Telegram.Bot.csproj
+++ b/src/Telegram.Bot/Telegram.Bot.csproj
@@ -23,6 +23,7 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Newtonsoft.Json" Version="10.0.3" />
+    <PackageReference Include="System.Net.Requests" Version="4.3.0" />
   </ItemGroup>
   <ItemGroup Condition="'$(TargetFramework)'=='net45'">
     <Reference Include="System.Net.Http" />

--- a/src/Telegram.Bot/TelegramBotClient.cs
+++ b/src/Telegram.Bot/TelegramBotClient.cs
@@ -349,7 +349,14 @@ namespace Telegram.Bot
         /// </summary>
         public void StopReceiving()
         {
-            _receivingCancellationTokenSource.Cancel();
+            try
+            {
+                _receivingCancellationTokenSource.Cancel();
+            }
+            catch (WebException)
+            { }
+            catch (TaskCanceledException)
+            { }
         }
 
         #endregion Helpers

--- a/src/Telegram.Bot/Types/InlineQueryResults/InlineQueryResultArticle.cs
+++ b/src/Telegram.Bot/Types/InlineQueryResults/InlineQueryResultArticle.cs
@@ -51,15 +51,10 @@ namespace Telegram.Bot.Types.InlineQueryResults
         [JsonProperty(DefaultValueHandling = DefaultValueHandling.Ignore)]
         public int ThumbHeight { get; set; }
 
-
-        /// <summary>
-        /// Initializes a new inline query result
-        /// </summary>
-        public InlineQueryResultArticle()
+        private InlineQueryResultArticle()
             : base(InlineQueryResultType.Article)
-        {
-        }
-
+        { }
+        
         /// <summary>
         /// Initializes a new inline query result
         /// </summary>
@@ -67,9 +62,8 @@ namespace Telegram.Bot.Types.InlineQueryResults
         /// <param name="title">Title of the result</param>
         /// <param name="inputMessageContent">Content of the message to be sent</param>
         public InlineQueryResultArticle(string id, string title, InputMessageContent inputMessageContent)
-            : this()
+            : base(InlineQueryResultType.Article, id)
         {
-            Id = id;
             Title = title;
             InputMessageContent = inputMessageContent;
         }

--- a/src/Telegram.Bot/Types/InlineQueryResults/InlineQueryResultAudio.cs
+++ b/src/Telegram.Bot/Types/InlineQueryResults/InlineQueryResultAudio.cs
@@ -42,14 +42,10 @@ namespace Telegram.Bot.Types.InlineQueryResults
         /// <inheritdoc />
         [JsonProperty(DefaultValueHandling = DefaultValueHandling.Ignore)]
         public InputMessageContent InputMessageContent { get; set; }
-
-        /// <summary>
-        /// Initializes a new inline query result
-        /// </summary>
-        public InlineQueryResultAudio()
+        
+        private InlineQueryResultAudio()
             : base(InlineQueryResultType.Audio)
-        {
-        }
+        { }
 
         /// <summary>
         /// Initializes a new inline query result
@@ -58,9 +54,8 @@ namespace Telegram.Bot.Types.InlineQueryResults
         /// <param name="audioUrl">A valid URL for the audio file</param>
         /// <param name="title">Title of the result</param>
         public InlineQueryResultAudio(string id, string audioUrl, string title)
-            : this()
+            : base(InlineQueryResultType.Audio, id)
         {
-            Id = id;
             AudioUrl = audioUrl;
             Title = title;
         }

--- a/src/Telegram.Bot/Types/InlineQueryResults/InlineQueryResultBase.cs
+++ b/src/Telegram.Bot/Types/InlineQueryResults/InlineQueryResultBase.cs
@@ -14,13 +14,13 @@ namespace Telegram.Bot.Types.InlineQueryResults
         /// Unique identifier of this result
         /// </summary>
         [JsonProperty(Required = Required.Always)]
-        public string Id { get; set; }
+        public string Id { get; private set; }
 
         /// <summary>
         /// Type of the result
         /// </summary>
         [JsonProperty(Required = Required.Always)]
-        public InlineQueryResultType Type { get; set; }
+        public InlineQueryResultType Type { get; private set; }
 
         /// <summary>
         /// Inline keyboard attached to the message
@@ -35,6 +35,17 @@ namespace Telegram.Bot.Types.InlineQueryResults
         protected InlineQueryResultBase(InlineQueryResultType type)
         {
             Type = type;
+        }
+
+        ///  <summary>
+        /// Initializes a new inline query result
+        ///  </summary>
+        /// <param name="type">Type of the result</param>
+        /// <param name="id">Unique identifier of this result</param>
+        protected InlineQueryResultBase(InlineQueryResultType type, string id)
+            : this(type)
+        {
+            Id = id;
         }
     }
 }

--- a/src/Telegram.Bot/Types/InlineQueryResults/InlineQueryResultCachedAudio.cs
+++ b/src/Telegram.Bot/Types/InlineQueryResults/InlineQueryResultCachedAudio.cs
@@ -25,14 +25,10 @@ namespace Telegram.Bot.Types.InlineQueryResults
         /// <inheritdoc />
         [JsonProperty(DefaultValueHandling = DefaultValueHandling.Ignore)]
         public InputMessageContent InputMessageContent { get; set; }
-
-        /// <summary>
-        /// Initializes a new inline query result
-        /// </summary>
-        public InlineQueryResultCachedAudio()
+        
+        private InlineQueryResultCachedAudio()
             : base(InlineQueryResultType.Audio)
-        {
-        }
+        { }
 
         /// <summary>
         /// Initializes a new inline query result
@@ -40,9 +36,8 @@ namespace Telegram.Bot.Types.InlineQueryResults
         /// <param name="id">Unique identifier of this result</param>
         /// <param name="audioFileId">A valid file identifier for the audio file</param>
         public InlineQueryResultCachedAudio(string id, string audioFileId)
-            : this()
+            : base(InlineQueryResultType.Audio, id)
         {
-            Id = id;
             AudioFileId = audioFileId;
         }
     }

--- a/src/Telegram.Bot/Types/InlineQueryResults/InlineQueryResultCachedDocument.cs
+++ b/src/Telegram.Bot/Types/InlineQueryResults/InlineQueryResultCachedDocument.cs
@@ -36,11 +36,8 @@ namespace Telegram.Bot.Types.InlineQueryResults
         /// <inheritdoc />
         [JsonProperty(DefaultValueHandling = DefaultValueHandling.Ignore)]
         public InputMessageContent InputMessageContent { get; set; }
-
-        /// <summary>
-        /// Initializes a new inline query result
-        /// </summary>
-        public InlineQueryResultCachedDocument()
+        
+        private InlineQueryResultCachedDocument()
             : base(InlineQueryResultType.Document)
         { }
 
@@ -51,9 +48,8 @@ namespace Telegram.Bot.Types.InlineQueryResults
         /// <param name="documentFileId">A valid file identifier for the file</param>
         /// <param name="title">Title of the result</param>
         public InlineQueryResultCachedDocument(string id, string documentFileId, string title)
-            : this()
+            : base(InlineQueryResultType.Document, id)
         {
-            Id = id;
             DocumentFileId = documentFileId;
             Title = title;
         }

--- a/src/Telegram.Bot/Types/InlineQueryResults/InlineQueryResultCachedGif.cs
+++ b/src/Telegram.Bot/Types/InlineQueryResults/InlineQueryResultCachedGif.cs
@@ -31,10 +31,7 @@ namespace Telegram.Bot.Types.InlineQueryResults
         [JsonProperty(DefaultValueHandling = DefaultValueHandling.Ignore)]
         public InputMessageContent InputMessageContent { get; set; }
 
-        /// <summary>
-        /// Initializes a new inline query result
-        /// </summary>
-        public InlineQueryResultCachedGif()
+        private InlineQueryResultCachedGif()
             : base(InlineQueryResultType.Gif)
         { }
 
@@ -44,9 +41,8 @@ namespace Telegram.Bot.Types.InlineQueryResults
         /// <param name="id">Unique identifier of this result</param>
         /// <param name="gifFileId">A valid file identifier for the GIF file</param>
         public InlineQueryResultCachedGif(string id, string gifFileId)
-            : this()
+            : base(InlineQueryResultType.Gif, id)
         {
-            Id = id;
             GifFileId = gifFileId;
         }
     }

--- a/src/Telegram.Bot/Types/InlineQueryResults/InlineQueryResultCachedMpeg4Gif.cs
+++ b/src/Telegram.Bot/Types/InlineQueryResults/InlineQueryResultCachedMpeg4Gif.cs
@@ -31,10 +31,7 @@ namespace Telegram.Bot.Types.InlineQueryResults
         [JsonProperty(DefaultValueHandling = DefaultValueHandling.Ignore)]
         public InputMessageContent InputMessageContent { get; set; }
 
-        /// <summary>
-        /// Initializes a new inline query result
-        /// </summary>
-        public InlineQueryResultCachedMpeg4Gif()
+        private InlineQueryResultCachedMpeg4Gif()
             : base(InlineQueryResultType.Mpeg4Gif)
         { }
 
@@ -44,9 +41,8 @@ namespace Telegram.Bot.Types.InlineQueryResults
         /// <param name="id">Unique identifier of this result</param>
         /// <param name="mpeg4FileId">A valid file identifier for the MP4 file</param>
         public InlineQueryResultCachedMpeg4Gif(string id, string mpeg4FileId)
-            : this()
+            : base(InlineQueryResultType.Mpeg4Gif, id)
         {
-            Id = id;
             Mpeg4FileId = mpeg4FileId;
         }
     }

--- a/src/Telegram.Bot/Types/InlineQueryResults/InlineQueryResultCachedPhoto.cs
+++ b/src/Telegram.Bot/Types/InlineQueryResults/InlineQueryResultCachedPhoto.cs
@@ -37,13 +37,9 @@ namespace Telegram.Bot.Types.InlineQueryResults
         [JsonProperty(DefaultValueHandling = DefaultValueHandling.Ignore)]
         public InputMessageContent InputMessageContent { get; set; }
 
-        /// <summary>
-        /// Initializes a new inline query result
-        /// </summary>
-        public InlineQueryResultCachedPhoto()
+        private InlineQueryResultCachedPhoto()
             : base(InlineQueryResultType.Photo)
-        {
-        }
+        { }
 
         /// <summary>
         /// Initializes a new inline query result
@@ -51,9 +47,8 @@ namespace Telegram.Bot.Types.InlineQueryResults
         /// <param name="id">Unique identifier of this result</param>
         /// <param name="photoFileId">A valid file identifier of the photo</param>
         public InlineQueryResultCachedPhoto(string id, string photoFileId)
-            : this()
+            : base(InlineQueryResultType.Photo, id)
         {
-            Id = id;
             PhotoFileId = photoFileId;
         }
     }

--- a/src/Telegram.Bot/Types/InlineQueryResults/InlineQueryResultCachedSticker.cs
+++ b/src/Telegram.Bot/Types/InlineQueryResults/InlineQueryResultCachedSticker.cs
@@ -21,10 +21,7 @@ namespace Telegram.Bot.Types.InlineQueryResults
         [JsonProperty(DefaultValueHandling = DefaultValueHandling.Ignore)]
         public InputMessageContent InputMessageContent { get; set; }
 
-        /// <summary>
-        /// Initializes a new inline query result
-        /// </summary>
-        public InlineQueryResultCachedSticker()
+        private InlineQueryResultCachedSticker()
             : base(InlineQueryResultType.Sticker)
         { }
 
@@ -34,9 +31,8 @@ namespace Telegram.Bot.Types.InlineQueryResults
         /// <param name="id">Unique identifier of this result</param>
         /// <param name="stickerFileId">A valid file identifier of the sticker</param>
         public InlineQueryResultCachedSticker(string id, string stickerFileId)
-            : this()
+            : base(InlineQueryResultType.Sticker, id)
         {
-            Id = id;
             StickerFileId = stickerFileId;
         }
     }

--- a/src/Telegram.Bot/Types/InlineQueryResults/InlineQueryResultCachedVideo.cs
+++ b/src/Telegram.Bot/Types/InlineQueryResults/InlineQueryResultCachedVideo.cs
@@ -37,13 +37,9 @@ namespace Telegram.Bot.Types.InlineQueryResults
         [JsonProperty(DefaultValueHandling = DefaultValueHandling.Ignore)]
         public InputMessageContent InputMessageContent { get; set; }
 
-        /// <summary>
-        /// Initializes a new inline query result
-        /// </summary>
-        public InlineQueryResultCachedVideo()
+        private InlineQueryResultCachedVideo()
             : base(InlineQueryResultType.Video)
-        {
-        }
+        { }
 
         /// <summary>
         /// Initializes a new inline query result
@@ -52,9 +48,8 @@ namespace Telegram.Bot.Types.InlineQueryResults
         /// <param name="videoFileId">A valid file identifier for the video file</param>
         /// <param name="title">Title of the result</param>
         public InlineQueryResultCachedVideo(string id, string videoFileId, string title)
-            : this()
+            : base(InlineQueryResultType.Video, id)
         {
-            Id = id;
             VideoFileId = videoFileId;
             Title = title;
         }

--- a/src/Telegram.Bot/Types/InlineQueryResults/InlineQueryResultCachedVoice.cs
+++ b/src/Telegram.Bot/Types/InlineQueryResults/InlineQueryResultCachedVoice.cs
@@ -31,13 +31,9 @@ namespace Telegram.Bot.Types.InlineQueryResults
         [JsonProperty(DefaultValueHandling = DefaultValueHandling.Ignore)]
         public InputMessageContent InputMessageContent { get; set; }
 
-        /// <summary>
-        /// Initializes a new inline query result
-        /// </summary>
-        public InlineQueryResultCachedVoice()
+        private InlineQueryResultCachedVoice()
             : base(InlineQueryResultType.Voice)
-        {
-        }
+        { }
 
         /// <summary>
         /// Initializes a new inline query result
@@ -46,9 +42,8 @@ namespace Telegram.Bot.Types.InlineQueryResults
         /// <param name="fileId">A valid file identifier for the voice message</param>
         /// <param name="title">Title of the result</param>
         public InlineQueryResultCachedVoice(string id, string fileId, string title)
-            : this()
+            : base(InlineQueryResultType.Voice, id)
         {
-            Id = id;
             VoiceFileId = fileId;
             Title = title;
         }

--- a/src/Telegram.Bot/Types/InlineQueryResults/InlineQueryResultContact.cs
+++ b/src/Telegram.Bot/Types/InlineQueryResults/InlineQueryResultContact.cs
@@ -49,13 +49,9 @@ namespace Telegram.Bot.Types.InlineQueryResults
         [JsonProperty(DefaultValueHandling = DefaultValueHandling.Ignore)]
         public InputMessageContent InputMessageContent { get; set; }
 
-        /// <summary>
-        /// Initializes a new inline query result
-        /// </summary>
-        public InlineQueryResultContact()
+        private InlineQueryResultContact()
             : base(InlineQueryResultType.Contact)
-        {
-        }
+        { }
 
         /// <summary>
         /// Initializes a new inline query result
@@ -64,9 +60,8 @@ namespace Telegram.Bot.Types.InlineQueryResults
         /// <param name="phoneNumber">Contact's phone number</param>
         /// <param name="firstName">Contact's first name</param>
         public InlineQueryResultContact(string id, string phoneNumber, string firstName)
-            : this()
+            : base(InlineQueryResultType.Contact, id)
         {
-            Id = id;
             PhoneNumber = phoneNumber;
             FirstName = firstName;
         }

--- a/src/Telegram.Bot/Types/InlineQueryResults/InlineQueryResultDocument.cs
+++ b/src/Telegram.Bot/Types/InlineQueryResults/InlineQueryResultDocument.cs
@@ -59,10 +59,7 @@ namespace Telegram.Bot.Types.InlineQueryResults
         [JsonProperty(DefaultValueHandling = DefaultValueHandling.Ignore)]
         public InputMessageContent InputMessageContent { get; set; }
 
-        /// <summary>
-        /// Initializes a new inline query result
-        /// </summary>
-        public InlineQueryResultDocument()
+        private InlineQueryResultDocument()
             : base(InlineQueryResultType.Document)
         { }
 
@@ -74,9 +71,8 @@ namespace Telegram.Bot.Types.InlineQueryResults
         /// <param name="title">Title of the result</param>
         /// <param name="mimeType">Mime type of the content of the file, either “application/pdf” or “application/zip”</param>
         public InlineQueryResultDocument(string id, string documentUrl, string title, string mimeType)
-            : this()
+            : base(InlineQueryResultType.Document, id)
         {
-            Id = id;
             DocumentUrl = documentUrl;
             Title = title;
             MimeType = mimeType;

--- a/src/Telegram.Bot/Types/InlineQueryResults/InlineQueryResultGame.cs
+++ b/src/Telegram.Bot/Types/InlineQueryResults/InlineQueryResultGame.cs
@@ -9,10 +9,7 @@ namespace Telegram.Bot.Types.InlineQueryResults
     [JsonObject(MemberSerialization.OptIn, NamingStrategyType = typeof(SnakeCaseNamingStrategy))]
     public class InlineQueryResultGame : InlineQueryResultBase
     {
-        /// <summary>
-        /// Initializes a new inline query result
-        /// </summary>
-        public InlineQueryResultGame()
+        private InlineQueryResultGame()
             : base(InlineQueryResultType.Game)
         { }
 
@@ -22,9 +19,8 @@ namespace Telegram.Bot.Types.InlineQueryResults
         /// <param name="id">Unique identifier of this result</param>
         /// <param name="gameShortName">Short name of the game</param>
         public InlineQueryResultGame(string id, string gameShortName)
-            : this()
+            : base(InlineQueryResultType.Game, id)
         {
-            Id = id;
             GameShortName = gameShortName;
         }
 

--- a/src/Telegram.Bot/Types/InlineQueryResults/InlineQueryResultGif.cs
+++ b/src/Telegram.Bot/Types/InlineQueryResults/InlineQueryResultGif.cs
@@ -56,10 +56,7 @@ namespace Telegram.Bot.Types.InlineQueryResults
         [JsonProperty(DefaultValueHandling = DefaultValueHandling.Ignore)]
         public InputMessageContent InputMessageContent { get; set; }
 
-        /// <summary>
-        /// Initializes a new inline query result
-        /// </summary>
-        public InlineQueryResultGif()
+        private InlineQueryResultGif()
             : base(InlineQueryResultType.Gif)
         { }
 
@@ -70,9 +67,8 @@ namespace Telegram.Bot.Types.InlineQueryResults
         /// <param name="gifUrl">Width of the GIF</param>
         /// <param name="thumbUrl">Url of the thumbnail for the result.</param>
         public InlineQueryResultGif(string id, string gifUrl, string thumbUrl)
-            : this()
+            : base(InlineQueryResultType.Gif, id)
         {
-            Id = id;
             GifUrl = gifUrl;
             ThumbUrl = thumbUrl;
         }

--- a/src/Telegram.Bot/Types/InlineQueryResults/InlineQueryResultLocation.cs
+++ b/src/Telegram.Bot/Types/InlineQueryResults/InlineQueryResultLocation.cs
@@ -50,14 +50,10 @@ namespace Telegram.Bot.Types.InlineQueryResults
         /// <inheritdoc />
         [JsonProperty(DefaultValueHandling = DefaultValueHandling.Ignore)]
         public InputMessageContent InputMessageContent { get; set; }
-
-        /// <summary>
-        /// Initializes a new inline query result
-        /// </summary>
-        public InlineQueryResultLocation()
+        
+        private InlineQueryResultLocation()
             : base(InlineQueryResultType.Location)
-        {
-        }
+        { }
 
         /// <summary>
         /// Initializes a new inline query result
@@ -67,9 +63,8 @@ namespace Telegram.Bot.Types.InlineQueryResults
         /// <param name="longitude">Longitude of the location in degrees</param>
         /// <param name="title">Title of the result</param>
         public InlineQueryResultLocation(string id, float latitude, float longitude, string title)
-            : this()
+            : base(InlineQueryResultType.Location, id)
         {
-            Id = id;
             Latitude = latitude;
             Longitude = longitude;
             Title = title;

--- a/src/Telegram.Bot/Types/InlineQueryResults/InlineQueryResultMpeg4Gif.cs
+++ b/src/Telegram.Bot/Types/InlineQueryResults/InlineQueryResultMpeg4Gif.cs
@@ -55,11 +55,8 @@ namespace Telegram.Bot.Types.InlineQueryResults
         /// <inheritdoc />
         [JsonProperty(DefaultValueHandling = DefaultValueHandling.Ignore)]
         public InputMessageContent InputMessageContent { get; set; }
-
-        /// <summary>
-        /// Initializes a new inline query result
-        /// </summary>
-        public InlineQueryResultMpeg4Gif()
+        
+        private InlineQueryResultMpeg4Gif()
             : base(InlineQueryResultType.Mpeg4Gif)
         { }
 
@@ -70,9 +67,8 @@ namespace Telegram.Bot.Types.InlineQueryResults
         /// <param name="mpeg4Url">A valid URL for the MP4 file. File size must not exceed 1MB.</param>
         /// <param name="thumbUrl">Url of the thumbnail for the result.</param>
         public InlineQueryResultMpeg4Gif(string id, string mpeg4Url, string thumbUrl)
-            : this()
+            : base(InlineQueryResultType.Mpeg4Gif, id)
         {
-            Id = id;
             Mpeg4Url = mpeg4Url;
             ThumbUrl = thumbUrl;
         }

--- a/src/Telegram.Bot/Types/InlineQueryResults/InlineQueryResultPhoto.cs
+++ b/src/Telegram.Bot/Types/InlineQueryResults/InlineQueryResultPhoto.cs
@@ -55,14 +55,10 @@ namespace Telegram.Bot.Types.InlineQueryResults
         /// <inheritdoc />
         [JsonProperty(DefaultValueHandling = DefaultValueHandling.Ignore)]
         public InputMessageContent InputMessageContent { get; set; }
-
-        /// <summary>
-        /// Initializes a new inline query result
-        /// </summary>
-        public InlineQueryResultPhoto()
+        
+        private InlineQueryResultPhoto()
             : base(InlineQueryResultType.Photo)
-        {
-        }
+        { }
 
         /// <summary>
         /// Initializes a new inline query representing a link to a photo
@@ -71,9 +67,8 @@ namespace Telegram.Bot.Types.InlineQueryResults
         /// <param name="photoUrl">A valid URL of the photo. Photo size must not exceed 5MB.</param>
         /// <param name="thumbUrl">Optional. Url of the thumbnail for the result.</param>
         public InlineQueryResultPhoto(string id, string photoUrl, string thumbUrl)
-            : this()
+            : base(InlineQueryResultType.Photo, id)
         {
-            Id = id;
             PhotoUrl = photoUrl;
             ThumbUrl = thumbUrl;
         }

--- a/src/Telegram.Bot/Types/InlineQueryResults/InlineQueryResultVenue.cs
+++ b/src/Telegram.Bot/Types/InlineQueryResults/InlineQueryResultVenue.cs
@@ -56,14 +56,10 @@ namespace Telegram.Bot.Types.InlineQueryResults
         /// <inheritdoc />
         [JsonProperty(DefaultValueHandling = DefaultValueHandling.Ignore)]
         public InputMessageContent InputMessageContent { get; set; }
-
-        /// <summary>
-        /// Initializes a new inline query result
-        /// </summary>
-        public InlineQueryResultVenue()
+        
+        private InlineQueryResultVenue()
             : base(InlineQueryResultType.Venue)
-        {
-        }
+        { }
 
         /// <summary>
         /// Initializes a new inline query result
@@ -79,9 +75,8 @@ namespace Telegram.Bot.Types.InlineQueryResults
             float longitude,
             string title,
             string address)
-            : this()
+            : base(InlineQueryResultType.Venue, id)
         {
-            Id = id;
             Latitude = latitude;
             Longitude = longitude;
             Title = title;

--- a/src/Telegram.Bot/Types/InlineQueryResults/InlineQueryResultVideo.cs
+++ b/src/Telegram.Bot/Types/InlineQueryResults/InlineQueryResultVideo.cs
@@ -65,14 +65,10 @@ namespace Telegram.Bot.Types.InlineQueryResults
         /// <inheritdoc />
         [JsonProperty(DefaultValueHandling = DefaultValueHandling.Ignore)]
         public InputMessageContent InputMessageContent { get; set; }
-
-        /// <summary>
-        /// Initializes a new inline query result
-        /// </summary>
-        public InlineQueryResultVideo()
+        
+        private InlineQueryResultVideo()
             : base(InlineQueryResultType.Video)
-        {
-        }
+        { }
 
         /// <summary>
         /// Initializes a new inline query result
@@ -89,9 +85,8 @@ namespace Telegram.Bot.Types.InlineQueryResults
             string thumbUrl,
             string title
         )
-            : this()
+            : base(InlineQueryResultType.Video)
         {
-            Id = id;
             VideoUrl = videoUrl;
             MimeType = mimeType;
             ThumbUrl = thumbUrl;

--- a/src/Telegram.Bot/Types/InlineQueryResults/InlineQueryResultVoice.cs
+++ b/src/Telegram.Bot/Types/InlineQueryResults/InlineQueryResultVoice.cs
@@ -45,8 +45,7 @@ namespace Telegram.Bot.Types.InlineQueryResults
         /// </summary>
         public InlineQueryResultVoice()
             : base(InlineQueryResultType.Voice)
-        {
-        }
+        { }
 
         /// <summary>
         /// Initializes a new inline query result
@@ -55,9 +54,8 @@ namespace Telegram.Bot.Types.InlineQueryResults
         /// <param name="voiceUrl">A valid URL for the voice recording</param>
         /// <param name="title">Title of the result</param>
         public InlineQueryResultVoice(string id, string voiceUrl, string title)
-            : this()
+            : base(InlineQueryResultType.Voice, id)
         {
-            Id = id;
             VoiceUrl = voiceUrl;
             Title = title;
         }

--- a/src/Telegram.Bot/Types/InlineQueryResults/InputContactMessageContent.cs
+++ b/src/Telegram.Bot/Types/InlineQueryResults/InputContactMessageContent.cs
@@ -14,18 +14,32 @@ namespace Telegram.Bot.Types.InlineQueryResults
         /// Contact's phone number
         /// </summary>
         [JsonProperty(Required = Required.Always)]
-        public string PhoneNumber { get; set; }
+        public string PhoneNumber { get; private set; }
 
         /// <summary>
         /// Contact's first name
         /// </summary>
         [JsonProperty(Required = Required.Always)]
-        public string FirstName { get; set; }
+        public string FirstName { get; private set; }
 
         /// <summary>
         /// Optional. Contact's last name
         /// </summary>
         [JsonProperty(DefaultValueHandling = DefaultValueHandling.IgnoreAndPopulate)]
         public string LastName { get; set; }
+
+        private InputContactMessageContent()
+        { }
+
+        /// <summary>
+        /// Initializes a new input contact message content
+        /// </summary>
+        /// <param name="phoneNumber">The phone number of the contact</param>
+        /// <param name="firstName">The first name of the contact</param>
+        public InputContactMessageContent(string phoneNumber, string firstName)
+        {
+            PhoneNumber = phoneNumber;
+            FirstName = firstName;
+        }
     }
 }

--- a/src/Telegram.Bot/Types/InlineQueryResults/InputLocationMessageContent.cs
+++ b/src/Telegram.Bot/Types/InlineQueryResults/InputLocationMessageContent.cs
@@ -17,18 +17,32 @@ namespace Telegram.Bot.Types.InlineQueryResults
         /// Latitude of the location in degrees
         /// </summary>
         [JsonProperty(Required = Required.Always)]
-        public float Latitude { get; set; }
+        public float Latitude { get; private set; }
 
         /// <summary>
         /// Longitude of the location in degrees
         /// </summary>
         [JsonProperty(Required = Required.Always)]
-        public float Longitude { get; set; }
+        public float Longitude { get; private set; }
 
         /// <summary>
-        /// Longitude of the location in degrees
+        /// How long the live location will be updated
         /// </summary>
         [JsonProperty(DefaultValueHandling = DefaultValueHandling.IgnoreAndPopulate)]
         public int LivePeriod { get; set; }
+
+        private InputLocationMessageContent()
+        { }
+
+        /// <summary>
+        /// Initializes a new input location message content
+        /// </summary>
+        /// <param name="latitude">The latitude of the location</param>
+        /// <param name="longitude">The longitude of the location</param>
+        public InputLocationMessageContent(float latitude, float longitude)
+        {
+            Latitude = latitude;
+            Longitude = longitude;
+        }
     }
 }

--- a/src/Telegram.Bot/Types/InlineQueryResults/InputTextMessageContent.cs
+++ b/src/Telegram.Bot/Types/InlineQueryResults/InputTextMessageContent.cs
@@ -15,7 +15,7 @@ namespace Telegram.Bot.Types.InlineQueryResults
         /// Text of the message to be sent, 1-4096 characters
         /// </summary>
         [JsonProperty(Required = Required.Always)]
-        public string MessageText { get; set; }
+        public string MessageText { get; private set; }
 
         /// <summary>
         /// Optional. Send Markdown or HTML, if you want Telegram apps to show bold, italic, fixed-width text or inline URLs in your bot's message.
@@ -28,5 +28,17 @@ namespace Telegram.Bot.Types.InlineQueryResults
         /// </summary>
         [JsonProperty(DefaultValueHandling = DefaultValueHandling.IgnoreAndPopulate)]
         public bool DisableWebPagePreview { get; set; }
+
+        private InputTextMessageContent()
+        { }
+
+        /// <summary>
+        /// Initializes a new input text message content
+        /// </summary>
+        /// <param name="messageText">The text of the message</param>
+        public InputTextMessageContent(string messageText)
+        {
+            MessageText = messageText;
+        }
     }
 }

--- a/src/Telegram.Bot/Types/InlineQueryResults/InputVenueMessageContent.cs
+++ b/src/Telegram.Bot/Types/InlineQueryResults/InputVenueMessageContent.cs
@@ -14,30 +14,48 @@ namespace Telegram.Bot.Types.InlineQueryResults
         /// Latitude of the location in degrees
         /// </summary>
         [JsonProperty(Required = Required.Always)]
-        public float Latitude { get; set; }
+        public float Latitude { get; private set; }
 
         /// <summary>
         /// Longitude of the location in degrees
         /// </summary>
         [JsonProperty(Required = Required.Always)]
-        public float Longitude { get; set; }
+        public float Longitude { get; private set; }
 
         /// <summary>
         /// Name of the venue
         /// </summary>
         [JsonProperty(Required = Required.Always)]
-        public string Name { get; set; }
+        public string Name { get; private set; }
 
         /// <summary>
         /// Address of the venue
         /// </summary>
         [JsonProperty(Required = Required.Always)]
-        public string Address { get; set; }
+        public string Address { get; private set; }
 
         /// <summary>
         /// Optional. Foursquare identifier of the venue, if known
         /// </summary>
         [JsonProperty(DefaultValueHandling = DefaultValueHandling.IgnoreAndPopulate)]
         public string FoursquareId { get; set; }
+
+        private InputVenueMessageContent()
+        { }
+
+        /// <summary>
+        /// Initializes a new inline query result
+        /// </summary>
+        /// <param name="name">The name of the venue</param>
+        /// <param name="address">The address of the venue</param>
+        /// <param name="latitude">The latitude of the venue</param>
+        /// <param name="longitude">The longitude of the venue</param>
+        public InputVenueMessageContent(string name, string address, float latitude, float longitude)
+        {
+            Name = name;
+            Address = address;
+            Latitude = latitude;
+            Longitude = longitude;
+        }
     }
 }

--- a/src/Telegram.Bot/Types/User.cs
+++ b/src/Telegram.Bot/Types/User.cs
@@ -44,5 +44,25 @@ namespace Telegram.Bot.Types
         /// </summary>
         [JsonProperty(DefaultValueHandling = DefaultValueHandling.Ignore)]
         public string LanguageCode { get; set; }
+
+        /// <inheritdoc/>
+        public override bool Equals(object obj)
+        {
+            var userObj = obj as User;
+
+            return userObj != null && userObj.Id == Id;
+        }
+
+        /// <inheritdoc/>
+        public override int GetHashCode()
+        {
+            return Id.GetHashCode();
+        }
+
+        /// <inheritdoc/>
+        public override string ToString()
+        {
+            return FirstName + (LastName ?? "");
+        }
     }
 }

--- a/test/Telegram.Bot.Tests.Integ/Inline Mode/InlineQueryTests.cs
+++ b/test/Telegram.Bot.Tests.Integ/Inline Mode/InlineQueryTests.cs
@@ -33,10 +33,7 @@ namespace Telegram.Bot.Tests.Integ.Inline_Mode
 
             Update update = await _fixture.UpdateReceiver.GetInlineQueryUpdateAsync();
 
-            InputMessageContent inputMessageContent = new InputTextMessageContent
-            {
-                MessageText = "https://core.telegram.org/bots/api",
-            };
+            InputMessageContent inputMessageContent = new InputTextMessageContent("https://core.telegram.org/bots/api");
 
             InlineQueryResultBase[] results =
             {
@@ -260,9 +257,8 @@ namespace Telegram.Bot.Tests.Integ.Inline_Mode
                     title: "30 Rare Goals We See in Football"
                 )
                 {
-                    InputMessageContent = new InputTextMessageContent
+                    InputMessageContent = new InputTextMessageContent("[30 Rare Goals We See in Football](https://www.youtube.com/watch?v=56MDJ9tD6MY)")
                     {
-                        MessageText = "[30 Rare Goals We See in Football](https://www.youtube.com/watch?v=56MDJ9tD6MY)",
                         ParseMode = ParseMode.Markdown
                     }
                 }

--- a/test/Telegram.Bot.Tests.Integ/Update Messages/EditReplyMarkupTests.cs
+++ b/test/Telegram.Bot.Tests.Integ/Update Messages/EditReplyMarkupTests.cs
@@ -68,10 +68,7 @@ namespace Telegram.Bot.Tests.Integ.Update_Messages
                 InlineKeyboardButton.WithCallbackData("Click here to change this button", data)
             });
 
-            InputMessageContent inputMessageContent = new InputTextMessageContent
-            {
-                MessageText = "https://core.telegram.org/bots/api"
-            };
+            InputMessageContent inputMessageContent = new InputTextMessageContent("https://core.telegram.org/bots/api");
 
             InlineQueryResultBase[] inlineQueryResults =
             {


### PR DESCRIPTION
* Made the parameterless constructors for InlineQueryResults private (Json.Net can still use them)
* Made required properties for the MessageContent objects have private setters and added constructors to them
* Made the StopReceiving() method on the BotClient not throw WebExceptions or TaskCanceled exceptions