### PR TITLE
Fix error CS8363 A default literal 'default' is not valid as a pattern

### DIFF
--- a/src/Telegram.Bot/Converters/InputFileConverter.cs
+++ b/src/Telegram.Bot/Converters/InputFileConverter.cs
@@ -36,7 +36,7 @@ namespace Telegram.Bot.Converters
         public override object ReadJson(JsonReader reader, Type objectType, object existingValue, JsonSerializer serializer)
         {
             string value = JToken.ReadFrom(reader).Value<string>();
-            if (value is default)
+            if (value == null)
             {
                 return new InputFileStream(Stream.Null);
             }

--- a/src/Telegram.Bot/Requests/Getting Updates/SetWebhookRequest.cs
+++ b/src/Telegram.Bot/Requests/Getting Updates/SetWebhookRequest.cs
@@ -52,7 +52,7 @@ namespace Telegram.Bot.Requests
 
         /// <inheritdoc cref="RequestBase{TResponse}.ToHttpContent"/>
         public override HttpContent ToHttpContent() =>
-            Certificate is default
+            Certificate == null
                 ? base.ToHttpContent()
                 : ToMultipartFormDataContent("certificate", Certificate);
     }

--- a/src/Telegram.Bot/TelegramBotClient.cs
+++ b/src/Telegram.Bot/TelegramBotClient.cs
@@ -717,7 +717,7 @@ namespace Telegram.Bot
             {
                 throw new ArgumentException("Invalid file path", nameof(filePath));
             }
-            if (destination is default)
+            if (destination == null)
             {
                 throw new ArgumentNullException(nameof(destination));
             }

--- a/src/Telegram.Bot/Types/InputFiles/InputFileStream.cs
+++ b/src/Telegram.Bot/Types/InputFiles/InputFileStream.cs
@@ -55,8 +55,8 @@ namespace Telegram.Bot.Types.InputFiles
         /// ToDo
         /// </summary>
         /// <param name="stream"></param>
-        public static implicit operator InputFileStream(Stream stream)
-            => stream is default
+        public static implicit operator InputFileStream(Stream stream) =>
+            stream == null
                 ? default
                 : new InputFileStream(stream);
     }

--- a/src/Telegram.Bot/Types/InputFiles/InputMedia.cs
+++ b/src/Telegram.Bot/Types/InputFiles/InputMedia.cs
@@ -33,8 +33,8 @@ namespace Telegram.Bot.Types
         /// ToDo
         /// </summary>
         /// <param name="value"></param>
-        public static implicit operator InputMedia(string value)
-            => value is default
+        public static implicit operator InputMedia(string value) =>
+            value == null
                 ? default
                 : new InputMedia(value);
     }

--- a/src/Telegram.Bot/Types/InputFiles/InputOnlineFile.cs
+++ b/src/Telegram.Bot/Types/InputFiles/InputOnlineFile.cs
@@ -71,8 +71,8 @@ namespace Telegram.Bot.Types.InputFiles
         /// ToDo
         /// </summary>
         /// <param name="stream"></param>
-        public static implicit operator InputOnlineFile(Stream stream)
-            => stream is default
+        public static implicit operator InputOnlineFile(Stream stream) =>
+            stream == null
                 ? default
                 : new InputOnlineFile(stream);
 
@@ -80,8 +80,8 @@ namespace Telegram.Bot.Types.InputFiles
         /// ToDo
         /// </summary>
         /// <param name="value"></param>
-        public static implicit operator InputOnlineFile(string value)
-            => value is default
+        public static implicit operator InputOnlineFile(string value) =>
+            value == null
                 ? default
                 : new InputOnlineFile(value);
     }

--- a/src/Telegram.Bot/Types/InputFiles/InputTelegramFile.cs
+++ b/src/Telegram.Bot/Types/InputFiles/InputTelegramFile.cs
@@ -69,8 +69,8 @@ namespace Telegram.Bot.Types.InputFiles
         /// ToDo
         /// </summary>
         /// <param name="stream"></param>
-        public static implicit operator InputTelegramFile(Stream stream)
-            => stream is default
+        public static implicit operator InputTelegramFile(Stream stream) =>
+            stream == null
                 ? default
                 : new InputTelegramFile(stream);
 
@@ -78,8 +78,8 @@ namespace Telegram.Bot.Types.InputFiles
         /// ToDo
         /// </summary>
         /// <param name="fileId"></param>
-        public static implicit operator InputTelegramFile(string fileId)
-            => fileId is default
+        public static implicit operator InputTelegramFile(string fileId) =>
+            fileId == null
                 ? default
                 : new InputTelegramFile(fileId);
     }

--- a/src/Telegram.Bot/Types/ReplyMarkups/InlineKeyboardButton.cs
+++ b/src/Telegram.Bot/Types/ReplyMarkups/InlineKeyboardButton.cs
@@ -152,7 +152,7 @@ namespace Telegram.Bot.Types.ReplyMarkups
         /// The result of the conversion.
         /// </returns>
         public static implicit operator InlineKeyboardButton(string textAndCallbackData) =>
-            textAndCallbackData is default
+            textAndCallbackData == null
                 ? default
                 : WithCallbackData(textAndCallbackData);
     }

--- a/src/Telegram.Bot/Types/ReplyMarkups/InlineKeyboardMarkup.cs
+++ b/src/Telegram.Bot/Types/ReplyMarkups/InlineKeyboardMarkup.cs
@@ -57,12 +57,12 @@ namespace Telegram.Bot.Types.ReplyMarkups
             new InlineKeyboardMarkup(new InlineKeyboardButton[0][]);
 
         public static implicit operator InlineKeyboardMarkup(InlineKeyboardButton button) =>
-            button is default
+            button == null
                 ? default
                 : new InlineKeyboardMarkup(button);
 
         public static implicit operator InlineKeyboardMarkup(string buttonText) =>
-            buttonText is default
+            buttonText == null
                 ? default
                 : new InlineKeyboardMarkup(buttonText);
     }

--- a/src/Telegram.Bot/Types/ReplyMarkups/ReplyKeyboardMarkup.cs
+++ b/src/Telegram.Bot/Types/ReplyMarkups/ReplyKeyboardMarkup.cs
@@ -65,17 +65,17 @@ namespace Telegram.Bot.Types.ReplyMarkups
         }
 
         public static implicit operator ReplyKeyboardMarkup(string text) =>
-            text is default
+            text == null
                 ? default
                 : new ReplyKeyboardMarkup(new[] {new KeyboardButton(text)});
 
         public static implicit operator ReplyKeyboardMarkup(string[] texts) =>
-            texts is default
+            texts == null
                 ? default
                 : new[] {texts};
 
         public static implicit operator ReplyKeyboardMarkup(string[][] textsItems) =>
-            textsItems is default
+            textsItems == null
                 ? default
                 : new ReplyKeyboardMarkup(
                     textsItems.Select(texts =>

--- a/src/Telegram.Bot/Types/User.cs
+++ b/src/Telegram.Bot/Types/User.cs
@@ -96,7 +96,7 @@ namespace Telegram.Bot.Types
         }
 
         /// <inheritdoc/>
-        public override string ToString() => (Username is default
+        public override string ToString() => (Username == null
                                                  ? FirstName + LastName?.Insert(0, " ")
                                                  : $"@{Username}") +
                                              $" ({Id})";

--- a/test/Telegram.Bot.Tests.Integ/Admin Bot/ChatMemberAdministrationTestFixture.cs
+++ b/test/Telegram.Bot.Tests.Integ/Admin Bot/ChatMemberAdministrationTestFixture.cs
@@ -34,8 +34,12 @@ namespace Telegram.Bot.Tests.Integ.Admin_Bot
         private static async Task<Chat> GetChat(TestsFixture testsFixture, string collectionName)
         {
             Chat chat;
-            int.TryParse(ConfigurationProvider.TestConfigurations.RegularGroupMemberId, out int userId);
-            if (userId is default)
+
+            if (int.TryParse(ConfigurationProvider.TestConfigurations.RegularGroupMemberId, out int userId))
+            {
+                chat = await testsFixture.BotClient.GetChatAsync(userId);
+            }
+            else
             {
                 await testsFixture.UpdateReceiver.DiscardNewUpdatesAsync();
 
@@ -48,12 +52,8 @@ namespace Telegram.Bot.Tests.Integ.Admin_Bot
 
                 chat = await testsFixture.GetChatFromTesterAsync(ChatType.Private);
             }
-            else
-            {
-                chat = await testsFixture.BotClient.GetChatAsync(userId);
-            }
 
-            if (chat.Username is default)
+            if (chat.Username == null)
             {
                 await testsFixture.SendTestCollectionNotificationAsync(collectionName,
                     $"[{chat.FirstName}](tg://user?id={chat.Id}) doesn't have a username.\n" +

--- a/test/Telegram.Bot.Tests.Integ/Framework/Fixtures/ChannelChatFixture.cs
+++ b/test/Telegram.Bot.Tests.Integ/Framework/Fixtures/ChannelChatFixture.cs
@@ -16,13 +16,13 @@ namespace Telegram.Bot.Tests.Integ.Framework.Fixtures
         {
             _testsFixture = testsFixture;
 
-            if (_testsFixture.ChannelChat is default)
+            if (_testsFixture.ChannelChat == null)
             {
                 _testsFixture.ChannelChat = GetChat(collectionName).GetAwaiter().GetResult();
             }
             ChannelChat = _testsFixture.ChannelChat;
 
-            ChannelChatId = ChannelChat.Username is default
+            ChannelChatId = ChannelChat.Username == null
                 ? ChannelChat.Id.ToString()
                 : '@' + ChannelChat.Username;
 
@@ -36,7 +36,7 @@ namespace Telegram.Bot.Tests.Integ.Framework.Fixtures
         {
             Chat chat;
             string chatId = ConfigurationProvider.TestConfigurations.ChannelChatId;
-            if (chatId is default)
+            if (chatId == null)
             {
                 await _testsFixture.UpdateReceiver.DiscardNewUpdatesAsync();
 

--- a/test/Telegram.Bot.Tests.Integ/Framework/Fixtures/PrivateChatFixture.cs
+++ b/test/Telegram.Bot.Tests.Integ/Framework/Fixtures/PrivateChatFixture.cs
@@ -14,7 +14,7 @@ namespace Telegram.Bot.Tests.Integ.Framework.Fixtures
         {
             _testsFixture = testsFixture;
 
-            if (_testsFixture.PrivateChat is default)
+            if (_testsFixture.PrivateChat == null)
             {
                 _testsFixture.PrivateChat = GetChat(collectionName).GetAwaiter().GetResult();
             }

--- a/test/Telegram.Bot.Tests.Integ/Framework/UpdateReceiver.cs
+++ b/test/Telegram.Bot.Tests.Integ/Framework/UpdateReceiver.cs
@@ -65,7 +65,7 @@ namespace Telegram.Bot.Tests.Integ.Framework
             {
                 IEnumerable<Update> updates = await GetOnlyAllowedUpdatesAsync(offset, cancellationToken, updateTypes);
 
-                if (predicate is default)
+                if (predicate == null)
                 {
                     updates = updates.Where(u => updateTypes.Contains(u.Type));
                 }

--- a/test/Telegram.Bot.Tests.Integ/Inline Mode/InlineQueryTests.cs
+++ b/test/Telegram.Bot.Tests.Integ/Inline Mode/InlineQueryTests.cs
@@ -749,7 +749,7 @@ namespace Telegram.Bot.Tests.Integ.Inline_Mode
 
             while (
                 !cancellationToken.IsCancellationRequested &&
-                (messageUpdate is default || chosenResultUpdate is default)
+                (messageUpdate == null || chosenResultUpdate == null)
             )
             {
                 await Task.Delay(1_000, cancellationToken);

--- a/test/Telegram.Bot.Tests.Integ/Payments/PaymentFixture.cs
+++ b/test/Telegram.Bot.Tests.Integ/Payments/PaymentFixture.cs
@@ -19,7 +19,7 @@ namespace Telegram.Bot.Tests.Integ.Payments
             : base(testsFixture, Constants.TestCollections.Payment)
         {
             PaymentProviderToken = ConfigurationProvider.TestConfigurations.PaymentProviderToken;
-            if (PaymentProviderToken is default)
+            if (PaymentProviderToken == null)
             {
                 throw new ArgumentNullException(nameof(PaymentProviderToken));
             }


### PR DESCRIPTION
- fix error CS8363 [disallow `default` as a constant pattern](dotnet/roslyn#23499) in library