### PR TITLE
Fix: call delegates outside receive loop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,11 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Added
 ### Changed
+
+- Stop catching user exceptions from event handlers
+
 ### Fixed
+
 ### Removed
 
 ## [14.3.0] - 2018-05-05

--- a/src/Telegram.Bot/Telegram.Bot.csproj
+++ b/src/Telegram.Bot/Telegram.Bot.csproj
@@ -1,7 +1,8 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFrameworks>netstandard1.1;net45</TargetFrameworks>
-    <VersionPrefix>14.3.0</VersionPrefix>
+    <VersionPrefix>14.4.0</VersionPrefix>
+    <VersionSuffix>alpha</VersionSuffix>
     <LangVersion>latest</LangVersion>
     <GeneratePackageOnBuild>True</GeneratePackageOnBuild>
     <GenerateDocumentationFile>True</GenerateDocumentationFile>

--- a/src/Telegram.Bot/TelegramBotClient.cs
+++ b/src/Telegram.Bot/TelegramBotClient.cs
@@ -312,20 +312,16 @@ namespace Telegram.Bot
             while (!cancellationToken.IsCancellationRequested)
             {
                 var timeout = Convert.ToInt32(Timeout.TotalSeconds);
+                Update[] updates = default;
 
                 try
                 {
-                    var updates =
-                        await
-                            GetUpdatesAsync(MessageOffset, timeout: timeout, allowedUpdates: allowedUpdates,
-                                    cancellationToken: cancellationToken)
-                                .ConfigureAwait(false);
-
-                    foreach (var update in updates)
-                    {
-                        MessageOffset = update.Id + 1;
-                        OnUpdateReceived(new UpdateEventArgs(update));
-                    }
+                    updates = await GetUpdatesAsync(
+                       MessageOffset,
+                       timeout: timeout,
+                       allowedUpdates: allowedUpdates,
+                       cancellationToken: cancellationToken
+                    ).ConfigureAwait(false);
                 }
                 catch (OperationCanceledException)
                 {
@@ -337,6 +333,12 @@ namespace Telegram.Bot
                 catch (Exception generalException)
                 {
                     OnReceiveGeneralError?.Invoke(this, generalException);
+                }
+
+                foreach (var update in updates)
+                {
+                    MessageOffset = update.Id + 1;
+                    OnUpdateReceived(new UpdateEventArgs(update));
                 }
             }
 

--- a/src/Telegram.Bot/TelegramBotClient.cs
+++ b/src/Telegram.Bot/TelegramBotClient.cs
@@ -337,8 +337,8 @@ namespace Telegram.Bot
 
                 foreach (var update in updates)
                 {
-                    MessageOffset = update.Id + 1;
                     OnUpdateReceived(new UpdateEventArgs(update));
+                    MessageOffset = update.Id + 1;
                 }
             }
 


### PR DESCRIPTION
- in update receive loop call delegates outside `try..catch` block to avoid catching exceptions in user code

#684 