### PR TITLE
Add editorconfig

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,29 @@
+# http://EditorConfig.org
+
+# This file is the top-most EditorConfig file
+root = true
+
+# All Files
+[*]
+charset = utf-8
+end_of_line = lf
+indent_style = space
+indent_size = 4
+insert_final_newline = true
+trim_trailing_whitespace = true
+
+# Solution Files
+[*.sln]
+indent_style = tab
+
+# XML Project Files
+[*.{csproj,vbproj,vcxproj,vcxproj.filters,proj,projitems,shproj}]
+indent_size = 2
+
+# Configuration Files
+[*.{json,xml,yml,config,props,targets,nuspec,resx,ruleset,vsixmanifest,vsct}]
+indent_size = 2
+
+# Markdown Files
+[*.md]
+trim_trailing_whitespace = false

--- a/Telegram.Bot.sln
+++ b/Telegram.Bot.sln
@@ -13,6 +13,15 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Telegram.Bot.Tests.Integ", 
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Telegram.Bot.Tests.Unit", "test\Telegram.Bot.Tests.Unit\Telegram.Bot.Tests.Unit.csproj", "{AAB9E3BA-D749-4D38-9021-EBD8D0BC8975}"
 EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{C45387C6-C93F-4FD2-84A8-A69CCE93B7EE}"
+	ProjectSection(SolutionItems) = preProject
+		.editorconfig = .editorconfig
+		CHANGELOG.md = CHANGELOG.md
+		CONTRIBUTING.md = CONTRIBUTING.md
+		ISSUE_TEMPLATE.md = ISSUE_TEMPLATE.md
+		README.md = README.md
+	EndProjectSection
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU

--- a/test/Telegram.Bot.Tests.Integ/.editorconfig
+++ b/test/Telegram.Bot.Tests.Integ/.editorconfig
@@ -1,0 +1,7 @@
+# http://EditorConfig.org
+
+# CSharp code style settings:
+[*.cs]
+csharp_style_var_for_built_in_types = false:error
+csharp_style_var_when_type_is_apparent = false:error
+csharp_style_var_elsewhere = false:error

--- a/test/Telegram.Bot.Tests.Integ/Framework/.editorconfig
+++ b/test/Telegram.Bot.Tests.Integ/Framework/.editorconfig
@@ -1,0 +1,7 @@
+# http://EditorConfig.org
+
+# CSharp code style settings:
+[*.cs]
+csharp_style_var_for_built_in_types = true:none
+csharp_style_var_when_type_is_apparent = true:none
+csharp_style_var_elsewhere = true:none


### PR DESCRIPTION
This PR will add `.editorconfig` file to prevent constant style changes in files between commits from different collaborators.

Following default configs are set:
- Charset is UTF-8
- Use LF for line endings
- Insert final new line
- Use spaces for indentation
- Indentation size is 4 spaces
- Trim trailing whitespace

Trimming trailing whitespace is turned off for markdown because it can break the markup.

Force explicit type instead of 'var' in integration tests project
- add .editorconfig to force explicit type instead of 'var' in integration tests project
- allow implicit type declaration for tests framework

#640 