### PR TITLE
Add editorconfig

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,29 @@
+# http://EditorConfig.org
+
+# This file is the top-most EditorConfig file
+root = true
+
+# All Files
+[*]
+charset = utf-8
+end_of_line = lf
+indent_style = space
+indent_size = 4
+insert_final_newline = true
+trim_trailing_whitespace = true
+
+# Solution Files
+[*.sln]
+indent_style = tab
+
+# XML Project Files
+[*.{csproj,vbproj,vcxproj,vcxproj.filters,proj,projitems,shproj}]
+indent_size = 2
+
+# Configuration Files
+[*.{json,xml,yml,config,props,targets,nuspec,resx,ruleset,vsixmanifest,vsct}]
+indent_size = 2
+
+# Markdown Files
+[*.md]
+trim_trailing_whitespace = false

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+### Added
+
+- Exception `InvalidQueryIdException`
 
 
 ## [14.2.0-rc-452] - 2018-02-24

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+
+
+## [14.2.0-rc-452] - 2018-02-24
+
 ### Added
 
 - Property `Message.MediaGroupId`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,17 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 - Exception `InvalidQueryIdException`
 
+### Changed
+
+- Access modifier of abstract class `BadRequestException` and `ForbiddenException` ctors to `protected`
+
+### Removed
+
+- Exception `BotBlockedException`
+- Exception `BotRestrictedException`
+- Exception `MissingParameterException`
+- Exception `NotEnoughRightsException`
+- Exception `WrongChatTypeException`
 
 ## [14.2.0-rc-452] - 2018-02-24
 

--- a/src/Telegram.Bot/Converters/InputFileConverter.cs
+++ b/src/Telegram.Bot/Converters/InputFileConverter.cs
@@ -36,7 +36,7 @@ namespace Telegram.Bot.Converters
         public override object ReadJson(JsonReader reader, Type objectType, object existingValue, JsonSerializer serializer)
         {
             string value = JToken.ReadFrom(reader).Value<string>();
-            if (value is default)
+            if (value == null)
             {
                 return new InputFileStream(Stream.Null);
             }

--- a/src/Telegram.Bot/Exceptions/ApiException.cs
+++ b/src/Telegram.Bot/Exceptions/ApiException.cs
@@ -16,7 +16,7 @@ namespace Telegram.Bot.Exceptions
         /// <summary>
         /// Contains information about why a request was unsuccessful.
         /// </summary>
-        public ResponseParameters Parameters { get; private set; }
+        public ResponseParameters Parameters { get; }
 
         /// <summary>
         /// Initializes a new instance of the <see cref="ApiRequestException"/> class.
@@ -60,6 +60,12 @@ namespace Telegram.Bot.Exceptions
             ErrorCode = errorCode;
         }
 
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ApiRequestException"/> class
+        /// </summary>
+        /// <param name="message">The message</param>
+        /// <param name="errorCode">The error code</param>
+        /// <param name="parameters">Response parameters</param>
         public ApiRequestException(string message, int errorCode, ResponseParameters parameters)
             : base(message)
         {
@@ -67,6 +73,13 @@ namespace Telegram.Bot.Exceptions
             Parameters = parameters;
         }
 
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ApiRequestException"/> class
+        /// </summary>
+        /// <param name="message">The message</param>
+        /// <param name="errorCode">The error code</param>
+        /// <param name="parameters">Response parameters</param>
+        /// <param name="innerException">The inner exception</param>
         public ApiRequestException(string message, int errorCode, ResponseParameters parameters, Exception innerException)
             : base(message, innerException)
         {
@@ -77,6 +90,7 @@ namespace Telegram.Bot.Exceptions
         /// <summary>
         /// Returns a new instance of the <see cref="ApiRequestException"/> class.
         /// </summary>
+        /// <typeparam name="T">Expected type of operation result</typeparam>
         /// <param name="apiResponse">The API response.</param>
         /// <returns><see cref="ApiRequestException"/></returns>
         public static ApiRequestException FromApiResponse<T>(ApiResponse<T> apiResponse)
@@ -90,12 +104,7 @@ namespace Telegram.Bot.Exceptions
                 case 400:
                     message = apiResponse.Description.Remove(0, "Bad Request: ".Length);
                     switch (message.Trim())
-                    {
-                        case "chat not found":
-                            return new ChatNotFoundException(apiResponse.Description)
-                            {
-                                Parameters = apiResponse.Parameters
-                            };
+                    {                       
                         case "have no rights to send a message":
                             return new BotRestrictedException(apiResponse.Description)
                             {
@@ -103,11 +112,6 @@ namespace Telegram.Bot.Exceptions
                             };
                         case "not enough rights to restrict/unrestrict chat member":
                             return new NotEnoughRightsException(apiResponse.Description)
-                            {
-                                Parameters = apiResponse.Parameters
-                            };
-                        case "user not found":
-                            return new UserNotFoundException(apiResponse.Description)
                             {
                                 Parameters = apiResponse.Parameters
                             };
@@ -138,12 +142,7 @@ namespace Telegram.Bot.Exceptions
                             return new BotBlockedException(apiResponse.Description)
                             {
                                 Parameters = apiResponse.Parameters
-                            };
-                        case "bot can't initiate conversation with a user":
-                            return new ChatNotInitiatedException(apiResponse.Description)
-                            {
-                                Parameters = apiResponse.Parameters
-                            };
+                            };                        
                         default:
                             LogMissingError(apiResponse);
                             return new ApiRequestException(apiResponse.Description, 403)

--- a/src/Telegram.Bot/Exceptions/ApiExceptionParser.cs
+++ b/src/Telegram.Bot/Exceptions/ApiExceptionParser.cs
@@ -11,6 +11,7 @@ namespace Telegram.Bot.Exceptions
             new BadRequestExceptionInfo<ChatNotFoundException>("chat not found"),
             new BadRequestExceptionInfo<UserNotFoundException>("user not found"),
             new BadRequestExceptionInfo<InvalidUserIdException>("USER_ID_INVALID"),
+            new BadRequestExceptionInfo<InvalidQueryIdException>("QUERY_ID_INVALID"),
 
             #region Stickers
 

--- a/src/Telegram.Bot/Exceptions/ApiExceptionParser.cs
+++ b/src/Telegram.Bot/Exceptions/ApiExceptionParser.cs
@@ -68,7 +68,6 @@ namespace Telegram.Bot.Exceptions
                     errorMessage = TruncateForbiddenErrorDescription(apiResponse.Description);
                     exception = Activator.CreateInstance(typeInfo.Type, errorMessage) as ApiRequestException;
                 }
-
             }
             return exception;
         }

--- a/src/Telegram.Bot/Exceptions/BadRequestException.cs
+++ b/src/Telegram.Bot/Exceptions/BadRequestException.cs
@@ -3,30 +3,60 @@ using Telegram.Bot.Types;
 
 namespace Telegram.Bot.Exceptions
 {
+    /// <summary>
+    /// A base class for "Error 400: Bad request" API responses
+    /// </summary>
     public abstract class BadRequestException : ApiRequestException
     {
+        /// <inheritdoc />
         public override int ErrorCode => BadRequestErrorCode;
 
+        /// <summary>
+        /// Represent error code number
+        /// </summary>
         public const int BadRequestErrorCode = 400;
 
+        /// <summary>
+        /// Represent error description
+        /// </summary>
         public const string BadRequestErrorDescription = "Bad Request: ";
 
-        public BadRequestException(string message)
+        /// <summary>
+        /// Initializes a new instance of the <see cref="BadRequestException"/> class
+        /// </summary>
+        /// <param name="message">The message</param>
+        protected BadRequestException(string message)
             : base(message, BadRequestErrorCode)
         {
         }
 
-        public BadRequestException(string message, Exception innerException)
+        /// <summary>
+        /// Initializes a new instance of the <see cref="BadRequestException"/> class
+        /// </summary>
+        /// <param name="message">The message</param>
+        /// <param name="innerException">The inner exception</param>
+        protected BadRequestException(string message, Exception innerException)
             : base(message, BadRequestErrorCode, innerException)
         {
         }
 
-        public BadRequestException(string message, ResponseParameters parameters)
+        /// <summary>
+        /// Initializes a new instance of the <see cref="BadRequestException"/> class
+        /// </summary>
+        /// <param name="message">The message</param>
+        /// <param name="parameters">Response parameters</param>
+        protected BadRequestException(string message, ResponseParameters parameters)
             : base(message, BadRequestErrorCode, parameters)
         {
         }
 
-        public BadRequestException(string message, ResponseParameters parameters, Exception innerException)
+        /// <summary>
+        /// Initializes a new instance of the <see cref="BadRequestException"/> class
+        /// </summary>
+        /// <param name="message">The message</param>
+        /// <param name="parameters">Response parameters</param>
+        /// <param name="innerException">The inner exception</param>
+        protected BadRequestException(string message, ResponseParameters parameters, Exception innerException)
             : base(message, BadRequestErrorCode, parameters, innerException)
         {
         }

--- a/src/Telegram.Bot/Exceptions/BadRequestExceptions/Invalid Parameter/InvalidParameterException.cs
+++ b/src/Telegram.Bot/Exceptions/BadRequestExceptions/Invalid Parameter/InvalidParameterException.cs
@@ -8,6 +8,7 @@ namespace Telegram.Bot.Exceptions
     {
         internal const string ParamGroupName = "param";
 
+        /// <inheritdoc />
         public string Parameter { get; }
 
         /// <summary>

--- a/src/Telegram.Bot/Exceptions/BadRequestExceptions/Invalid Parameter/InvalidQueryIdException.cs
+++ b/src/Telegram.Bot/Exceptions/BadRequestExceptions/Invalid Parameter/InvalidQueryIdException.cs
@@ -1,0 +1,19 @@
+﻿// ReSharper disable once CheckNamespace
+namespace Telegram.Bot.Exceptions
+{
+    /// <summary>
+    /// The exception that is thrown when Query Id is invalid or AnswerInlineQueryAsync 
+    /// called with 10 second delay
+    /// </summary>
+    public class InvalidQueryIdException : InvalidParameterException
+    {
+        /// <summary>
+        /// Initializes a new object of the <see cref="InvalidQueryIdException"/> class
+        /// </summary>
+        /// <param name="message">The error message of this exception.</param>
+        public InvalidQueryIdException(string message)
+            : base("inline_query_id", message)
+        {
+        }
+    }
+}

--- a/src/Telegram.Bot/Exceptions/BotBlockedException.cs
+++ b/src/Telegram.Bot/Exceptions/BotBlockedException.cs
@@ -1,14 +1,14 @@
-﻿namespace Telegram.Bot.Exceptions
-{
-    /// <summary>
-    /// This represents an exception when the bot is blocked by the user
-    /// </summary>
-    public class BotBlockedException : ApiRequestException
-    {
-        /// <summary>
-        /// Initializes a new object of the <see cref="BotBlockedException"/> class
-        /// </summary>
-        /// <param name="message">The message of this exception</param>
-        public BotBlockedException(string message) : base(message, 403) { }
-    }
-}
+﻿//namespace Telegram.Bot.Exceptions
+//{
+//    /// <summary>
+//    /// This represents an exception when the bot is blocked by the user
+//    /// </summary>
+//    public class BotBlockedException : ApiRequestException
+//    {
+//        /// <summary>
+//        /// Initializes a new object of the <see cref="BotBlockedException"/> class
+//        /// </summary>
+//        /// <param name="message">The message of this exception</param>
+//        public BotBlockedException(string message) : base(message, 403) { }
+//    }
+//}

--- a/src/Telegram.Bot/Exceptions/BotRestrictedException.cs
+++ b/src/Telegram.Bot/Exceptions/BotRestrictedException.cs
@@ -1,14 +1,14 @@
-﻿namespace Telegram.Bot.Exceptions
-{
-    /// <summary>
-    /// THis represents an api error when the bot is restricted in a group.
-    /// </summary>
-    public class BotRestrictedException : ApiRequestException
-    {
-        /// <summary>
-        /// Initializes a new object of the <see cref="BotRestrictedException"/> class.
-        /// </summary>
-        /// <param name="message">The error message.</param>
-        public BotRestrictedException(string message) : base(message, 400) { }
-    }
-}
+﻿//namespace Telegram.Bot.Exceptions
+//{
+//    /// <summary>
+//    /// THis represents an api error when the bot is restricted in a group.
+//    /// </summary>
+//    public class BotRestrictedException : ApiRequestException
+//    {
+//        /// <summary>
+//        /// Initializes a new object of the <see cref="BotRestrictedException"/> class.
+//        /// </summary>
+//        /// <param name="message">The error message.</param>
+//        public BotRestrictedException(string message) : base(message, 400) { }
+//    }
+//}

--- a/src/Telegram.Bot/Exceptions/ForbiddenException.cs
+++ b/src/Telegram.Bot/Exceptions/ForbiddenException.cs
@@ -5,28 +5,55 @@ namespace Telegram.Bot.Exceptions
 {
     public abstract class ForbiddenException : ApiRequestException
     {
+        /// <inheritdoc />
         public override int ErrorCode => ForbiddenErrorCode;
 
+        /// <summary>
+        /// Represent error code number
+        /// </summary>
         public const int ForbiddenErrorCode = 403;
 
+        /// <summary>
+        /// Represent error description
+        /// </summary>
         public const string ForbiddenErrorDescription = "Forbidden: ";
 
-        public ForbiddenException(string message)
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ForbiddenException"/> class
+        /// </summary>
+        /// <param name="message">The message</param>
+        protected ForbiddenException(string message)
             : base(message, ForbiddenErrorCode)
         {
         }
 
-        public ForbiddenException(string message, Exception innerException)
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ForbiddenException"/> class
+        /// </summary>
+        /// <param name="message">The message</param>
+        /// <param name="innerException">The inner exception</param>
+        protected ForbiddenException(string message, Exception innerException)
             : base(message, ForbiddenErrorCode, innerException)
         {
         }
 
-        public ForbiddenException(string message, ResponseParameters parameters)
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ForbiddenException"/> class
+        /// </summary>
+        /// <param name="message">The message</param>
+        /// <param name="parameters">Response parameters</param>
+        protected ForbiddenException(string message, ResponseParameters parameters)
             : base(message, ForbiddenErrorCode, parameters)
         {
         }
 
-        public ForbiddenException(string message, ResponseParameters parameters, Exception innerException)
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ForbiddenException"/> class
+        /// </summary>
+        /// <param name="message">The message</param>
+        /// <param name="parameters">Response parameters</param>
+        /// <param name="innerException">The inner exception</param>
+        protected ForbiddenException(string message, ResponseParameters parameters, Exception innerException)
             : base(message, ForbiddenErrorCode, parameters, innerException)
         {
         }

--- a/src/Telegram.Bot/Exceptions/MissingParameterException.cs
+++ b/src/Telegram.Bot/Exceptions/MissingParameterException.cs
@@ -1,23 +1,23 @@
-﻿namespace Telegram.Bot.Exceptions
-{
-    /// <summary>
-    /// Represents an api exception for a missing parameter.
-    /// </summary>
-    public class MissingParameterException : ApiRequestException
-    {
-        /// <summary>
-        /// The missing parameter.
-        /// </summary>
-        public string MissingParameter { get; }
+﻿//namespace Telegram.Bot.Exceptions
+//{
+//    /// <summary>
+//    /// Represents an api exception for a missing parameter.
+//    /// </summary>
+//    public class MissingParameterException : ApiRequestException
+//    {
+//        /// <summary>
+//        /// The missing parameter.
+//        /// </summary>
+//        public string MissingParameter { get; }
 
-        /// <summary>
-        /// Initializes a new object of the <see cref="MissingParameterException"/> class
-        /// </summary>
-        /// <param name="message">The error message of this exception.</param>
-        /// <param name="paramName">The name of the missing parameter.</param>
-        public MissingParameterException(string message, string paramName) : base(message, 400)
-        {
-            MissingParameter = paramName;
-        }
-    }
-}
+//        /// <summary>
+//        /// Initializes a new object of the <see cref="MissingParameterException"/> class
+//        /// </summary>
+//        /// <param name="message">The error message of this exception.</param>
+//        /// <param name="paramName">The name of the missing parameter.</param>
+//        public MissingParameterException(string message, string paramName) : base(message, 400)
+//        {
+//            MissingParameter = paramName;
+//        }
+//    }
+//}

--- a/src/Telegram.Bot/Exceptions/NotEnoughRightsException.cs
+++ b/src/Telegram.Bot/Exceptions/NotEnoughRightsException.cs
@@ -1,16 +1,16 @@
-﻿using Telegram.Bot.Types;
+﻿//using Telegram.Bot.Types;
 
-namespace Telegram.Bot.Exceptions
-{
-    /// <summary>
-    /// Reperesents an api exception when the bot has not enough rights to do something
-    /// </summary>
-    public class NotEnoughRightsException : ApiRequestException
-    {
-        /// <summary>
-        /// Initializes a new object of the <see cref="NotEnoughRightsException"/> class
-        /// </summary>
-        /// <param name="message">The error message of this exception.</param>
-        public NotEnoughRightsException(string message) : base(message, 400) { }
-    }
-}
+//namespace Telegram.Bot.Exceptions
+//{
+//    /// <summary>
+//    /// Reperesents an api exception when the bot has not enough rights to do something
+//    /// </summary>
+//    public class NotEnoughRightsException : ApiRequestException
+//    {
+//        /// <summary>
+//        /// Initializes a new object of the <see cref="NotEnoughRightsException"/> class
+//        /// </summary>
+//        /// <param name="message">The error message of this exception.</param>
+//        public NotEnoughRightsException(string message) : base(message, 400) { }
+//    }
+//}

--- a/src/Telegram.Bot/Exceptions/WrongChatTypeException.cs
+++ b/src/Telegram.Bot/Exceptions/WrongChatTypeException.cs
@@ -1,14 +1,14 @@
-﻿namespace Telegram.Bot.Exceptions
-{
-    /// <summary>
-    /// Reperesents an api exception when the bot sent a request for the wrong chat type
-    /// </summary>
-    public class WrongChatTypeException : ApiRequestException
-    {
-        /// <summary>
-        /// Initializes a new object of the <see cref="WrongChatTypeException"/> class
-        /// </summary>
-        /// <param name="message">The error message of this exception.</param>
-        public WrongChatTypeException(string message) : base(message, 400) { }
-    }
-}
+﻿//namespace Telegram.Bot.Exceptions
+//{
+//    /// <summary>
+//    /// Reperesents an api exception when the bot sent a request for the wrong chat type
+//    /// </summary>
+//    public class WrongChatTypeException : ApiRequestException
+//    {
+//        /// <summary>
+//        /// Initializes a new object of the <see cref="WrongChatTypeException"/> class
+//        /// </summary>
+//        /// <param name="message">The error message of this exception.</param>
+//        public WrongChatTypeException(string message) : base(message, 400) { }
+//    }
+//}

--- a/src/Telegram.Bot/Requests/Getting Updates/SetWebhookRequest.cs
+++ b/src/Telegram.Bot/Requests/Getting Updates/SetWebhookRequest.cs
@@ -52,7 +52,7 @@ namespace Telegram.Bot.Requests
 
         /// <inheritdoc cref="RequestBase{TResponse}.ToHttpContent"/>
         public override HttpContent ToHttpContent() =>
-            Certificate is default
+            Certificate == null
                 ? base.ToHttpContent()
                 : ToMultipartFormDataContent("certificate", Certificate);
     }

--- a/src/Telegram.Bot/TelegramBotClient.cs
+++ b/src/Telegram.Bot/TelegramBotClient.cs
@@ -717,7 +717,7 @@ namespace Telegram.Bot
             {
                 throw new ArgumentException("Invalid file path", nameof(filePath));
             }
-            if (destination is default)
+            if (destination == null)
             {
                 throw new ArgumentNullException(nameof(destination));
             }

--- a/src/Telegram.Bot/Types/InputFiles/InputFileStream.cs
+++ b/src/Telegram.Bot/Types/InputFiles/InputFileStream.cs
@@ -55,8 +55,8 @@ namespace Telegram.Bot.Types.InputFiles
         /// ToDo
         /// </summary>
         /// <param name="stream"></param>
-        public static implicit operator InputFileStream(Stream stream)
-            => stream is default
+        public static implicit operator InputFileStream(Stream stream) =>
+            stream == null
                 ? default
                 : new InputFileStream(stream);
     }

--- a/src/Telegram.Bot/Types/InputFiles/InputMedia.cs
+++ b/src/Telegram.Bot/Types/InputFiles/InputMedia.cs
@@ -33,8 +33,8 @@ namespace Telegram.Bot.Types
         /// ToDo
         /// </summary>
         /// <param name="value"></param>
-        public static implicit operator InputMedia(string value)
-            => value is default
+        public static implicit operator InputMedia(string value) =>
+            value == null
                 ? default
                 : new InputMedia(value);
     }

--- a/src/Telegram.Bot/Types/InputFiles/InputOnlineFile.cs
+++ b/src/Telegram.Bot/Types/InputFiles/InputOnlineFile.cs
@@ -71,8 +71,8 @@ namespace Telegram.Bot.Types.InputFiles
         /// ToDo
         /// </summary>
         /// <param name="stream"></param>
-        public static implicit operator InputOnlineFile(Stream stream)
-            => stream is default
+        public static implicit operator InputOnlineFile(Stream stream) =>
+            stream == null
                 ? default
                 : new InputOnlineFile(stream);
 
@@ -80,8 +80,8 @@ namespace Telegram.Bot.Types.InputFiles
         /// ToDo
         /// </summary>
         /// <param name="value"></param>
-        public static implicit operator InputOnlineFile(string value)
-            => value is default
+        public static implicit operator InputOnlineFile(string value) =>
+            value == null
                 ? default
                 : new InputOnlineFile(value);
     }

--- a/src/Telegram.Bot/Types/InputFiles/InputTelegramFile.cs
+++ b/src/Telegram.Bot/Types/InputFiles/InputTelegramFile.cs
@@ -69,8 +69,8 @@ namespace Telegram.Bot.Types.InputFiles
         /// ToDo
         /// </summary>
         /// <param name="stream"></param>
-        public static implicit operator InputTelegramFile(Stream stream)
-            => stream is default
+        public static implicit operator InputTelegramFile(Stream stream) =>
+            stream == null
                 ? default
                 : new InputTelegramFile(stream);
 
@@ -78,8 +78,8 @@ namespace Telegram.Bot.Types.InputFiles
         /// ToDo
         /// </summary>
         /// <param name="fileId"></param>
-        public static implicit operator InputTelegramFile(string fileId)
-            => fileId is default
+        public static implicit operator InputTelegramFile(string fileId) =>
+            fileId == null
                 ? default
                 : new InputTelegramFile(fileId);
     }

--- a/src/Telegram.Bot/Types/ReplyMarkups/InlineKeyboardButton.cs
+++ b/src/Telegram.Bot/Types/ReplyMarkups/InlineKeyboardButton.cs
@@ -152,7 +152,7 @@ namespace Telegram.Bot.Types.ReplyMarkups
         /// The result of the conversion.
         /// </returns>
         public static implicit operator InlineKeyboardButton(string textAndCallbackData) =>
-            textAndCallbackData is default
+            textAndCallbackData == null
                 ? default
                 : WithCallbackData(textAndCallbackData);
     }

--- a/src/Telegram.Bot/Types/ReplyMarkups/InlineKeyboardMarkup.cs
+++ b/src/Telegram.Bot/Types/ReplyMarkups/InlineKeyboardMarkup.cs
@@ -57,12 +57,12 @@ namespace Telegram.Bot.Types.ReplyMarkups
             new InlineKeyboardMarkup(new InlineKeyboardButton[0][]);
 
         public static implicit operator InlineKeyboardMarkup(InlineKeyboardButton button) =>
-            button is default
+            button == null
                 ? default
                 : new InlineKeyboardMarkup(button);
 
         public static implicit operator InlineKeyboardMarkup(string buttonText) =>
-            buttonText is default
+            buttonText == null
                 ? default
                 : new InlineKeyboardMarkup(buttonText);
     }

--- a/src/Telegram.Bot/Types/ReplyMarkups/ReplyKeyboardMarkup.cs
+++ b/src/Telegram.Bot/Types/ReplyMarkups/ReplyKeyboardMarkup.cs
@@ -65,17 +65,17 @@ namespace Telegram.Bot.Types.ReplyMarkups
         }
 
         public static implicit operator ReplyKeyboardMarkup(string text) =>
-            text is default
+            text == null
                 ? default
                 : new ReplyKeyboardMarkup(new[] {new KeyboardButton(text)});
 
         public static implicit operator ReplyKeyboardMarkup(string[] texts) =>
-            texts is default
+            texts == null
                 ? default
                 : new[] {texts};
 
         public static implicit operator ReplyKeyboardMarkup(string[][] textsItems) =>
-            textsItems is default
+            textsItems == null
                 ? default
                 : new ReplyKeyboardMarkup(
                     textsItems.Select(texts =>

--- a/src/Telegram.Bot/Types/User.cs
+++ b/src/Telegram.Bot/Types/User.cs
@@ -96,7 +96,7 @@ namespace Telegram.Bot.Types
         }
 
         /// <inheritdoc/>
-        public override string ToString() => (Username is default
+        public override string ToString() => (Username == null
                                                  ? FirstName + LastName?.Insert(0, " ")
                                                  : $"@{Username}") +
                                              $" ({Id})";

--- a/test/Telegram.Bot.Tests.Integ/Admin Bot/ChatMemberAdministrationTestFixture.cs
+++ b/test/Telegram.Bot.Tests.Integ/Admin Bot/ChatMemberAdministrationTestFixture.cs
@@ -34,8 +34,12 @@ namespace Telegram.Bot.Tests.Integ.Admin_Bot
         private static async Task<Chat> GetChat(TestsFixture testsFixture, string collectionName)
         {
             Chat chat;
-            int.TryParse(ConfigurationProvider.TestConfigurations.RegularGroupMemberId, out int userId);
-            if (userId is default)
+
+            if (int.TryParse(ConfigurationProvider.TestConfigurations.RegularGroupMemberId, out int userId))
+            {
+                chat = await testsFixture.BotClient.GetChatAsync(userId);
+            }
+            else
             {
                 await testsFixture.UpdateReceiver.DiscardNewUpdatesAsync();
 
@@ -48,12 +52,8 @@ namespace Telegram.Bot.Tests.Integ.Admin_Bot
 
                 chat = await testsFixture.GetChatFromTesterAsync(ChatType.Private);
             }
-            else
-            {
-                chat = await testsFixture.BotClient.GetChatAsync(userId);
-            }
 
-            if (chat.Username is default)
+            if (chat.Username == null)
             {
                 await testsFixture.SendTestCollectionNotificationAsync(collectionName,
                     $"[{chat.FirstName}](tg://user?id={chat.Id}) doesn't have a username.\n" +

--- a/test/Telegram.Bot.Tests.Integ/Exceptions/ApiExceptionsTests.cs
+++ b/test/Telegram.Bot.Tests.Integ/Exceptions/ApiExceptionsTests.cs
@@ -4,6 +4,7 @@ using Telegram.Bot.Exceptions;
 using Telegram.Bot.Tests.Integ.Framework;
 using Telegram.Bot.Types;
 using Telegram.Bot.Types.Enums;
+using Telegram.Bot.Types.InlineQueryResults;
 using Telegram.Bot.Types.ReplyMarkups;
 using Xunit;
 
@@ -109,6 +110,37 @@ namespace Telegram.Bot.Tests.Integ.Exceptions
             Assert.IsType<MessageIsNotModifiedException>(e);
         }
 
+        [Fact(DisplayName = FactTitles.ShouldThrowExceptionInvalidQueryIdException)]
+        [Trait(Constants.MethodTraitName, Constants.TelegramBotApiMethods.AnswerInlineQuery)]
+        [ExecutionOrder(6)]
+        public async Task Should_Throw_Exception_QueryIdInvalidException()
+        {
+            await _fixture.SendTestCaseNotificationAsync(FactTitles.ShouldThrowExceptionInvalidQueryIdException);
+
+            Update queryUpdate = await _fixture.UpdateReceiver.GetInlineQueryUpdateAsync();
+
+            InlineQueryResultBase[] results =
+            {
+                new InlineQueryResultArticle(
+                    id: "article:bot-api",
+                    title: "Telegram Bot API",
+                    inputMessageContent: new InputTextMessageContent("https://core.telegram.org/bots/api"))
+                    {
+                        Description = "The Bot API is an HTTP-based interface created for developers",
+                    },
+            };
+
+            await Task.Delay(10_000);
+
+            InvalidQueryIdException e = await Assert.ThrowsAnyAsync<InvalidQueryIdException>(() =>
+                BotClient.AnswerInlineQueryAsync(
+                    inlineQueryId: queryUpdate.InlineQuery.Id,
+                    results: results,
+                    cacheTime: 0));
+
+            Assert.Equal("inline_query_id", e.Parameter);
+        }
+
         private static class FactTitles
         {
             public const string ShouldThrowChatNotFoundException =
@@ -128,6 +160,10 @@ namespace Telegram.Bot.Tests.Integ.Exceptions
             public const string ShouldThrowExceptionMessageIsNotModifiedException =
                "Should throw MessageIsNotModifiedException while editing previously sent message " +
                 "with the same text";
+
+            public const string ShouldThrowExceptionInvalidQueryIdException =
+                   "Should throw InvalidQueryIdException when AnswerInlineQueryAsync called with" +
+                    " 10 second delay";
         }
     }
 }

--- a/test/Telegram.Bot.Tests.Integ/Framework/Fixtures/ChannelChatFixture.cs
+++ b/test/Telegram.Bot.Tests.Integ/Framework/Fixtures/ChannelChatFixture.cs
@@ -16,13 +16,13 @@ namespace Telegram.Bot.Tests.Integ.Framework.Fixtures
         {
             _testsFixture = testsFixture;
 
-            if (_testsFixture.ChannelChat is default)
+            if (_testsFixture.ChannelChat == null)
             {
                 _testsFixture.ChannelChat = GetChat(collectionName).GetAwaiter().GetResult();
             }
             ChannelChat = _testsFixture.ChannelChat;
 
-            ChannelChatId = ChannelChat.Username is default
+            ChannelChatId = ChannelChat.Username == null
                 ? ChannelChat.Id.ToString()
                 : '@' + ChannelChat.Username;
 
@@ -36,7 +36,7 @@ namespace Telegram.Bot.Tests.Integ.Framework.Fixtures
         {
             Chat chat;
             string chatId = ConfigurationProvider.TestConfigurations.ChannelChatId;
-            if (chatId is default)
+            if (chatId == null)
             {
                 await _testsFixture.UpdateReceiver.DiscardNewUpdatesAsync();
 

--- a/test/Telegram.Bot.Tests.Integ/Framework/Fixtures/PrivateChatFixture.cs
+++ b/test/Telegram.Bot.Tests.Integ/Framework/Fixtures/PrivateChatFixture.cs
@@ -14,7 +14,7 @@ namespace Telegram.Bot.Tests.Integ.Framework.Fixtures
         {
             _testsFixture = testsFixture;
 
-            if (_testsFixture.PrivateChat is default)
+            if (_testsFixture.PrivateChat == null)
             {
                 _testsFixture.PrivateChat = GetChat(collectionName).GetAwaiter().GetResult();
             }

--- a/test/Telegram.Bot.Tests.Integ/Framework/UpdateReceiver.cs
+++ b/test/Telegram.Bot.Tests.Integ/Framework/UpdateReceiver.cs
@@ -65,7 +65,7 @@ namespace Telegram.Bot.Tests.Integ.Framework
             {
                 IEnumerable<Update> updates = await GetOnlyAllowedUpdatesAsync(offset, cancellationToken, updateTypes);
 
-                if (predicate is default)
+                if (predicate == null)
                 {
                     updates = updates.Where(u => updateTypes.Contains(u.Type));
                 }

--- a/test/Telegram.Bot.Tests.Integ/Inline Mode/InlineQueryTests.cs
+++ b/test/Telegram.Bot.Tests.Integ/Inline Mode/InlineQueryTests.cs
@@ -28,7 +28,6 @@ namespace Telegram.Bot.Tests.Integ.Inline_Mode
         [ExecutionOrder(1)]
         public async Task Should_Answer_Inline_Query_With_Article()
         {
-            // ToDo: add exception: Bad Request: QUERY_ID_INVALID
             await _fixture.SendTestCaseNotificationAsync(FactTitles.ShouldAnswerInlineQueryWithArticle,
                 startInlineQuery: true);
 

--- a/test/Telegram.Bot.Tests.Integ/Inline Mode/InlineQueryTests.cs
+++ b/test/Telegram.Bot.Tests.Integ/Inline Mode/InlineQueryTests.cs
@@ -749,7 +749,7 @@ namespace Telegram.Bot.Tests.Integ.Inline_Mode
 
             while (
                 !cancellationToken.IsCancellationRequested &&
-                (messageUpdate is default || chosenResultUpdate is default)
+                (messageUpdate == null || chosenResultUpdate == null)
             )
             {
                 await Task.Delay(1_000, cancellationToken);

--- a/test/Telegram.Bot.Tests.Integ/Payments/PaymentFixture.cs
+++ b/test/Telegram.Bot.Tests.Integ/Payments/PaymentFixture.cs
@@ -19,7 +19,7 @@ namespace Telegram.Bot.Tests.Integ.Payments
             : base(testsFixture, Constants.TestCollections.Payment)
         {
             PaymentProviderToken = ConfigurationProvider.TestConfigurations.PaymentProviderToken;
-            if (PaymentProviderToken is default)
+            if (PaymentProviderToken == null)
             {
                 throw new ArgumentNullException(nameof(PaymentProviderToken));
             }


### PR DESCRIPTION
This PR will add `.editorconfig` file to prevent constant style changes in files between commits from different collaborators.

Following default configs are set:
- Charset is UTF-8
- Use LF for line endings
- Insert final new line
- Use spaces for indentation
- Indentation size is 4 spaces
- Trim trailing whitespace

Trimming trailing whitespace is turned off for markdown because it can break the markup.