### PR TITLE
Fix tests

### DIFF
--- a/test/Telegram.Bot.Tests.Integ/Admin Bot/ChatMemberAdministrationTests.cs
+++ b/test/Telegram.Bot.Tests.Integ/Admin Bot/ChatMemberAdministrationTests.cs
@@ -62,6 +62,7 @@ namespace Telegram.Bot.Tests.Integ.Admin_Bot
             Assert.StartsWith("https://t.me/joinchat/", result);
 
             _classFixture.GroupInviteLink = result;
+            _fixture.SupergroupChat.InviteLink = result;
         }
 
         [OrderedFact(DisplayName = FactTitles.ShouldReceiveNewChatMemberNotification)]

--- a/test/Telegram.Bot.Tests.Integ/Games/GamesTests.cs
+++ b/test/Telegram.Bot.Tests.Integ/Games/GamesTests.cs
@@ -80,7 +80,7 @@ namespace Telegram.Bot.Tests.Integ.Games
         public async Task Should_Set_Game_Score_Inline_Message()
         {
             int playerId = _classFixture.Player.Id;
-            int oldScore = _classFixture.HighScores.Single(highScore => highScore.User.Id == playerId).Score;
+            int oldScore = _classFixture.HighScores.First(highScore => highScore.User.Id == playerId).Score;
             int newScore = oldScore + 1 + new Random().Next(3);
 
             await _fixture.SendTestCaseNotificationAsync(FactTitles.ShouldSetGameScoreInline,


### PR DESCRIPTION
- `GamesTests` - get `.First(...)` player score instead of `.Single(..)`
- `InlineMessageLiveLocationTests` - wait for the reply in `Should_Answer_Inline_Query_With_Location`
- replace `SupergroupChat.InviteLink` with modified link after `ExportChatInviteLinkAsync` call