### PR TITLE
Delay test execution

### DIFF
--- a/test/Telegram.Bot.Tests.Integ/Framework/DelayTests.cs
+++ b/test/Telegram.Bot.Tests.Integ/Framework/DelayTests.cs
@@ -1,0 +1,24 @@
+using System.Threading.Tasks;
+using Xunit;
+
+namespace Telegram.Bot.Tests.Integ.Framework
+{
+    public abstract class DelayTestsBase
+    {
+        [OrderedFact]
+        public async Task Delay()
+        {
+            await Task.Delay(60_000);
+        }
+    }
+
+    [Collection(nameof(DelayTests1))] public class DelayTests1 : DelayTestsBase { }
+
+    [Collection(nameof(DelayTests2))] public class DelayTests2 : DelayTestsBase { }
+
+    [Collection(nameof(DelayTests3))] public class DelayTests3 : DelayTestsBase { }
+
+    [Collection(nameof(DelayTests4))] public class DelayTests4 : DelayTestsBase { }
+
+    [Collection(nameof(DelayTests5))] public class DelayTests5 : DelayTestsBase { }
+}

--- a/test/Telegram.Bot.Tests.Integ/Framework/TestCollectionOrderer.cs
+++ b/test/Telegram.Bot.Tests.Integ/Framework/TestCollectionOrderer.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using Xunit;
@@ -12,23 +12,28 @@ namespace Telegram.Bot.Tests.Integ.Framework
             Constants.TestCollections.GettingUpdates,
             Constants.TestCollections.Webhook,
             Constants.TestCollections.SendTextMessage,
+            nameof(DelayTests1),
             Constants.TestCollections.PrivateChatReplyMarkup,
             Constants.TestCollections.ReplyMarkup,
             Constants.TestCollections.SendPhotoMessage,
+            nameof(DelayTests2),
             Constants.TestCollections.SendAudioMessage,
             Constants.TestCollections.SendVenueMessage,
             Constants.TestCollections.SendContactMessage,
             Constants.TestCollections.InlineQuery,
+            nameof(DelayTests3),
             Constants.TestCollections.SendVideoMessage,
             Constants.TestCollections.FileDownload,
             Constants.TestCollections.LeaveChat,
             Constants.TestCollections.GetUserProfilePhotos,
             Constants.TestCollections.SendDocumentMessage,
             Constants.TestCollections.ChatInfo,
+            nameof(DelayTests4),
             Constants.TestCollections.AlbumMessage,
             Constants.TestCollections.CallbackQuery,
             Constants.TestCollections.EditMessage,
             Constants.TestCollections.DeleteMessage,
+            nameof(DelayTests5),
             Constants.TestCollections.InlineMessageLiveLocation,
             Constants.TestCollections.LiveLocation,
             Constants.TestCollections.Stickers,

--- a/test/Telegram.Bot.Tests.Integ/Update Messages/EditMessageContentTests.cs
+++ b/test/Telegram.Bot.Tests.Integ/Update Messages/EditMessageContentTests.cs
@@ -1,7 +1,6 @@
 ﻿using System;
 using System.IO;
 using System.Threading.Tasks;
-using Newtonsoft.Json.Linq;
 using Telegram.Bot.Tests.Integ.Framework;
 using Telegram.Bot.Types;
 using Telegram.Bot.Types.InlineQueryResults;
@@ -35,7 +34,8 @@ namespace Telegram.Bot.Tests.Integ.Update_Messages
                 text: "Message text will be edited shortly."
             );
 
-            await Task.Delay(500);
+            DateTime timeBeforeEdition = DateTime.UtcNow;
+            await Task.Delay(1_000);
 
             const string newText = "Text is edited.";
             Message editedMessage = await BotClient.EditMessageTextAsync(
@@ -46,7 +46,7 @@ namespace Telegram.Bot.Tests.Integ.Update_Messages
 
             Assert.Equal(newText, editedMessage.Text);
             Assert.Equal(originalMessage.MessageId, editedMessage.MessageId);
-            // Assert.True(timeBeforeEdition < editedMessage.EditDate.Value); // ToDo: edit_date isn null. Check with @BotSupport
+            Assert.True(timeBeforeEdition < editedMessage.EditDate);
         }
 
         [OrderedFact(DisplayName = FactTitles.ShouldEditInlineMessageText)]
@@ -102,7 +102,8 @@ namespace Telegram.Bot.Tests.Integ.Update_Messages
                 replyMarkup: (InlineKeyboardMarkup) "Original markup"
             );
 
-            await Task.Delay(500);
+            DateTime timeBeforeEdition = DateTime.UtcNow;
+            await Task.Delay(1_000);
 
             Message editedMessage = await BotClient.EditMessageReplyMarkupAsync(
                 chatId: message.Chat.Id,
@@ -110,9 +111,9 @@ namespace Telegram.Bot.Tests.Integ.Update_Messages
                 replyMarkup: "Edited 👍"
             );
 
-            Assert.True(JToken.DeepEquals(
-                JToken.FromObject(message), JToken.FromObject(editedMessage)
-            ));
+            Assert.Equal(message.MessageId, editedMessage.MessageId);
+            Assert.Equal(message.Text, editedMessage.Text);
+            Assert.True(timeBeforeEdition < editedMessage.EditDate);
         }
 
         [OrderedFact(DisplayName = FactTitles.ShouldEditInlineMessageMarkup)]
@@ -178,7 +179,8 @@ namespace Telegram.Bot.Tests.Integ.Update_Messages
                 );
             }
 
-            await Task.Delay(500);
+            DateTime timeBeforeEdition = DateTime.UtcNow;
+            await Task.Delay(1_000);
 
             const string newCaption = "Caption is edited.";
 
@@ -190,6 +192,7 @@ namespace Telegram.Bot.Tests.Integ.Update_Messages
 
             Assert.Equal(originalMessage.MessageId, editedMessage.MessageId);
             Assert.Equal(newCaption, editedMessage.Caption);
+            Assert.True(timeBeforeEdition < editedMessage.EditDate);
         }
 
         [OrderedFact(DisplayName = FactTitles.ShouldEditInlineMessageCaption)]


### PR DESCRIPTION
This is a workaround for API rate limiting. It delays test execution for 60 seconds at multiple points.