### PR TITLE
Implement Bot API v3.6 (2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,19 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
   - `ITelegramBotClient.SendDocumentAsync`
   - `ITelegramBotClient.SendVoiceAsync`
 - Parameter `supportsStreaming` to method `ITelegramBotClient.SendVideoAsync`
+- New fields to enum `MessageType`
+  - `WebsiteConnected`
+  - `ChatMembersAdded`
+  - `ChatMemberLeft`
+  - `ChatTitleChanged`
+  - `ChatPhotoChanged`
+  - `MessagePinned`
+  - `ChatPhotoDeleted`
+  - `GroupCreated`
+  - `SupergroupCreated`
+  - `ChannelCreated`
+  - `MigratedToSupergroup`
+  - `MigratedFromGroup`
 
 ### Changed
 
@@ -37,6 +50,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ### Fixed
 
 - Renamed `InputVenueMessageContent.Name` to `InputVenueMessageContent.Title`
+
+### Removed
+
+- Field `MessageType.Service`
 
 ## [14.0.0-rc-367] - 2018-01-04
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
   - `ChannelCreated`
   - `MigratedToSupergroup`
   - `MigratedFromGroup`
+- Exception `MessageIsNotModifiedException` 
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,6 +50,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ### Fixed
 
 - Renamed `InputVenueMessageContent.Name` to `InputVenueMessageContent.Title`
+- Property `Message.Type` returns correct value after group chat migration
 
 ### Removed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,24 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ### Added
 
 - Override equality comparison for `User` type
+- Property `ParseMode` to file requests with a caption
+  - `SendVideoRequest`
+  - `SendPhotoRequest`
+  - `SendAudioRequest`
+  - `SendDocumentRequest`
+  - `SendVoiceRequest`
+- Property `InputMediaBase.ParseMode`
+- Property `SendVideoRequest.SupportsStreaming`
+- Property `InputMediaVideo.SupportsStreaming`
+- Property `Message.ConnectedWebsite`
+- Enum field `MessageType.WebsiteConnected`
+- Parameter `parseMode` to methods
+  - `ITelegramBotClient.SendVideoAsync`
+  - `ITelegramBotClient.SendAudioAsync`
+  - `ITelegramBotClient.SendPhotoAsync`
+  - `ITelegramBotClient.SendDocumentAsync`
+  - `ITelegramBotClient.SendVoiceAsync`
+- Parameter `supportsStreaming` to method `ITelegramBotClient.SendVideoAsync`
 
 ### Changed
 

--- a/docs/wikis/migration/v13-to-v14.md
+++ b/docs/wikis/migration/v13-to-v14.md
@@ -161,6 +161,10 @@ message = await BotClient.SendPhotoAsync("chat id", fileId);
 
 Values in these two enums are renamed e.g. `UpdateType.MessageUpdate` is now `UpdateType.Message`.
 
+Value `MessageType.Service` is removed. Now each type of message has its own `MessageType` value.
+
+E.g. after a chat member lefts a group corresponding update contains a message with the property `Type` that returns `MessageType.ChatMemberLeft` value.
+
 ## `VideoNote`
 
 Properties `Width` and `Height` are removed. Vide notes are squared and `Length` property represents both width and height.

--- a/src/Telegram.Bot/Exceptions/ApiExceptionParser.cs
+++ b/src/Telegram.Bot/Exceptions/ApiExceptionParser.cs
@@ -28,6 +28,8 @@ namespace Telegram.Bot.Exceptions
 
             new BadRequestExceptionInfo<InvalidParameterException>($@"\w{{3,}} Request: invalid (?<{InvalidParameterException.ParamGroupName}>[\w|\s]+)$"),
             new BadRequestExceptionInfo<InvalidParameterException>($@"\w{{3,}} Request: (?<{InvalidParameterException.ParamGroupName}>[\w|\s]+) invalid$"),
+
+            new BadRequestExceptionInfo<MessageIsNotModifiedException>("message is not modified"),
         };
 
         public static ApiRequestException Parse<T>(ApiResponse<T> apiResponse)

--- a/src/Telegram.Bot/Exceptions/BadRequestExceptions/MessageIsNotModifiedException.cs
+++ b/src/Telegram.Bot/Exceptions/BadRequestExceptions/MessageIsNotModifiedException.cs
@@ -1,0 +1,18 @@
+﻿// ReSharper disable once CheckNamespace
+namespace Telegram.Bot.Exceptions
+{
+    /// <summary>
+    /// The exception that is thrown when the message is not modified
+    /// </summary>
+    public class MessageIsNotModifiedException : BadRequestException
+    {
+        /// <summary>
+        /// Initializes a new object of the <see cref="MessageIsNotModifiedException"/> class
+        /// </summary>
+        /// <param name="message">The error message of this exception.</param>
+        public MessageIsNotModifiedException(string message)
+            : base(message)
+        {
+        }
+    }
+}

--- a/src/Telegram.Bot/ITelegramBotClient.cs
+++ b/src/Telegram.Bot/ITelegramBotClient.cs
@@ -282,22 +282,22 @@ namespace Telegram.Bot
         /// <param name="chatId"><see cref="ChatId"/> for the target chat</param>
         /// <param name="photo">Photo to send.</param>
         /// <param name="caption">Photo caption (may also be used when resending photos by file_id).</param>
+        /// <param name="parseMode">Change, if you want Telegram apps to show bold, italic, fixed-width text or inline URLs in your bot's message.</param>
         /// <param name="disableNotification">Sends the message silently. iOS users will not receive a notification, Android users will receive a notification with no sound.</param>
         /// <param name="replyToMessageId">If the message is a reply, ID of the original message</param>
         /// <param name="replyMarkup">Additional interface options. A JSON-serialized object for a custom reply keyboard, instructions to hide keyboard or to force a reply from the user.</param>
         /// <param name="cancellationToken">A cancellation token that can be used by other objects or threads to receive notice of cancellation.</param>
-        /// <param name="parseMode">Change, if you want Telegram apps to show bold, italic, fixed-width text or inline URLs in your bot's message.</param>
         /// <returns>On success, the sent Description is returned.</returns>
         /// <see href="https://core.telegram.org/bots/api#sendphoto"/>
         Task<Message> SendPhotoAsync(
             ChatId chatId,
             InputOnlineFile photo,
             string caption = default,
+            ParseMode parseMode = default,
             bool disableNotification = default,
             int replyToMessageId = default,
             IReplyMarkup replyMarkup = default,
-            CancellationToken cancellationToken = default,
-            ParseMode parseMode = default);
+            CancellationToken cancellationToken = default);
 
         /// <summary>
         /// Use this method to send audio files, if you want Telegram clients to display them in the music player. Your audio must be in the .mp3 format. On success, the sent Description is returned. Bots can currently send audio files of up to 50 MB in size, this limit may be changed in the future.
@@ -305,6 +305,7 @@ namespace Telegram.Bot
         /// <param name="chatId"><see cref="ChatId"/> for the target chat</param>
         /// <param name="audio">Audio file to send.</param>
         /// <param name="caption">Audio caption, 0-200 characters</param>
+        /// <param name="parseMode">Change, if you want Telegram apps to show bold, italic, fixed-width text or inline URLs in your bot's message.</param>
         /// <param name="duration">Duration of the audio in seconds</param>
         /// <param name="performer">Performer</param>
         /// <param name="title">Track name</param>
@@ -312,21 +313,20 @@ namespace Telegram.Bot
         /// <param name="replyToMessageId">If the message is a reply, ID of the original message</param>
         /// <param name="replyMarkup">Additional interface options. A JSON-serialized object for a custom reply keyboard, instructions to hide keyboard or to force a reply from the user.</param>
         /// <param name="cancellationToken">A cancellation token that can be used by other objects or threads to receive notice of cancellation.</param>
-        /// <param name="parseMode">Change, if you want Telegram apps to show bold, italic, fixed-width text or inline URLs in your bot's message.</param>
         /// <returns>On success, the sent Description is returned.</returns>
         /// <see href="https://core.telegram.org/bots/api#sendaudio"/>
         Task<Message> SendAudioAsync(
             ChatId chatId,
             InputOnlineFile audio,
             string caption = default,
+            ParseMode parseMode = default,
             int duration = default,
             string performer = default,
             string title = default,
             bool disableNotification = default,
             int replyToMessageId = default,
             IReplyMarkup replyMarkup = default,
-            CancellationToken cancellationToken = default,
-            ParseMode parseMode = default);
+            CancellationToken cancellationToken = default);
 
         /// <summary>
         /// Use this method to send general files. On success, the sent Description is returned. Bots can send files of any type of up to 50 MB in size.
@@ -345,11 +345,11 @@ namespace Telegram.Bot
             ChatId chatId,
             InputOnlineFile document,
             string caption = default,
+            ParseMode parseMode = default,
             bool disableNotification = default,
             int replyToMessageId = default,
             IReplyMarkup replyMarkup = default,
-            CancellationToken cancellationToken = default,
-            ParseMode parseMode = default);
+            CancellationToken cancellationToken = default);
 
         /// <summary>
         /// Use this method to send .webp stickers. On success, the sent Description is returned.
@@ -379,12 +379,12 @@ namespace Telegram.Bot
         /// <param name="width">Video width</param>
         /// <param name="height">Video height</param>
         /// <param name="caption">Video caption</param>
+        /// <param name="parseMode">Change, if you want Telegram apps to show bold, italic, fixed-width text or inline URLs in your bot's message.</param>
+        /// <param name="supportsStreaming">Pass True, if the uploaded video is suitable for streaming</param>
         /// <param name="disableNotification">Sends the message silently. iOS users will not receive a notification, Android users will receive a notification with no sound.</param>
         /// <param name="replyToMessageId">If the message is a reply, ID of the original message</param>
         /// <param name="replyMarkup">Additional interface options. A JSON-serialized object for a custom reply keyboard, instructions to hide keyboard or to force a reply from the user.</param>
         /// <param name="cancellationToken">A cancellation token that can be used by other objects or threads to receive notice of cancellation.</param>
-        /// <param name="parseMode">Change, if you want Telegram apps to show bold, italic, fixed-width text or inline URLs in your bot's message.</param>
-        /// <param name="supportsStreaming">Pass True, if the uploaded video is suitable for streaming</param>
         /// <returns>On success, the sent Description is returned.</returns>
         /// <see href="https://core.telegram.org/bots/api#sendvideo"/>
         Task<Message> SendVideoAsync(
@@ -394,12 +394,12 @@ namespace Telegram.Bot
             int width = default,
             int height = default,
             string caption = default,
+            ParseMode parseMode = default,
+            bool supportsStreaming = default,
             bool disableNotification = default,
             int replyToMessageId = default,
             IReplyMarkup replyMarkup = default,
-            CancellationToken cancellationToken = default,
-            ParseMode parseMode = default,
-            bool supportsStreaming = default);
+            CancellationToken cancellationToken = default);
 
         /// <summary>
         /// Use this method to send audio files, if you want Telegram clients to display the file as a playable voice message. For this to work, your audio must be in an .ogg file encoded with OPUS (other formats may be sent as Audio or Document). On success, the sent Description is returned. Bots can currently send voice messages of up to 50 MB in size, this limit may be changed in the future.
@@ -407,24 +407,24 @@ namespace Telegram.Bot
         /// <param name="chatId"><see cref="ChatId"/> for the target chat</param>
         /// <param name="voice">Audio file to send.</param>
         /// <param name="caption">Voice message caption, 0-200 characters</param>
+        /// <param name="parseMode">Change, if you want Telegram apps to show bold, italic, fixed-width text or inline URLs in your bot's message.</param>
         /// <param name="duration">Duration of sent audio in seconds</param>
         /// <param name="disableNotification">Sends the message silently. iOS users will not receive a notification, Android users will receive a notification with no sound.</param>
         /// <param name="replyToMessageId">If the message is a reply, ID of the original message</param>
         /// <param name="replyMarkup">Additional interface options. A JSON-serialized object for a custom reply keyboard, instructions to hide keyboard or to force a reply from the user.</param>
         /// <param name="cancellationToken">A cancellation token that can be used by other objects or threads to receive notice of cancellation.</param>
-        /// <param name="parseMode">Change, if you want Telegram apps to show bold, italic, fixed-width text or inline URLs in your bot's message.</param>
         /// <returns>On success, the sent Description is returned.</returns>
         /// <see href="https://core.telegram.org/bots/api#sendvoice"/>
         Task<Message> SendVoiceAsync(
             ChatId chatId,
             InputOnlineFile voice,
             string caption = default,
+            ParseMode parseMode = default,
             int duration = default,
             bool disableNotification = default,
             int replyToMessageId = default,
             IReplyMarkup replyMarkup = default,
-            CancellationToken cancellationToken = default,
-            ParseMode parseMode = default);
+            CancellationToken cancellationToken = default);
 
         /// <summary>
         /// As of v.4.0, Telegram clients support rounded square mp4 videos of up to 1 minute long. Use this method to send video messages.

--- a/src/Telegram.Bot/ITelegramBotClient.cs
+++ b/src/Telegram.Bot/ITelegramBotClient.cs
@@ -286,6 +286,7 @@ namespace Telegram.Bot
         /// <param name="replyToMessageId">If the message is a reply, ID of the original message</param>
         /// <param name="replyMarkup">Additional interface options. A JSON-serialized object for a custom reply keyboard, instructions to hide keyboard or to force a reply from the user.</param>
         /// <param name="cancellationToken">A cancellation token that can be used by other objects or threads to receive notice of cancellation.</param>
+        /// <param name="parseMode">Change, if you want Telegram apps to show bold, italic, fixed-width text or inline URLs in your bot's message.</param>
         /// <returns>On success, the sent Description is returned.</returns>
         /// <see href="https://core.telegram.org/bots/api#sendphoto"/>
         Task<Message> SendPhotoAsync(
@@ -295,7 +296,8 @@ namespace Telegram.Bot
             bool disableNotification = default,
             int replyToMessageId = default,
             IReplyMarkup replyMarkup = default,
-            CancellationToken cancellationToken = default);
+            CancellationToken cancellationToken = default,
+            ParseMode parseMode = default);
 
         /// <summary>
         /// Use this method to send audio files, if you want Telegram clients to display them in the music player. Your audio must be in the .mp3 format. On success, the sent Description is returned. Bots can currently send audio files of up to 50 MB in size, this limit may be changed in the future.
@@ -310,6 +312,7 @@ namespace Telegram.Bot
         /// <param name="replyToMessageId">If the message is a reply, ID of the original message</param>
         /// <param name="replyMarkup">Additional interface options. A JSON-serialized object for a custom reply keyboard, instructions to hide keyboard or to force a reply from the user.</param>
         /// <param name="cancellationToken">A cancellation token that can be used by other objects or threads to receive notice of cancellation.</param>
+        /// <param name="parseMode">Change, if you want Telegram apps to show bold, italic, fixed-width text or inline URLs in your bot's message.</param>
         /// <returns>On success, the sent Description is returned.</returns>
         /// <see href="https://core.telegram.org/bots/api#sendaudio"/>
         Task<Message> SendAudioAsync(
@@ -322,7 +325,8 @@ namespace Telegram.Bot
             bool disableNotification = default,
             int replyToMessageId = default,
             IReplyMarkup replyMarkup = default,
-            CancellationToken cancellationToken = default);
+            CancellationToken cancellationToken = default,
+            ParseMode parseMode = default);
 
         /// <summary>
         /// Use this method to send general files. On success, the sent Description is returned. Bots can send files of any type of up to 50 MB in size.
@@ -334,6 +338,7 @@ namespace Telegram.Bot
         /// <param name="replyToMessageId">If the message is a reply, ID of the original message</param>
         /// <param name="replyMarkup">Additional interface options. A JSON-serialized object for a custom reply keyboard, instructions to hide keyboard or to force a reply from the user.</param>
         /// <param name="cancellationToken">A cancellation token that can be used by other objects or threads to receive notice of cancellation.</param>
+        /// <param name="parseMode">Change, if you want Telegram apps to show bold, italic, fixed-width text or inline URLs in your bot's message.</param>
         /// <returns>On success, the sent Description is returned.</returns>
         /// <see href="https://core.telegram.org/bots/api#senddocument"/>
         Task<Message> SendDocumentAsync(
@@ -343,7 +348,8 @@ namespace Telegram.Bot
             bool disableNotification = default,
             int replyToMessageId = default,
             IReplyMarkup replyMarkup = default,
-            CancellationToken cancellationToken = default);
+            CancellationToken cancellationToken = default,
+            ParseMode parseMode = default);
 
         /// <summary>
         /// Use this method to send .webp stickers. On success, the sent Description is returned.
@@ -377,6 +383,7 @@ namespace Telegram.Bot
         /// <param name="replyToMessageId">If the message is a reply, ID of the original message</param>
         /// <param name="replyMarkup">Additional interface options. A JSON-serialized object for a custom reply keyboard, instructions to hide keyboard or to force a reply from the user.</param>
         /// <param name="cancellationToken">A cancellation token that can be used by other objects or threads to receive notice of cancellation.</param>
+        /// <param name="parseMode">Change, if you want Telegram apps to show bold, italic, fixed-width text or inline URLs in your bot's message.</param>
         /// <returns>On success, the sent Description is returned.</returns>
         /// <see href="https://core.telegram.org/bots/api#sendvideo"/>
         Task<Message> SendVideoAsync(
@@ -389,7 +396,8 @@ namespace Telegram.Bot
             bool disableNotification = default,
             int replyToMessageId = default,
             IReplyMarkup replyMarkup = default,
-            CancellationToken cancellationToken = default);
+            CancellationToken cancellationToken = default,
+            ParseMode parseMode = default);
 
         /// <summary>
         /// Use this method to send audio files, if you want Telegram clients to display the file as a playable voice message. For this to work, your audio must be in an .ogg file encoded with OPUS (other formats may be sent as Audio or Document). On success, the sent Description is returned. Bots can currently send voice messages of up to 50 MB in size, this limit may be changed in the future.
@@ -402,6 +410,7 @@ namespace Telegram.Bot
         /// <param name="replyToMessageId">If the message is a reply, ID of the original message</param>
         /// <param name="replyMarkup">Additional interface options. A JSON-serialized object for a custom reply keyboard, instructions to hide keyboard or to force a reply from the user.</param>
         /// <param name="cancellationToken">A cancellation token that can be used by other objects or threads to receive notice of cancellation.</param>
+        /// <param name="parseMode">Change, if you want Telegram apps to show bold, italic, fixed-width text or inline URLs in your bot's message.</param>
         /// <returns>On success, the sent Description is returned.</returns>
         /// <see href="https://core.telegram.org/bots/api#sendvoice"/>
         Task<Message> SendVoiceAsync(
@@ -412,7 +421,8 @@ namespace Telegram.Bot
             bool disableNotification = default,
             int replyToMessageId = default,
             IReplyMarkup replyMarkup = default,
-            CancellationToken cancellationToken = default);
+            CancellationToken cancellationToken = default,
+            ParseMode parseMode = default);
 
         /// <summary>
         /// As of v.4.0, Telegram clients support rounded square mp4 videos of up to 1 minute long. Use this method to send video messages.
@@ -789,7 +799,7 @@ namespace Telegram.Bot
             bool disableWebPagePreview = default,
             InlineKeyboardMarkup replyMarkup = default,
             CancellationToken cancellationToken = default);
-        
+
         /// <summary>
         /// Use this method to stop updating a live location message sent by the bot before live_period expires.
         /// </summary>
@@ -877,7 +887,7 @@ namespace Telegram.Bot
             string inlineMessageId,
             InlineKeyboardMarkup replyMarkup = default,
             CancellationToken cancellationToken = default);
-        
+
         /// <summary>
         /// Use this method to edit live location messages sent by the bot.
         /// </summary>

--- a/src/Telegram.Bot/ITelegramBotClient.cs
+++ b/src/Telegram.Bot/ITelegramBotClient.cs
@@ -384,6 +384,7 @@ namespace Telegram.Bot
         /// <param name="replyMarkup">Additional interface options. A JSON-serialized object for a custom reply keyboard, instructions to hide keyboard or to force a reply from the user.</param>
         /// <param name="cancellationToken">A cancellation token that can be used by other objects or threads to receive notice of cancellation.</param>
         /// <param name="parseMode">Change, if you want Telegram apps to show bold, italic, fixed-width text or inline URLs in your bot's message.</param>
+        /// <param name="supportsStreaming">Pass True, if the uploaded video is suitable for streaming</param>
         /// <returns>On success, the sent Description is returned.</returns>
         /// <see href="https://core.telegram.org/bots/api#sendvideo"/>
         Task<Message> SendVideoAsync(
@@ -397,7 +398,8 @@ namespace Telegram.Bot
             int replyToMessageId = default,
             IReplyMarkup replyMarkup = default,
             CancellationToken cancellationToken = default,
-            ParseMode parseMode = default);
+            ParseMode parseMode = default,
+            bool supportsStreaming = default);
 
         /// <summary>
         /// Use this method to send audio files, if you want Telegram clients to display the file as a playable voice message. For this to work, your audio must be in an .ogg file encoded with OPUS (other formats may be sent as Audio or Document). On success, the sent Description is returned. Bots can currently send voice messages of up to 50 MB in size, this limit may be changed in the future.

--- a/src/Telegram.Bot/Requests/Available Methods/Sending Messages/SendDocumentRequest.cs
+++ b/src/Telegram.Bot/Requests/Available Methods/Sending Messages/SendDocumentRequest.cs
@@ -17,7 +17,8 @@ namespace Telegram.Bot.Requests
     public class SendDocumentRequest : FileRequestBase<Message>,
                                        INotifiableMessage,
                                        IReplyMessage,
-                                       IReplyMarkupMessage<IReplyMarkup>
+                                       IReplyMarkupMessage<IReplyMarkup>,
+                                       IFormattableMessage
     {
         /// <summary>
         /// Unique identifier for the target chat or username of the target channel (in the format @channelusername)
@@ -36,6 +37,10 @@ namespace Telegram.Bot.Requests
         /// </summary>
         [JsonProperty(DefaultValueHandling = DefaultValueHandling.Ignore)]
         public string Caption { get; set; }
+
+        /// <inheritdoc />
+        [JsonProperty(DefaultValueHandling = DefaultValueHandling.Ignore)]
+        public ParseMode ParseMode { get; set; }
 
         /// <inheritdoc />
         [JsonProperty(DefaultValueHandling = DefaultValueHandling.Ignore)]
@@ -66,5 +71,7 @@ namespace Telegram.Bot.Requests
             Document.FileType == FileType.Stream
                 ? ToMultipartFormDataContent("document", Document)
                 : base.ToHttpContent();
+
+
     }
 }

--- a/src/Telegram.Bot/Requests/Available Methods/Sending Messages/SendPhotoRequest.cs
+++ b/src/Telegram.Bot/Requests/Available Methods/Sending Messages/SendPhotoRequest.cs
@@ -17,7 +17,8 @@ namespace Telegram.Bot.Requests
     public class SendPhotoRequest : FileRequestBase<Message>,
                                     INotifiableMessage,
                                     IReplyMessage,
-                                    IReplyMarkupMessage<IReplyMarkup>
+                                    IReplyMarkupMessage<IReplyMarkup>,
+                                    IFormattableMessage
     {
         /// <summary>
         /// Unique identifier for the target chat or username of the target channel (in the format @channelusername)
@@ -36,6 +37,10 @@ namespace Telegram.Bot.Requests
         /// </summary>
         [JsonProperty(DefaultValueHandling = DefaultValueHandling.Ignore)]
         public string Caption { get; set; }
+
+        /// <inheritdoc />
+        [JsonProperty(DefaultValueHandling = DefaultValueHandling.Ignore)]
+        public ParseMode ParseMode { get; set; }
 
         /// <inheritdoc />
         [JsonProperty(DefaultValueHandling = DefaultValueHandling.Ignore)]

--- a/src/Telegram.Bot/Requests/Available Methods/Sending Messages/SendVideoRequest.cs
+++ b/src/Telegram.Bot/Requests/Available Methods/Sending Messages/SendVideoRequest.cs
@@ -60,6 +60,12 @@ namespace Telegram.Bot.Requests
         [JsonProperty(DefaultValueHandling = DefaultValueHandling.Ignore)]
         public ParseMode ParseMode { get; set; }
 
+        /// <summary>
+        /// Pass True, if the uploaded video is suitable for streaming
+        /// </summary>
+        [JsonProperty(DefaultValueHandling = DefaultValueHandling.Ignore)]
+        public bool SupportsStreaming { get; set; }
+
         /// <inheritdoc />
         [JsonProperty(DefaultValueHandling = DefaultValueHandling.Ignore)]
         public bool DisableNotification { get; set; }

--- a/src/Telegram.Bot/Requests/Available Methods/Sending Messages/SendVideoRequest.cs
+++ b/src/Telegram.Bot/Requests/Available Methods/Sending Messages/SendVideoRequest.cs
@@ -17,7 +17,8 @@ namespace Telegram.Bot.Requests
     public class SendVideoRequest : FileRequestBase<Message>,
                                     INotifiableMessage,
                                     IReplyMessage,
-                                    IReplyMarkupMessage<IReplyMarkup>
+                                    IReplyMarkupMessage<IReplyMarkup>,
+                                    IFormattableMessage
     {
         /// <summary>
         /// Unique identifier for the target chat or username of the target channel (in the format @channelusername)
@@ -54,6 +55,10 @@ namespace Telegram.Bot.Requests
         /// </summary>
         [JsonProperty(DefaultValueHandling = DefaultValueHandling.Ignore)]
         public string Caption { get; set; }
+
+        /// <inheritdoc />
+        [JsonProperty(DefaultValueHandling = DefaultValueHandling.Ignore)]
+        public ParseMode ParseMode { get; set; }
 
         /// <inheritdoc />
         [JsonProperty(DefaultValueHandling = DefaultValueHandling.Ignore)]

--- a/src/Telegram.Bot/Requests/_/SendAudioRequest.cs
+++ b/src/Telegram.Bot/Requests/_/SendAudioRequest.cs
@@ -17,7 +17,8 @@ namespace Telegram.Bot.Requests
     public class SendAudioRequest : FileRequestBase<Message>,
                                     INotifiableMessage,
                                     IReplyMessage,
-                                    IReplyMarkupMessage<IReplyMarkup>
+                                    IReplyMarkupMessage<IReplyMarkup>,
+                                    IFormattableMessage
     {
         /// <summary>
         /// Unique identifier for the target chat or username of the target channel (in the format @channelusername)
@@ -36,6 +37,10 @@ namespace Telegram.Bot.Requests
         /// </summary>
         [JsonProperty(DefaultValueHandling = DefaultValueHandling.Ignore)]
         public string Caption { get; set; }
+
+        /// <inheritdoc />
+        [JsonProperty(DefaultValueHandling = DefaultValueHandling.Ignore)]
+        public ParseMode ParseMode { get; set; }
 
         /// <summary>
         /// Duration of the audio in seconds

--- a/src/Telegram.Bot/Requests/_/SendVoiceRequest.cs
+++ b/src/Telegram.Bot/Requests/_/SendVoiceRequest.cs
@@ -17,7 +17,8 @@ namespace Telegram.Bot.Requests
     public class SendVoiceRequest : FileRequestBase<Message>,
                                     INotifiableMessage,
                                     IReplyMessage,
-                                    IReplyMarkupMessage<IReplyMarkup>
+                                    IReplyMarkupMessage<IReplyMarkup>,
+                                    IFormattableMessage
     {
         /// <summary>
         /// Unique identifier for the target chat or username of the target channel (in the format @channelusername)
@@ -42,6 +43,10 @@ namespace Telegram.Bot.Requests
         /// </summary>
         [JsonProperty(DefaultValueHandling = DefaultValueHandling.Ignore)]
         public string Caption { get; set; }
+
+        /// <inheritdoc />
+        [JsonProperty(DefaultValueHandling = DefaultValueHandling.Ignore)]
+        public ParseMode ParseMode { get; set; }
 
         /// <inheritdoc />
         [JsonProperty(DefaultValueHandling = DefaultValueHandling.Ignore)]

--- a/src/Telegram.Bot/TelegramBotClient.cs
+++ b/src/Telegram.Bot/TelegramBotClient.cs
@@ -447,11 +447,11 @@ namespace Telegram.Bot
             ChatId chatId,
             InputOnlineFile photo,
             string caption = default,
+            ParseMode parseMode = default,
             bool disableNotification = default,
             int replyToMessageId = default,
             IReplyMarkup replyMarkup = default,
-            CancellationToken cancellationToken = default,
-            ParseMode parseMode = default
+            CancellationToken cancellationToken = default
         ) =>
             MakeRequestAsync(new SendPhotoRequest(chatId, photo)
             {
@@ -467,14 +467,14 @@ namespace Telegram.Bot
             ChatId chatId,
             InputOnlineFile audio,
             string caption = default,
+            ParseMode parseMode = default,
             int duration = default,
             string performer = default,
             string title = default,
             bool disableNotification = default,
             int replyToMessageId = default,
             IReplyMarkup replyMarkup = default,
-            CancellationToken cancellationToken = default,
-            ParseMode parseMode = default
+            CancellationToken cancellationToken = default
         ) =>
             MakeRequestAsync(new SendAudioRequest(chatId, audio)
             {
@@ -493,11 +493,11 @@ namespace Telegram.Bot
             ChatId chatId,
             InputOnlineFile document,
             string caption = default,
+            ParseMode parseMode = default,
             bool disableNotification = default,
             int replyToMessageId = default,
             IReplyMarkup replyMarkup = default,
-            CancellationToken cancellationToken = default,
-            ParseMode parseMode = default
+            CancellationToken cancellationToken = default
         ) =>
             MakeRequestAsync(new SendDocumentRequest(chatId, document)
             {
@@ -532,12 +532,12 @@ namespace Telegram.Bot
             int width = default,
             int height = default,
             string caption = default,
+            ParseMode parseMode = default,
+            bool supportsStreaming = default,
             bool disableNotification = default,
             int replyToMessageId = default,
             IReplyMarkup replyMarkup = default,
-            CancellationToken cancellationToken = default,
-            ParseMode parseMode = default,
-            bool supportsStreaming = default
+            CancellationToken cancellationToken = default
         ) =>
             MakeRequestAsync(new SendVideoRequest(chatId, video)
             {
@@ -557,12 +557,12 @@ namespace Telegram.Bot
             ChatId chatId,
             InputOnlineFile voice,
             string caption = default,
+            ParseMode parseMode = default,
             int duration = default,
             bool disableNotification = default,
             int replyToMessageId = default,
             IReplyMarkup replyMarkup = default,
-            CancellationToken cancellationToken = default,
-            ParseMode parseMode = default
+            CancellationToken cancellationToken = default
         ) =>
             MakeRequestAsync(new SendVoiceRequest(chatId, voice)
             {

--- a/src/Telegram.Bot/TelegramBotClient.cs
+++ b/src/Telegram.Bot/TelegramBotClient.cs
@@ -536,7 +536,8 @@ namespace Telegram.Bot
             int replyToMessageId = default,
             IReplyMarkup replyMarkup = default,
             CancellationToken cancellationToken = default,
-            ParseMode parseMode = default
+            ParseMode parseMode = default,
+            bool supportsStreaming = default
         ) =>
             MakeRequestAsync(new SendVideoRequest(chatId, video)
             {
@@ -545,6 +546,7 @@ namespace Telegram.Bot
                 Height = height,
                 Caption = caption,
                 ParseMode = parseMode,
+                SupportsStreaming = supportsStreaming,
                 DisableNotification = disableNotification,
                 ReplyToMessageId = replyToMessageId,
                 ReplyMarkup = replyMarkup

--- a/src/Telegram.Bot/TelegramBotClient.cs
+++ b/src/Telegram.Bot/TelegramBotClient.cs
@@ -450,11 +450,13 @@ namespace Telegram.Bot
             bool disableNotification = default,
             int replyToMessageId = default,
             IReplyMarkup replyMarkup = default,
-            CancellationToken cancellationToken = default
+            CancellationToken cancellationToken = default,
+            ParseMode parseMode = default
         ) =>
             MakeRequestAsync(new SendPhotoRequest(chatId, photo)
             {
                 Caption = caption,
+                ParseMode = parseMode,
                 ReplyToMessageId = replyToMessageId,
                 DisableNotification = disableNotification,
                 ReplyMarkup = replyMarkup
@@ -471,11 +473,13 @@ namespace Telegram.Bot
             bool disableNotification = default,
             int replyToMessageId = default,
             IReplyMarkup replyMarkup = default,
-            CancellationToken cancellationToken = default
+            CancellationToken cancellationToken = default,
+            ParseMode parseMode = default
         ) =>
             MakeRequestAsync(new SendAudioRequest(chatId, audio)
             {
                 Caption = caption,
+                ParseMode = parseMode,
                 Duration = duration,
                 Performer = performer,
                 Title = title,
@@ -492,11 +496,13 @@ namespace Telegram.Bot
             bool disableNotification = default,
             int replyToMessageId = default,
             IReplyMarkup replyMarkup = default,
-            CancellationToken cancellationToken = default
+            CancellationToken cancellationToken = default,
+            ParseMode parseMode = default
         ) =>
             MakeRequestAsync(new SendDocumentRequest(chatId, document)
             {
                 Caption = caption,
+                ParseMode = parseMode,
                 DisableNotification = disableNotification,
                 ReplyToMessageId = replyToMessageId,
                 ReplyMarkup = replyMarkup
@@ -529,7 +535,8 @@ namespace Telegram.Bot
             bool disableNotification = default,
             int replyToMessageId = default,
             IReplyMarkup replyMarkup = default,
-            CancellationToken cancellationToken = default
+            CancellationToken cancellationToken = default,
+            ParseMode parseMode = default
         ) =>
             MakeRequestAsync(new SendVideoRequest(chatId, video)
             {
@@ -537,6 +544,7 @@ namespace Telegram.Bot
                 Width = width,
                 Height = height,
                 Caption = caption,
+                ParseMode = parseMode,
                 DisableNotification = disableNotification,
                 ReplyToMessageId = replyToMessageId,
                 ReplyMarkup = replyMarkup
@@ -551,11 +559,13 @@ namespace Telegram.Bot
             bool disableNotification = default,
             int replyToMessageId = default,
             IReplyMarkup replyMarkup = default,
-            CancellationToken cancellationToken = default
+            CancellationToken cancellationToken = default,
+            ParseMode parseMode = default
         ) =>
             MakeRequestAsync(new SendVoiceRequest(chatId, voice)
             {
                 Caption = caption,
+                ParseMode = parseMode,
                 Duration = duration,
                 DisableNotification = disableNotification,
                 ReplyToMessageId = replyToMessageId,

--- a/src/Telegram.Bot/Types/Enums/MessageType.cs
+++ b/src/Telegram.Bot/Types/Enums/MessageType.cs
@@ -60,11 +60,6 @@ namespace Telegram.Bot.Types.Enums
         Contact,
 
         /// <summary>
-        /// The <see cref="Message"/> contains meta informations, for example <see cref="Message.GroupChatCreated"/> or <see cref="Message.NewChatTitle"/>
-        /// </summary>
-        Service,
-
-        /// <summary>
         /// The <see cref="Message"/> contains a <see cref="Types.Venue"/>
         /// </summary>
         Venue,
@@ -92,6 +87,61 @@ namespace Telegram.Bot.Types.Enums
         /// <summary>
         /// The <see cref="Message"/> contains a <see cref="Message.ConnectedWebsite"/>
         /// </summary>
-        WebsiteConnected
+        WebsiteConnected,
+
+        /// <summary>
+        /// The <see cref="Message"/> contains a <see cref="Message.NewChatMembers"/>
+        /// </summary>
+        ChatMembersAdded,
+
+        /// <summary>
+        /// The <see cref="Message"/> contains a <see cref="Message.LeftChatMember"/>
+        /// </summary>
+        ChatMemberLeft,
+
+        /// <summary>
+        /// The <see cref="Message"/> contains a <see cref="Message.NewChatTitle"/>
+        /// </summary>
+        ChatTitleChanged,
+
+        /// <summary>
+        /// The <see cref="Message"/> contains a <see cref="Message.NewChatPhoto"/>
+        /// </summary>
+        ChatPhotoChanged,
+
+        /// <summary>
+        /// The <see cref="Message"/> contains a <see cref="Message.PinnedMessage"/>
+        /// </summary>
+        MessagePinned,
+
+        /// <summary>
+        /// The <see cref="Message"/> contains a <see cref="Message.DeleteChatPhoto"/>
+        /// </summary>
+        ChatPhotoDeleted,
+
+        /// <summary>
+        /// The <see cref="Message"/> contains a <see cref="Message.GroupChatCreated"/>
+        /// </summary>
+        GroupCreated,
+
+        /// <summary>
+        /// The <see cref="Message"/> contains a <see cref="Message.SupergroupChatCreated"/>
+        /// </summary>
+        SupergroupCreated,
+
+        /// <summary>
+        /// The <see cref="Message"/> contains a <see cref="Message.ChannelChatCreated"/>
+        /// </summary>
+        ChannelCreated,
+
+        /// <summary>
+        /// The <see cref="Message"/> contains non-default <see cref="Message.MigrateFromChatId"/>
+        /// </summary>
+        MigratedToSupergroup,
+
+        /// <summary>
+        /// The <see cref="Message"/> contains non-default <see cref="Message.MigrateToChatId"/>
+        /// </summary>
+        MigratedFromGroup
     }
 }

--- a/src/Telegram.Bot/Types/Enums/MessageType.cs
+++ b/src/Telegram.Bot/Types/Enums/MessageType.cs
@@ -88,5 +88,10 @@ namespace Telegram.Bot.Types.Enums
         /// The <see cref="Message"/> contains a <see cref="SuccessfulPayment"/>
         /// </summary>
         SuccessfulPayment,
+
+        /// <summary>
+        /// The <see cref="Message"/> contains a <see cref="Message.ConnectedWebsite"/>
+        /// </summary>
+        WebsiteConnected
     }
 }

--- a/src/Telegram.Bot/Types/InputFiles/InputMediaBase.cs
+++ b/src/Telegram.Bot/Types/InputFiles/InputMediaBase.cs
@@ -1,5 +1,6 @@
 ﻿using Newtonsoft.Json;
 using Newtonsoft.Json.Serialization;
+using Telegram.Bot.Types.Enums;
 
 // ReSharper disable once CheckNamespace
 namespace Telegram.Bot.Types
@@ -27,5 +28,11 @@ namespace Telegram.Bot.Types
         /// </summary>
         [JsonProperty(DefaultValueHandling = DefaultValueHandling.Ignore)]
         public string Caption { get; set; }
+
+        /// <summary>
+        /// Change, if you want Telegram apps to show bold, italic, fixed-width text or inline URLs in a caption
+        /// </summary>
+        [JsonProperty(DefaultValueHandling = DefaultValueHandling.Ignore)]
+        public ParseMode ParseMode { get; set; }
     }
 }

--- a/src/Telegram.Bot/Types/InputFiles/InputMediaVideo.cs
+++ b/src/Telegram.Bot/Types/InputFiles/InputMediaVideo.cs
@@ -28,6 +28,12 @@ namespace Telegram.Bot.Types
         public int Duration { get; set; }
 
         /// <summary>
+        /// Optional. Pass True, if the uploaded video is suitable for streaming
+        /// </summary>
+        [JsonProperty(DefaultValueHandling = DefaultValueHandling.Ignore)]
+        public bool SupportsStreaming { get; set; }
+
+        /// <summary>
         /// Initializes a new video media to send
         /// </summary>
         public InputMediaVideo()

--- a/src/Telegram.Bot/Types/Message.cs
+++ b/src/Telegram.Bot/Types/Message.cs
@@ -282,6 +282,12 @@ namespace Telegram.Bot.Types
         public SuccessfulPayment SuccessfulPayment { get; set; }
 
         /// <summary>
+        /// Optional. The domain name of the website on which the user has logged in
+        /// </summary>
+        [JsonProperty(DefaultValueHandling = DefaultValueHandling.Ignore)]
+        public string ConnectedWebsite { get; set; }
+
+        /// <summary>
         /// Gets the <see cref="MessageType"/> of the <see cref="Message"/>
         /// </summary>
         /// <value>
@@ -332,6 +338,9 @@ namespace Telegram.Bot.Types
 
                 if (VideoNote != null)
                     return MessageType.VideoNote;
+
+                if (ConnectedWebsite != null)
+                    return MessageType.WebsiteConnected;
 
                 if (NewChatMembers?.Any() == true ||
                     LeftChatMember != null ||

--- a/src/Telegram.Bot/Types/Message.cs
+++ b/src/Telegram.Bot/Types/Message.cs
@@ -342,18 +342,38 @@ namespace Telegram.Bot.Types
                 if (ConnectedWebsite != null)
                     return MessageType.WebsiteConnected;
 
-                if (NewChatMembers?.Any() == true ||
-                    LeftChatMember != null ||
-                    NewChatTitle != null ||
-                    NewChatPhoto != null ||
-                    PinnedMessage != null ||
-                    DeleteChatPhoto ||
-                    GroupChatCreated ||
-                    SupergroupChatCreated ||
-                    ChannelChatCreated ||
-                    MigrateFromChatId == default ||
-                    MigrateToChatId == default)
-                    return MessageType.Service;
+                if (NewChatMembers?.Any() == true)
+                    return MessageType.ChatMembersAdded;
+
+                if (LeftChatMember != null)
+                    return MessageType.ChatMemberLeft;
+
+                if (NewChatTitle != null)
+                    return MessageType.ChatTitleChanged;
+
+                if (NewChatPhoto != null)
+                    return MessageType.ChatPhotoChanged;
+
+                if (PinnedMessage != null)
+                    return MessageType.MessagePinned;
+
+                if (DeleteChatPhoto)
+                    return MessageType.ChatPhotoDeleted;
+
+                if (GroupChatCreated)
+                    return MessageType.GroupCreated;
+
+                if (SupergroupChatCreated)
+                    return MessageType.SupergroupCreated;
+
+                if (ChannelChatCreated)
+                    return MessageType.ChannelCreated;
+
+                if (MigrateFromChatId != default)
+                    return MessageType.MigratedFromGroup;
+
+                if (MigrateToChatId != default)
+                    return MessageType.MigratedToSupergroup;
 
                 return MessageType.Unknown;
             }

--- a/src/Telegram.Bot/Types/ReplyMarkups/InlineKeyboardButton.cs
+++ b/src/Telegram.Bot/Types/ReplyMarkups/InlineKeyboardButton.cs
@@ -20,7 +20,7 @@ namespace Telegram.Bot.Types.ReplyMarkups
         public string Url { get; set; }
 
         /// <summary>
-        /// Data to be sent in a callback query to the bot when button is pressed
+        /// Optional. Data to be sent in a callback query to the bot when button is pressed
         /// </summary>
         [JsonProperty(DefaultValueHandling = DefaultValueHandling.Ignore)]
         public string CallbackData { get; set; }
@@ -44,7 +44,7 @@ namespace Telegram.Bot.Types.ReplyMarkups
         public string SwitchInlineQueryCurrentChat { get; set; }
 
         /// <summary>
-        /// Optimal. Description of the game that will be launched when the user presses the button.
+        /// Optional. Description of the game that will be launched when the user presses the button.
         /// </summary>
         /// <remarks>
         /// Note: This type of button must always be the first button in the first row.

--- a/test/Telegram.Bot.Tests.Integ/Admin Bot/ChatMemberAdministrationTests.cs
+++ b/test/Telegram.Bot.Tests.Integ/Admin Bot/ChatMemberAdministrationTests.cs
@@ -85,7 +85,7 @@ namespace Telegram.Bot.Tests.Integ.Admin_Bot
                 .GetUpdatesAsync(u =>
                     u.Message.Chat.Type == ChatType.Supergroup &&
                     u.Message.Chat.Id.ToString() == _fixture.SupergroupChat.Id.ToString() &&
-                    u.Message.Type == MessageType.Service,
+                    u.Message.Type == MessageType.ChatMembersAdded,
                 updateTypes: UpdateType.Message)
             ).Single();
 

--- a/test/Telegram.Bot.Tests.Integ/Admin Bot/SupergroupAdminBotTests.cs
+++ b/test/Telegram.Bot.Tests.Integ/Admin Bot/SupergroupAdminBotTests.cs
@@ -193,7 +193,7 @@ namespace Telegram.Bot.Tests.Integ.Admin_Bot
 
             // ToDo: Create exception type
             Assert.Equal(400, exception.ErrorCode);
-            Assert.Equal("Bad Request: can't set channel sticker set", exception.Message);
+            Assert.Equal("Bad Request: can't set supergroup sticker set", exception.Message);
         }
 
         #endregion

--- a/test/Telegram.Bot.Tests.Integ/Exceptions/ApiExceptionsTests.cs
+++ b/test/Telegram.Bot.Tests.Integ/Exceptions/ApiExceptionsTests.cs
@@ -88,6 +88,27 @@ namespace Telegram.Bot.Tests.Integ.Exceptions
             Assert.IsType<ContactRequestException>(e);
         }
 
+        [Fact(DisplayName = FactTitles.ShouldThrowExceptionMessageIsNotModifiedException)]
+        [Trait(Constants.MethodTraitName, Constants.TelegramBotApiMethods.SendMessage)]
+        [ExecutionOrder(5)]
+        public async Task Should_Throw_Exception_MessageIsNotModifiedException()
+        {
+            await _fixture.SendTestCaseNotificationAsync(FactTitles.ShouldThrowExceptionMessageIsNotModifiedException);
+
+            const string MessageTextToModify = "Message text to modify";
+            Message message = await BotClient.SendTextMessageAsync(
+                _fixture.SupergroupChat.Id,
+                MessageTextToModify);
+
+            BadRequestException e = await Assert.ThrowsAnyAsync<BadRequestException>(() =>
+                BotClient.EditMessageTextAsync(
+                    _fixture.SupergroupChat.Id,
+                    message.MessageId,
+                    MessageTextToModify));
+
+            Assert.IsType<MessageIsNotModifiedException>(e);
+        }
+
         private static class FactTitles
         {
             public const string ShouldThrowChatNotFoundException =
@@ -103,6 +124,10 @@ namespace Telegram.Bot.Tests.Integ.Exceptions
             public const string ShouldThrowExceptionContactRequestException =
                 "Should throw ContactRequestException while asking for user's phone number in non-private " +
                 "chat via reply keyboard markup";
+
+            public const string ShouldThrowExceptionMessageIsNotModifiedException =
+               "Should throw MessageIsNotModifiedException while editing previously sent message " +
+                "with the same text";
         }
     }
 }

--- a/test/Telegram.Bot.Tests.Integ/Sending Messages/AlbumMessageTests.cs
+++ b/test/Telegram.Bot.Tests.Integ/Sending Messages/AlbumMessageTests.cs
@@ -181,6 +181,52 @@ namespace Telegram.Bot.Tests.Integ.Sending_Messages
             Assert.InRange(messages.First().Video.Duration, firstMediaDuration - 2, firstMediaDuration + 2);
         }
 
+        [Fact(DisplayName = FactTitles.ShouldUpload2PhotosAlbumWithMarkdownEncodedCaptions)]
+        [Trait(Constants.MethodTraitName, Constants.TelegramBotApiMethods.SendMediaGroup)]
+        [ExecutionOrder(5)]
+        public async Task Should_Upload_2_Photos_Album_With_Markdown_Encoded_Captions()
+        {
+            await _fixture.SendTestCaseNotificationAsync(FactTitles.ShouldUpload2PhotosAlbumWithMarkdownEncodedCaptions);
+
+            var captionsMappings = new(MessageEntityType Type, string EntityBody, string EncodedEntity)[]
+            {
+                ( MessageEntityType.Bold, "Logo", "*Logo*" ),
+                ( MessageEntityType.Italic, "Bot", "_Bot_" ),
+            };
+
+            Message[] messages;
+            using (Stream
+                stream1 = System.IO.File.OpenRead(Constants.FileNames.Photos.Logo),
+                stream2 = System.IO.File.OpenRead(Constants.FileNames.Photos.Bot)
+            )
+            {
+                InputMediaBase[] inputMedia =
+                {
+                    new InputMediaPhoto
+                    {
+                        Media = new InputMedia(stream1, "logo"),
+                        Caption = captionsMappings[0].EncodedEntity,
+                        ParseMode = ParseMode.Markdown
+                    },
+                    new InputMediaPhoto
+                    {
+                        Media = new InputMedia(stream2, "bot"),
+                        Caption = captionsMappings[1].EncodedEntity,
+                        ParseMode = ParseMode.Markdown
+                    },
+                };
+
+                messages = await BotClient.SendMediaGroupAsync(
+                    chatId: _fixture.SupergroupChat.Id,
+                    media: inputMedia,
+                    disableNotification: true
+                );
+            }
+
+            Assert.True(messages[0].CaptionEntityValues.Contains(captionsMappings[0].EntityBody));
+            Assert.True(messages[1].CaptionEntityValues.Contains(captionsMappings[1].EntityBody));
+        }
+
         private static class FactTitles
         {
             public const string ShouldUploadPhotosInAlbum =
@@ -194,6 +240,9 @@ namespace Telegram.Bot.Tests.Integ.Sending_Messages
 
             public const string ShouldUploadVideosInAlbum =
                 "Should upload 2 videos and a photo with captions and send them in an album";
+
+            public const string ShouldUpload2PhotosAlbumWithMarkdownEncodedCaptions =
+                "Should upload 2 photos with markdown encoded captions and send them in an album";
         }
     }
 }


### PR DESCRIPTION
This PR implements Bot API v3.6.

It makes a few other changes such as:

- It changes enum `MessageType`:
    - Removed field `Service`
    - The following fields are added
        - `WebsiteConnected`
        - `ChatMembersAdded`
        - `ChatMemberLeft`
        - `ChatTitleChanged`
        - `ChatPhotoChanged`
        - `MessagePinned`
        - `ChatPhotoDeleted`
        - `GroupCreated`
        - `SupergroupCreated`
        - `ChannelCreated`
        - `MigratedToSupergroup`
        - `MigratedFromGroup`
- It adds new exception type `MessageIsNotModifiedException`.
- It fixes a bug when after migrating a group to a supergroup corresponding updates had message object with the property `Type` that returned `MessageType.Unknown`.