### PR TITLE
Fix tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,14 +2,14 @@ language: csharp
 dist: trusty
 sudo: false
 mono: none
-dotnet: 2.0.0
+dotnet: 2.1.300
 branches:
   except:
   - master
 script: >
   cd "test/Telegram.Bot.Tests.Integ" &&
   dotnet test --configuration Release --list-tests &&
-  dotnet xunit -configuration Release -nobuild -stoponfail -verbose $([ "$TRAVIS_BRANCH" != 'develop' ] && echo '-notrait "Category=Interactive"')
+  dotnet xunit -configuration Release -nobuild -stoponfail -verbose
 notifications:
   email: false
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,7 @@ branches:
 script: >
   cd "test/Telegram.Bot.Tests.Integ" &&
   dotnet test --configuration Release --list-tests &&
-  dotnet xunit -configuration Release -nobuild -stoponfail -verbose
+  dotnet xunit -configuration Release -nobuild -stoponfail -verbose  $([ "$TRAVIS_BRANCH" != 'develop' ] && echo '-notrait "Category=Interactive"')
 notifications:
   email: false
 

--- a/Telegram.Bot.sln
+++ b/Telegram.Bot.sln
@@ -15,7 +15,9 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Telegram.Bot.Tests.Unit", "
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{C45387C6-C93F-4FD2-84A8-A69CCE93B7EE}"
 	ProjectSection(SolutionItems) = preProject
+		.appveyor.yml = .appveyor.yml
 		.editorconfig = .editorconfig
+		.travis.yml = .travis.yml
 		CHANGELOG.md = CHANGELOG.md
 		CONTRIBUTING.md = CONTRIBUTING.md
 		README.md = README.md

--- a/test/Telegram.Bot.Tests.Integ/Admin Bot/ChatMemberAdministrationTests.cs
+++ b/test/Telegram.Bot.Tests.Integ/Admin Bot/ChatMemberAdministrationTests.cs
@@ -62,6 +62,7 @@ namespace Telegram.Bot.Tests.Integ.Admin_Bot
             Assert.StartsWith("https://t.me/joinchat/", result);
 
             _classFixture.GroupInviteLink = result;
+            _fixture.SupergroupChat.InviteLink = result;
         }
 
         [OrderedFact(DisplayName = FactTitles.ShouldReceiveNewChatMemberNotification)]

--- a/test/Telegram.Bot.Tests.Integ/Games/GamesTests.cs
+++ b/test/Telegram.Bot.Tests.Integ/Games/GamesTests.cs
@@ -80,7 +80,7 @@ namespace Telegram.Bot.Tests.Integ.Games
         public async Task Should_Set_Game_Score_Inline_Message()
         {
             int playerId = _classFixture.Player.Id;
-            int oldScore = _classFixture.HighScores.Single(highScore => highScore.User.Id == playerId).Score;
+            int oldScore = _classFixture.HighScores.First(highScore => highScore.User.Id == playerId).Score;
             int newScore = oldScore + 1 + new Random().Next(3);
 
             await _fixture.SendTestCaseNotificationAsync(FactTitles.ShouldSetGameScoreInline,

--- a/test/Telegram.Bot.Tests.Integ/Location/InlineMessageLiveLocationTests .cs
+++ b/test/Telegram.Bot.Tests.Integ/Location/InlineMessageLiveLocationTests .cs
@@ -2,6 +2,7 @@ using System;
 using System.Threading.Tasks;
 using Telegram.Bot.Tests.Integ.Framework;
 using Telegram.Bot.Types;
+using Telegram.Bot.Types.Enums;
 using Telegram.Bot.Types.InlineQueryResults;
 using Telegram.Bot.Types.ReplyMarkups;
 using Xunit;
@@ -35,29 +36,38 @@ namespace Telegram.Bot.Tests.Integ.Locations
 
             Update iqUpdate = await _fixture.UpdateReceiver.GetInlineQueryUpdateAsync();
 
+            const string resultId = "live-location";
             string callbackQueryData = "edit-location" + new Random().Next(1_000);
-            Location newYork = new Location {Latitude = 40.7128f, Longitude = -74.0060f};
+            Location newYork = new Location { Latitude = 40.7128f, Longitude = -74.0060f };
+            InlineQueryResultBase[] results =
+           {
+                new InlineQueryResultLocation(
+                         id: resultId,
+                         latitude: newYork.Latitude,
+                         longitude: newYork.Longitude,
+                         title: "Live Locations Test")
+                     {
+                         LivePeriod = 60,
+                         ReplyMarkup = InlineKeyboardButton.WithCallbackData(
+                             "Start live locations", callbackQueryData
+                         )
+                     }
+             };
 
             await BotClient.AnswerInlineQueryAsync(
                 inlineQueryId: iqUpdate.InlineQuery.Id,
+                results: results,
                 cacheTime: 0,
-                results: new[]
-                {
-                    new InlineQueryResultLocation(
-                        id: "live-location",
-                        latitude: newYork.Latitude,
-                        longitude: newYork.Longitude,
-                        title: "Live Locations Test")
-                    {
-                        LivePeriod = 60,
-                        ReplyMarkup = InlineKeyboardButton.WithCallbackData(
-                            "Start live locations", callbackQueryData
-                        )
-                    }
-                }
-            );
+                isPersonal: true);
 
             _classFixture.CallbackQueryData = callbackQueryData;
+
+            (Update messageUpdate, Update chosenResultUpdate) = await _fixture.UpdateReceiver.GetInlineQueryResultUpdates(MessageType.Location);
+            ChosenInlineResult chosenResult = chosenResultUpdate.ChosenInlineResult;
+
+            Assert.Equal(MessageType.Location, messageUpdate.Message.Type);
+            Assert.Equal(resultId, chosenResult.ResultId);
+            Assert.Equal(iqUpdate.InlineQuery.Query, chosenResultUpdate.ChosenInlineResult.Query);
         }
 
         [OrderedFact(DisplayName = FactTitles.ShouldEditInlineMessageLiveLocation)]
@@ -70,7 +80,7 @@ namespace Telegram.Bot.Tests.Integ.Locations
             Update cqUpdate = await _fixture.UpdateReceiver
                 .GetCallbackQueryUpdateAsync(data: _classFixture.CallbackQueryData);
 
-            Location beijing = new Location {Latitude = 39.9042f, Longitude = 116.4074f};
+            Location beijing = new Location { Latitude = 39.9042f, Longitude = 116.4074f };
 
             await BotClient.EditMessageLiveLocationAsync(
                 inlineMessageId: cqUpdate.CallbackQuery.InlineMessageId,

--- a/test/Telegram.Bot.Tests.Integ/Telegram.Bot.Tests.Integ.csproj
+++ b/test/Telegram.Bot.Tests.Integ/Telegram.Bot.Tests.Integ.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.0</TargetFramework>
+    <TargetFrameworks>netcoreapp2.0;netcoreapp2.1</TargetFrameworks>
     <LangVersion>latest</LangVersion>
     <IsPackable>false</IsPackable>
   </PropertyGroup>

--- a/test/Telegram.Bot.Tests.Unit/Telegram.Bot.Tests.Unit.csproj
+++ b/test/Telegram.Bot.Tests.Unit/Telegram.Bot.Tests.Unit.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.0</TargetFramework>
+    <TargetFrameworks>netcoreapp2.0;netcoreapp2.1</TargetFrameworks>
     <LangVersion>latest</LangVersion>
     <IsPackable>false</IsPackable>
   </PropertyGroup>


### PR DESCRIPTION
- `GamesTests` - get `.First(...)` player score instead of `.Single(..)`
- `InlineMessageLiveLocationTests` - wait for the reply in `Should_Answer_Inline_Query_With_Location`
- replace `SupergroupChat.InviteLink` with modified link after `ExportChatInviteLinkAsync` call

- change travis config for .Net Core 2.1