### PR TITLE
Fix EditMessageTextAsync

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ### Added
 ### Changed
 ### Fixed
+
+- `EditMessageTextAsync` pass `ParseMode` to request
+
 ### Removed
 
 ## [14.3.0] - 2018-05-05

--- a/src/Telegram.Bot/TelegramBotClient.cs
+++ b/src/Telegram.Bot/TelegramBotClient.cs
@@ -928,7 +928,8 @@ namespace Telegram.Bot
             MakeRequestAsync(new EditInlineMessageTextRequest(inlineMessageId, text)
             {
                 DisableWebPagePreview = disableWebPagePreview,
-                ReplyMarkup = replyMarkup
+                ReplyMarkup = replyMarkup,
+                ParseMode = parseMode
             }, cancellationToken);
 
         /// <inheritdoc />


### PR DESCRIPTION
- `EditMessageTextAsync` now pass `ParseMode` to `EditInlineMessageTextRequest`
- in `EditMessageTextAsync` tests messages now have HTML markup

 #699