### PR TITLE
Add ParseMode support to EditMessageCaptionAsync

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+### Added
+
+- Property `ParseMode` to requests with a caption
+  - `EditMessageCaptionRequest`
+  - `EditInlineMessageCaptionRequest`
+- Parameter `parseMode` to method `ITelegramBotClient.EditMessageCaptionAsync`
+
 ## [14.5.0] - 2018-06-06
 
 ### Added

--- a/src/Telegram.Bot/ITelegramBotClient.cs
+++ b/src/Telegram.Bot/ITelegramBotClient.cs
@@ -854,6 +854,7 @@ namespace Telegram.Bot
         /// <param name="chatId"><see cref="ChatId"/> for the target chat</param>
         /// <param name="messageId">Unique identifier of the sent message</param>
         /// <param name="caption">New caption of the message</param>
+        /// <param name="parseMode">Send Markdown or HTML, if you want Telegram apps to show bold, italic, fixed-width text or inline URLs in the media caption.</param>
         /// <param name="replyMarkup">A JSON-serialized object for an inline keyboard.</param>
         /// <param name="cancellationToken">A cancellation token that can be used by other objects or threads to receive notice of cancellation.</param>
         /// <returns>On success, the edited Description is returned.</returns>
@@ -862,6 +863,7 @@ namespace Telegram.Bot
             ChatId chatId,
             int messageId,
             string caption,
+            ParseMode parseMode = default,
             InlineKeyboardMarkup replyMarkup = default,
             CancellationToken cancellationToken = default);
 
@@ -870,6 +872,7 @@ namespace Telegram.Bot
         /// </summary>
         /// <param name="inlineMessageId">Unique identifier of the sent message</param>
         /// <param name="caption">New caption of the message</param>
+        /// <param name="parseMode">Send Markdown or HTML, if you want Telegram apps to show bold, italic, fixed-width text or inline URLs in the media caption.</param>
         /// <param name="replyMarkup">A JSON-serialized object for an inline keyboard.</param>
         /// <param name="cancellationToken">A cancellation token that can be used by other objects or threads to receive notice of cancellation.</param>
         /// <returns><c>true</c> on success.</returns>
@@ -877,6 +880,7 @@ namespace Telegram.Bot
         Task EditMessageCaptionAsync(
             string inlineMessageId,
             string caption,
+            ParseMode parseMode = default,
             InlineKeyboardMarkup replyMarkup = default,
             CancellationToken cancellationToken = default);
 

--- a/src/Telegram.Bot/ITelegramBotClient.cs
+++ b/src/Telegram.Bot/ITelegramBotClient.cs
@@ -863,9 +863,9 @@ namespace Telegram.Bot
             ChatId chatId,
             int messageId,
             string caption,
-            ParseMode parseMode = default,
             InlineKeyboardMarkup replyMarkup = default,
-            CancellationToken cancellationToken = default);
+            CancellationToken cancellationToken = default,
+            ParseMode parseMode = default);
 
         /// <summary>
         /// Use this method to edit captions of messages sent by the bot or via the bot (for inline bots).
@@ -880,9 +880,9 @@ namespace Telegram.Bot
         Task EditMessageCaptionAsync(
             string inlineMessageId,
             string caption,
-            ParseMode parseMode = default,
             InlineKeyboardMarkup replyMarkup = default,
-            CancellationToken cancellationToken = default);
+            CancellationToken cancellationToken = default,
+            ParseMode parseMode = default);
 
         /// <summary>
         /// Use this method to edit only the reply markup of messages sent by the bot or via the bot (for inline bots).

--- a/src/Telegram.Bot/Requests/Update Messages/EditInlineMessageCaptionRequest.cs
+++ b/src/Telegram.Bot/Requests/Update Messages/EditInlineMessageCaptionRequest.cs
@@ -1,6 +1,7 @@
-﻿using Newtonsoft.Json;
+using Newtonsoft.Json;
 using Newtonsoft.Json.Serialization;
 using Telegram.Bot.Requests.Abstractions;
+using Telegram.Bot.Types.Enums;
 using Telegram.Bot.Types.ReplyMarkups;
 
 // ReSharper disable once CheckNamespace
@@ -11,6 +12,7 @@ namespace Telegram.Bot.Requests
     /// </summary>
     [JsonObject(MemberSerialization.OptIn, NamingStrategyType = typeof(SnakeCaseNamingStrategy))]
     public class EditInlineMessageCaptionRequest : RequestBase<bool>,
+                                                   IFormattableMessage,
                                                    IInlineMessage,
                                                    IInlineReplyMarkupMessage
     {
@@ -23,6 +25,10 @@ namespace Telegram.Bot.Requests
         /// </summary>
         [JsonProperty(DefaultValueHandling = DefaultValueHandling.Ignore)]
         public string Caption { get; set; }
+
+        /// <inheritdoc />
+        [JsonProperty(DefaultValueHandling = DefaultValueHandling.Ignore)]
+        public ParseMode ParseMode { get; set; }
 
         /// <inheritdoc cref="IInlineReplyMarkupMessage.ReplyMarkup" />
         [JsonProperty(DefaultValueHandling = DefaultValueHandling.Ignore)]

--- a/src/Telegram.Bot/Requests/Update Messages/EditMessageCaptionRequest.cs
+++ b/src/Telegram.Bot/Requests/Update Messages/EditMessageCaptionRequest.cs
@@ -1,7 +1,8 @@
-﻿using Newtonsoft.Json;
+using Newtonsoft.Json;
 using Newtonsoft.Json.Serialization;
 using Telegram.Bot.Requests.Abstractions;
 using Telegram.Bot.Types;
+using Telegram.Bot.Types.Enums;
 using Telegram.Bot.Types.ReplyMarkups;
 
 // ReSharper disable once CheckNamespace
@@ -31,6 +32,10 @@ namespace Telegram.Bot.Requests
         /// </summary>
         [JsonProperty(DefaultValueHandling = DefaultValueHandling.Ignore)]
         public string Caption { get; set; }
+
+        /// <inheritdoc />
+        [JsonProperty(DefaultValueHandling = DefaultValueHandling.Ignore)]
+        public ParseMode ParseMode { get; set; }
 
         /// <inheritdoc cref="IInlineReplyMarkupMessage.ReplyMarkup" />
         [JsonProperty(DefaultValueHandling = DefaultValueHandling.Ignore)]

--- a/src/Telegram.Bot/Telegram.Bot.csproj
+++ b/src/Telegram.Bot/Telegram.Bot.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFrameworks>netstandard1.1;net45</TargetFrameworks>
-    <VersionPrefix>14.5.0</VersionPrefix>
+    <VersionPrefix>14.6.0</VersionPrefix>
     <LangVersion>latest</LangVersion>
     <GeneratePackageOnBuild>True</GeneratePackageOnBuild>
     <GenerateDocumentationFile>True</GenerateDocumentationFile>

--- a/src/Telegram.Bot/TelegramBotClient.cs
+++ b/src/Telegram.Bot/TelegramBotClient.cs
@@ -933,12 +933,14 @@ namespace Telegram.Bot
             ChatId chatId,
             int messageId,
             string caption,
+            ParseMode parseMode = default,
             InlineKeyboardMarkup replyMarkup = default,
             CancellationToken cancellationToken = default
         ) =>
             MakeRequestAsync(new EditMessageCaptionRequest(chatId, messageId)
             {
                 Caption = caption,
+                ParseMode = parseMode,
                 ReplyMarkup = replyMarkup
             }, cancellationToken);
 
@@ -946,12 +948,14 @@ namespace Telegram.Bot
         public Task EditMessageCaptionAsync(
             string inlineMessageId,
             string caption,
+            ParseMode parseMode = default,
             InlineKeyboardMarkup replyMarkup = default,
             CancellationToken cancellationToken = default
         ) =>
             MakeRequestAsync(new EditInlineMessageCaptionRequest(inlineMessageId)
             {
                 Caption = caption,
+                ParseMode = parseMode,
                 ReplyMarkup = replyMarkup
             }, cancellationToken);
 

--- a/src/Telegram.Bot/TelegramBotClient.cs
+++ b/src/Telegram.Bot/TelegramBotClient.cs
@@ -303,10 +303,10 @@ namespace Telegram.Bot
                 try
                 {
                     updates = await GetUpdatesAsync(
-                       MessageOffset,
-                       timeout: timeout,
-                       allowedUpdates: allowedUpdates,
-                       cancellationToken: cancellationToken
+                        MessageOffset,
+                        timeout: timeout,
+                        allowedUpdates: allowedUpdates,
+                        cancellationToken: cancellationToken
                     ).ConfigureAwait(false);
                 }
                 catch (OperationCanceledException)
@@ -350,9 +350,11 @@ namespace Telegram.Bot
                 _receivingCancellationTokenSource.Cancel();
             }
             catch (WebException)
-            { }
+            {
+            }
             catch (TaskCanceledException)
-            { }
+            {
+            }
         }
 
         #endregion Helpers
@@ -714,6 +716,7 @@ namespace Telegram.Bot
             {
                 throw new ArgumentException("Invalid file path", nameof(filePath));
             }
+
             if (destination == null)
             {
                 throw new ArgumentNullException(nameof(destination));
@@ -933,9 +936,9 @@ namespace Telegram.Bot
             ChatId chatId,
             int messageId,
             string caption,
-            ParseMode parseMode = default,
             InlineKeyboardMarkup replyMarkup = default,
-            CancellationToken cancellationToken = default
+            CancellationToken cancellationToken = default,
+            ParseMode parseMode = default
         ) =>
             MakeRequestAsync(new EditMessageCaptionRequest(chatId, messageId)
             {
@@ -948,9 +951,9 @@ namespace Telegram.Bot
         public Task EditMessageCaptionAsync(
             string inlineMessageId,
             string caption,
-            ParseMode parseMode = default,
             InlineKeyboardMarkup replyMarkup = default,
-            CancellationToken cancellationToken = default
+            CancellationToken cancellationToken = default,
+            ParseMode parseMode = default
         ) =>
             MakeRequestAsync(new EditInlineMessageCaptionRequest(inlineMessageId)
             {

--- a/test/Telegram.Bot.Tests.Integ/Update Messages/EditMessageContentTests.cs
+++ b/test/Telegram.Bot.Tests.Integ/Update Messages/EditMessageContentTests.cs
@@ -166,7 +166,8 @@ namespace Telegram.Bot.Tests.Integ.Update_Messages
 
             await BotClient.EditMessageCaptionAsync(
                 inlineMessageId: callbackQUpdate.CallbackQuery.InlineMessageId,
-                caption: "Caption is edited 👌"
+                caption: "_Caption is edited_ 👌",
+                parseMode: ParseMode.Markdown
             );
         }
 

--- a/test/Telegram.Bot.Tests.Integ/Update Messages/EditMessageContentTests2.cs
+++ b/test/Telegram.Bot.Tests.Integ/Update Messages/EditMessageContentTests2.cs
@@ -114,17 +114,22 @@ namespace Telegram.Bot.Tests.Integ.Update_Messages
             DateTime timeBeforeEdition = DateTime.UtcNow;
             await Task.Delay(1_000);
 
-            const string newCaption = "Caption is edited.";
+            const string captionPrefix = "Modified caption";
+            (MessageEntityType Type, string Value) captionEntity = (MessageEntityType.Italic, "_with Markdown_");
+            string caption = $"{captionPrefix} {captionEntity.Value}";
 
             Message editedMessage = await BotClient.EditMessageCaptionAsync(
                 chatId: originalMessage.Chat.Id,
                 messageId: originalMessage.MessageId,
-                caption: newCaption
+                caption: caption,
+                parseMode: ParseMode.Markdown
             );
 
             Assert.Equal(originalMessage.MessageId, editedMessage.MessageId);
-            Assert.Equal(newCaption, editedMessage.Caption);
             Assert.True(timeBeforeEdition < editedMessage.EditDate);
+            Assert.StartsWith(captionPrefix, editedMessage.Caption);
+
+            Assert.Equal(editedMessage.CaptionEntities.Single().Type, captionEntity.Type);
         }
 
         private static class FactTitles


### PR DESCRIPTION
Add
- Property `ParseMode` to requests with a caption
  - `EditMessageCaptionRequest`
  - `EditInlineMessageCaptionRequest`
- Parameter `parseMode` to method `ITelegramBotClient.EditMessageCaptionAsync`

 #722