### PR TITLE
Fix message entity type serialization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,16 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+[Unreleased]
+
+### Added
+
+- New enum member `MessageEntityType.Unknown`
+
+### Fixed
+
+- Exception during deserialization of unknown message entity type  
+
 ## [14.4.0] - 2018-05-17
 
 ### Changed

--- a/src/Telegram.Bot/Converters/MessageEntityTypeConverter.cs
+++ b/src/Telegram.Bot/Converters/MessageEntityTypeConverter.cs
@@ -1,0 +1,25 @@
+﻿using System;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
+using Telegram.Bot.Types.Enums;
+
+namespace Telegram.Bot.Converters
+{
+    internal class MessageEntityTypeConverter : JsonConverter
+    {
+        public override void WriteJson(JsonWriter writer, object value, JsonSerializer serializer)
+        {
+            var messageEntityType = (MessageEntityType)value;
+            var convertedEntityType = messageEntityType.ToStringValue();
+            writer.WriteValue(convertedEntityType);
+        }
+
+        public override object ReadJson(JsonReader reader, Type objectType, object existingValue, JsonSerializer serializer)
+        {
+            string value = JToken.ReadFrom(reader).Value<string>();
+            return value.ToMessageType();
+        }
+
+        public override bool CanConvert(Type objectType) => typeof(MessageEntityType) == objectType;
+    }
+}

--- a/src/Telegram.Bot/Types/Enums/MessageEntityType.cs
+++ b/src/Telegram.Bot/Types/Enums/MessageEntityType.cs
@@ -1,13 +1,14 @@
-﻿using Newtonsoft.Json;
-using Newtonsoft.Json.Converters;
-using System.Runtime.Serialization;
+﻿using System;
+using System.Collections.Generic;
+using Newtonsoft.Json;
+using Telegram.Bot.Converters;
 
 namespace Telegram.Bot.Types.Enums
 {
     /// <summary>
     /// Type of a <see cref="MessageEntity"/>
     /// </summary>
-    [JsonConverter(typeof(StringEnumConverter), true)]
+    [JsonConverter(typeof(MessageEntityTypeConverter))]
     public enum MessageEntityType
     {
         /// <summary>
@@ -23,7 +24,6 @@ namespace Telegram.Bot.Types.Enums
         /// <summary>
         /// A Bot command
         /// </summary>
-        [EnumMember(Value = "bot_command")]
         BotCommand,
 
         /// <summary>
@@ -59,13 +59,69 @@ namespace Telegram.Bot.Types.Enums
         /// <summary>
         /// Clickable text urls
         /// </summary>
-        [EnumMember(Value = "text_link")]
         TextLink,
 
         /// <summary>
         /// Mentions for a <see cref="User"/> without <see cref="User.Username"/>
         /// </summary>
-        [EnumMember(Value = "text_mention")]
         TextMention,
+
+        /// <summary>
+        /// Phone number
+        /// </summary>
+        PhoneNumber,
+
+        /// <summary>
+        /// Unknown entity type
+        /// </summary>
+        Unknown
+    }
+
+    internal static class MessageEntityTypeExtensions
+    {
+        private static readonly IDictionary<string, MessageEntityType> StringToEnum =
+            new Dictionary<string, MessageEntityType>
+            {
+                { "mention", MessageEntityType.Mention },
+                { "hashtag", MessageEntityType.Hashtag },
+                { "bot_command", MessageEntityType.BotCommand },
+                { "url", MessageEntityType.Url },
+                { "email", MessageEntityType.Email },
+                { "bold", MessageEntityType.Bold },
+                { "italic", MessageEntityType.Italic },
+                { "code", MessageEntityType.Code },
+                { "pre", MessageEntityType.Pre },
+                { "text_link", MessageEntityType.TextLink },
+                { "text_mention", MessageEntityType.TextMention },
+                { "phone_number", MessageEntityType.PhoneNumber },
+            };
+
+        private static readonly IDictionary<MessageEntityType, string> EnumToString =
+            new Dictionary<MessageEntityType, string>
+            {
+                { MessageEntityType.Mention, "mention" },
+                { MessageEntityType.Hashtag, "hashtag" },
+                { MessageEntityType.BotCommand, "bot_command" },
+                { MessageEntityType.Url, "url" },
+                { MessageEntityType.Email, "email" },
+                { MessageEntityType.Bold, "bold" },
+                { MessageEntityType.Italic, "italic" },
+                { MessageEntityType.Code, "code" },
+                { MessageEntityType.Pre, "pre" },
+                { MessageEntityType.TextLink, "text_link" },
+                { MessageEntityType.TextMention, "text_mention" },
+                { MessageEntityType.PhoneNumber, "phone_number" },
+                { MessageEntityType.Unknown, "unknown" },
+            };
+
+        internal static MessageEntityType ToMessageType(this string value) =>
+            StringToEnum.TryGetValue(value, out var messageEntityType)
+                ? messageEntityType
+                : MessageEntityType.Unknown;
+
+        internal static string ToStringValue(this MessageEntityType value) =>
+            EnumToString.TryGetValue(value, out var messageEntityType)
+                ? messageEntityType
+                : throw new NotSupportedException();
     }
 }

--- a/test/Telegram.Bot.Tests.Integ/Framework/Extensions.cs
+++ b/test/Telegram.Bot.Tests.Integ/Framework/Extensions.cs
@@ -31,7 +31,7 @@ namespace Telegram.Bot.Tests.Integ.Framework
         public static string GetTesterMentions(this UpdateReceiver updateReceiver)
         {
             return string.Join(", ",
-                updateReceiver.AllowedUsernames.Select(username => '@' + username)
+                updateReceiver.AllowedUsernames.Select(username => $"@{username}".Replace("_", "\\_"))
             );
         }
     }

--- a/test/Telegram.Bot.Tests.Unit/Serialization/MessageEntityTests.cs
+++ b/test/Telegram.Bot.Tests.Unit/Serialization/MessageEntityTests.cs
@@ -1,0 +1,73 @@
+﻿using System;
+using Newtonsoft.Json;
+using Telegram.Bot.Types;
+using Telegram.Bot.Types.Enums;
+using Xunit;
+
+namespace Telegram.Bot.Tests.Unit.Serialization
+{
+    public class MessageEntityTests
+    {
+        [Fact(DisplayName = "Should deserialize message entity with phone number type")]
+        public void Should_Deserialize_Message_Entity_With_Phone_Number_Type()
+        {
+            const string json = @"{
+                ""offset"": 10,
+                ""length"": 10,
+                ""type"": ""phone_number""
+            }";
+
+            var message = JsonConvert.DeserializeObject<MessageEntity>(json);
+
+            Assert.Equal(MessageEntityType.PhoneNumber, message.Type);
+        }
+
+        [Fact(DisplayName = "Should serialize message entity with phone number type")]
+        public void Should_Serialize_Message_Entity_With_Phone_Number_Type()
+        {
+            var messageEntity = new MessageEntity
+            {
+                Length = 10,
+                Offset = 10,
+                Type = MessageEntityType.PhoneNumber
+            };
+
+            var json = JsonConvert.SerializeObject(messageEntity);
+
+            Assert.NotNull(json);
+            Assert.True(json.Length > 10);
+            Assert.Contains(@"""type"":""phone_number""", json);
+        }
+
+        [Fact(DisplayName = "Should deserialize message entity with unknown type")]
+        public void Should_Deserialize_Message_Entity_With_Unknown_Type()
+        {
+            const string json = @"{
+                ""offset"": 10,
+                ""length"": 10,
+                ""type"": ""totally_unknown_type""
+            }";
+
+            var message = JsonConvert.DeserializeObject<MessageEntity>(json);
+
+            Assert.Equal(MessageEntityType.Unknown, message.Type);
+        }
+
+        [Fact(DisplayName = "Should serialize message entity with unknown type")]
+        public void Should_Serialize_Message_Entity_With_Unknown_Type()
+        {
+            var messageEntity = new MessageEntity
+            {
+                Length = 10,
+                Offset = 10,
+                Type = MessageEntityType.Unknown
+            };
+
+            var json = JsonConvert.SerializeObject(messageEntity);
+
+            Assert.NotNull(json);
+            Assert.True(json.Length > 10);
+            Assert.Contains(@"""type"":""unknown""", json);
+        }
+    }
+}


### PR DESCRIPTION
This PR adds two new message entity type members: `PhoneNumber` and `Unknown`.
It also adds custom json converter for `MessageEntityType`. This ensures that deserialization of `MessageEntityType` is forward compatible and won't cause exception during deserialization.