### PR TITLE
Fix: TestApiAsync should not catch 404

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,11 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Added
 ### Changed
+
+- `MakeRequestAsync` throws `ApiRequestException` with `ErrorCode = HttpStatusCode.Unauthorized` and `Message = apiResponse.Description` ("Unauthorized"), to be consistent with Telegram Bot API
+- `TelegramBotClient` ctor does not check API token format: Telegram Bot API does not provide token format specification
+- `TestApiAsync` return `false` when `ApiRequestException.ErrorCode == 401` (API Token is modified or recalled)
+
 ### Fixed
 ### Removed
 

--- a/src/Telegram.Bot/TelegramBotClient.cs
+++ b/src/Telegram.Bot/TelegramBotClient.cs
@@ -34,8 +34,6 @@ namespace Telegram.Bot
 
         private readonly string _token;
 
-        private bool _invalidToken;
-
         private readonly HttpClient _httpClient;
 
         #region Config Properties
@@ -157,9 +155,6 @@ namespace Telegram.Bot
         /// <exception cref="ArgumentException">Thrown if <paramref name="token"/> format is invalid</exception>
         public TelegramBotClient(string token, HttpClient httpClient = null)
         {
-            if (!Regex.IsMatch(token, @"^\d*:[\w\d-_]{35}$"))
-                throw new ArgumentException("Invalid token format", nameof(token));
-
             _token = token;
             _baseRequestUrl = $"{BaseUrl}{_token}/";
             _httpClient = httpClient ?? new HttpClient();
@@ -173,9 +168,6 @@ namespace Telegram.Bot
         /// <exception cref="ArgumentException">Thrown if <paramref name="token"/> format is invalid</exception>
         public TelegramBotClient(string token, IWebProxy webProxy)
         {
-            if (!Regex.IsMatch(token, @"^\d*:[\w\d-_]{35}$"))
-                throw new ArgumentException("Invalid token format", nameof(token));
-
             var httpClientHander = new HttpClientHandler
             {
                 Proxy = webProxy,
@@ -194,9 +186,6 @@ namespace Telegram.Bot
             IRequest<TResponse> request,
             CancellationToken cancellationToken = default)
         {
-            if (_invalidToken)
-                throw new ApiRequestException("Invalid token", 401);
-
             string url = _baseRequestUrl + request.MethodName;
 
             var httpRequest = new HttpRequestMessage(request.Method, url)
@@ -241,8 +230,6 @@ namespace Telegram.Bot
                 case HttpStatusCode.OK:
                     break;
                 case HttpStatusCode.Unauthorized:
-                    _invalidToken = true;
-                    throw new ApiRequestException("Invalid token", 401);
                 case HttpStatusCode.BadRequest when !string.IsNullOrWhiteSpace(responseJson):
                 case HttpStatusCode.Forbidden when !string.IsNullOrWhiteSpace(responseJson):
                 case HttpStatusCode.Conflict when !string.IsNullOrWhiteSpace(responseJson):
@@ -278,7 +265,8 @@ namespace Telegram.Bot
                 await GetMeAsync(cancellationToken).ConfigureAwait(false);
                 return true;
             }
-            catch (HttpRequestException e) when (e.Message.EndsWith("404 (Not Found)."))
+            catch (ApiRequestException e)
+                when (e.ErrorCode == 401)
             {
                 return false;
             }
@@ -293,9 +281,6 @@ namespace Telegram.Bot
         public void StartReceiving(UpdateType[] allowedUpdates = null,
             CancellationToken cancellationToken = default)
         {
-            if (_invalidToken)
-                throw new ApiRequestException("Invalid token", 401);
-
             _receivingCancellationTokenSource = new CancellationTokenSource();
 
             cancellationToken.Register(() => _receivingCancellationTokenSource.Cancel());

--- a/test/Telegram.Bot.Tests.Integ/Getting Updates/GettingUpdatesTests.cs
+++ b/test/Telegram.Bot.Tests.Integ/Getting Updates/GettingUpdatesTests.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Net.Http;
 using System.Threading.Tasks;
 using Telegram.Bot.Tests.Integ.Framework;
 using Telegram.Bot.Types;
@@ -30,13 +31,28 @@ namespace Telegram.Bot.Tests.Integ.Getting_Updates
             Assert.True(result);
         }
 
-        [OrderedFact(DisplayName = FactTitles.ShouldFailApiTokenTest)]
+        [OrderedFact(DisplayName = FactTitles.ShouldThrowHttpRequestException)]
         [Trait(Constants.MethodTraitName, Constants.TelegramBotApiMethods.GetMe)]
         public async Task Should_Fail_Test_Api_Token()
         {
-            await _fixture.SendTestCaseNotificationAsync(FactTitles.ShouldFailApiTokenTest);
+            await _fixture.SendTestCaseNotificationAsync(FactTitles.ShouldThrowHttpRequestException);
 
             ITelegramBotClient botClient = new TelegramBotClient("0:1this_is_an-invalid-token_for_tests");
+
+            HttpRequestException exception = await Assert.ThrowsAnyAsync<HttpRequestException>(() =>
+                botClient.TestApiAsync()
+            );
+
+            Assert.Equal("Response status code does not indicate success: 404 (Not Found).", exception.Message);
+        }
+
+        [OrderedFact(DisplayName = FactTitles.ShouldTestBadApiToken)]
+        [Trait(Constants.MethodTraitName, Constants.TelegramBotApiMethods.GetMe)]
+        public async Task Should_Test_Bad_BotToken()
+        {
+            await _fixture.SendTestCaseNotificationAsync(FactTitles.ShouldTestBadApiToken);
+
+            ITelegramBotClient botClient = new TelegramBotClient("123456:ABC-DEF1234ghIkl-zyx57W2v1u123ew11");
             bool result = await botClient.TestApiAsync();
 
             Assert.False(result);
@@ -58,7 +74,11 @@ namespace Telegram.Bot.Tests.Integ.Getting_Updates
         {
             public const string ShouldPassApiTokenTest = "Should pass API Token test with valid token";
 
-            public const string ShouldFailApiTokenTest = "Should pass API Token test with invalid token";
+            public const string ShouldThrowHttpRequestException =
+                "Should throw HttpRequestException with \"404 (Not Found)\" error when malformed API Token is provided";
+
+            public const string ShouldTestBadApiToken =
+                "Should fail API Token test with invalid token";
 
             public const string ShouldGetBotUser = "Should get bot user info";
         }


### PR DESCRIPTION
- `TestApiAsync` return `false` when `ApiRequestException.ErrorCode == 401` (API Token is modified or recalled)
- `TelegramBotClient` ctor does not check API token format: Telegram Bot API does not provide token format specification
- `MakeRequestAsync` throw `ApiRequestException` with `ErrorCode = HttpStatusCode.Unauthorized`  and `Message = apiResponse.Description` ("Unauthorized"), to keep consistent with Telegram Bot API
- fixed `TestApiAsync` tests

#622 