### PR TITLE
Bot API v4.0: Second set of updates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,24 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+### Added
+
+- Parameter `vCard` to method `SendContactAsync`
+- Parameter `foursquareType` to method `SendVenueAsync`
+- Property `SendContactRequest.Vcard`
+- Property `SendVenueRequest.FoursquareType`
+- Property `InlineQueryResultContact.Vcard`
+- Property `InlineQueryResultVenue.FoursquareType`
+- Property `InputContactMessageContent.Vcard`
+- Property `InputVenueMessageContent.FoursquareType`
+- Property `Contact.Vcard`
+- Property `Venue.FoursquareType`
+- Enum value `MessageEntityType.Cashtag`
+
+### Changed
+
+- Marked `MessageType.Animation` as obsolete.
+
 ## [14.7.0] - 2018-07-29
 
 ### Added

--- a/src/Telegram.Bot/ITelegramBotClient.cs
+++ b/src/Telegram.Bot/ITelegramBotClient.cs
@@ -541,6 +541,7 @@ namespace Telegram.Bot
         /// <param name="phoneNumber">Contact's phone number</param>
         /// <param name="firstName">Contact's first name</param>
         /// <param name="lastName">Contact's last name</param>
+        /// <param name="vCard">Additional data about the contact in the form of a vCard, 0-2048 bytes</param>
         /// <param name="disableNotification">Sends the message silently. iOS users will not receive a notification, Android users will receive a notification with no sound.</param>
         /// <param name="replyToMessageId">If the message is a reply, ID of the original message</param>
         /// <param name="replyMarkup">Additional interface options. A JSON-serialized object for an inline keyboard, custom reply keyboard, instructions to hide keyboard or to force a reply from the user.</param>
@@ -555,7 +556,8 @@ namespace Telegram.Bot
             bool disableNotification = default,
             int replyToMessageId = default,
             IReplyMarkup replyMarkup = default,
-            CancellationToken cancellationToken = default);
+            CancellationToken cancellationToken = default,
+            string vCard = default); // ToDo inconsistent order of parameters
 
         /// <summary>
         /// Use this method when you need to tell the user that something is happening on the bot's side. The status is set for 5 seconds or less (when a message arrives from your bot, Telegram clients clear its typing status).

--- a/src/Telegram.Bot/ITelegramBotClient.cs
+++ b/src/Telegram.Bot/ITelegramBotClient.cs
@@ -516,10 +516,15 @@ namespace Telegram.Bot
         /// <param name="title">Name of the venue</param>
         /// <param name="address">Address of the venue</param>
         /// <param name="foursquareId">Foursquare identifier of the venue</param>
-        /// <param name="disableNotification">Sends the message silently. iOS users will not receive a notification, Android users will receive a notification with no sound.</param>
+        /// <param name="foursquareType">Foursquare type of the venue, if known. (For example,
+        /// "arts_entertainment/default", "arts_entertainment/aquarium" or "food/icecream".) </param>
+        /// <param name="disableNotification">Sends the message silently. iOS users will not receive a notification,
+        /// Android users will receive a notification with no sound.</param>
         /// <param name="replyToMessageId">If the message is a reply, ID of the original message</param>
-        /// <param name="replyMarkup">Additional interface options. A JSON-serialized object for a custom reply keyboard, instructions to hide keyboard or to force a reply from the user.</param>
-        /// <param name="cancellationToken">A cancellation token that can be used by other objects or threads to receive notice of cancellation.</param>
+        /// <param name="replyMarkup">Additional interface options. A JSON-serialized object for a custom reply
+        /// keyboard, instructions to hide keyboard or to force a reply from the user.</param>
+        /// <param name="cancellationToken">A cancellation token that can be used by other objects or threads to receive
+        /// notice of cancellation.</param>
         /// <returns>On success, the sent <see cref="Message"/> is returned.</returns>
         /// <see href="https://core.telegram.org/bots/api#sendvenue"/>
         Task<Message> SendVenueAsync(
@@ -532,7 +537,8 @@ namespace Telegram.Bot
             bool disableNotification = default,
             int replyToMessageId = default,
             IReplyMarkup replyMarkup = default,
-            CancellationToken cancellationToken = default);
+            CancellationToken cancellationToken = default,
+            string foursquareType = default); // ToDo inconsistent order of parameters
 
         /// <summary>
         /// Use this method to send phone contacts.

--- a/src/Telegram.Bot/Requests/Available Methods/Sending Messages/SendContactRequest.cs
+++ b/src/Telegram.Bot/Requests/Available Methods/Sending Messages/SendContactRequest.cs
@@ -1,4 +1,4 @@
-﻿using Newtonsoft.Json;
+using Newtonsoft.Json;
 using Newtonsoft.Json.Serialization;
 using Telegram.Bot.Requests.Abstractions;
 using Telegram.Bot.Types;
@@ -39,6 +39,12 @@ namespace Telegram.Bot.Requests
         /// </summary>
         [JsonProperty(DefaultValueHandling = DefaultValueHandling.Ignore)]
         public string LastName { get; set; }
+        
+        /// <summary>
+        /// Optional. Additional data about the contact in the form of a vCard, 0-2048 bytes
+        /// </summary>
+        [JsonProperty(DefaultValueHandling = DefaultValueHandling.Ignore)]
+        public string Vcard { get; set; }
 
         /// <inheritdoc />
         [JsonProperty(DefaultValueHandling = DefaultValueHandling.Ignore)]

--- a/src/Telegram.Bot/Requests/Available Methods/Sending Messages/SendVenueRequest.cs
+++ b/src/Telegram.Bot/Requests/Available Methods/Sending Messages/SendVenueRequest.cs
@@ -52,6 +52,13 @@ namespace Telegram.Bot.Requests
         [JsonProperty(DefaultValueHandling = DefaultValueHandling.Ignore)]
         public string FoursquareId { get; set; }
 
+        /// <summary>
+        /// Optional. Foursquare type of the venue. (For example, "arts_entertainment/default",
+        /// "arts_entertainment/aquarium" or "food/icecream".)
+        /// </summary>
+        [JsonProperty(DefaultValueHandling = DefaultValueHandling.Ignore)]
+        public string FoursquareType { get; set; }
+
         /// <inheritdoc />
         [JsonProperty(DefaultValueHandling = DefaultValueHandling.Ignore)]
         public bool DisableNotification { get; set; }

--- a/src/Telegram.Bot/Requests/Update Messages/EditInlineMessageCaptionRequest.cs
+++ b/src/Telegram.Bot/Requests/Update Messages/EditInlineMessageCaptionRequest.cs
@@ -37,7 +37,7 @@ namespace Telegram.Bot.Requests
         /// <summary>
         /// Initializes a new request with inlineMessageId and new caption
         /// </summary>
-        /// <param name="inlineMessageId">InlineMessageId</param>
+        /// <param name="inlineMessageId">Identifier of the inline message</param>
         /// <param name="caption">New caption of the message</param>
         public EditInlineMessageCaptionRequest(string inlineMessageId, string caption = default)
             : base("editMessageCaption")

--- a/src/Telegram.Bot/Requests/Update Messages/EditInlineMessageTextRequest.cs
+++ b/src/Telegram.Bot/Requests/Update Messages/EditInlineMessageTextRequest.cs
@@ -1,4 +1,4 @@
-﻿using Newtonsoft.Json;
+using Newtonsoft.Json;
 using Newtonsoft.Json.Serialization;
 using Telegram.Bot.Requests.Abstractions;
 using Telegram.Bot.Types.Enums;
@@ -43,7 +43,7 @@ namespace Telegram.Bot.Requests
         /// <summary>
         /// Initializes a new request with inlineMessageId and new text
         /// </summary>
-        /// <param name="inlineMessageId"></param>
+        /// <param name="inlineMessageId">Identifier of the inline message</param>
         /// <param name="text">New text of the message</param>
         public EditInlineMessageTextRequest(string inlineMessageId, string text)
             : base("editMessageText")

--- a/src/Telegram.Bot/Requests/Update Messages/EditMessageCaptionRequest.cs
+++ b/src/Telegram.Bot/Requests/Update Messages/EditMessageCaptionRequest.cs
@@ -13,7 +13,8 @@ namespace Telegram.Bot.Requests
     /// </summary>
     [JsonObject(MemberSerialization.OptIn, NamingStrategyType = typeof(SnakeCaseNamingStrategy))]
     public class EditMessageCaptionRequest : RequestBase<Message>,
-                                             IInlineReplyMarkupMessage
+                                             IInlineReplyMarkupMessage,
+                                             IFormattableMessage
     {
         /// <summary>
         /// Unique identifier for the target chat or username of the target channel (in the format @channelusername)

--- a/src/Telegram.Bot/Telegram.Bot.csproj
+++ b/src/Telegram.Bot/Telegram.Bot.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFrameworks>netstandard1.1;net45</TargetFrameworks>
-    <VersionPrefix>14.7.0</VersionPrefix>
+    <VersionPrefix>14.8.0</VersionPrefix>
     <LangVersion>latest</LangVersion>
     <GeneratePackageOnBuild>True</GeneratePackageOnBuild>
     <GenerateDocumentationFile>True</GenerateDocumentationFile>

--- a/src/Telegram.Bot/TelegramBotClient.cs
+++ b/src/Telegram.Bot/TelegramBotClient.cs
@@ -962,9 +962,8 @@ namespace Telegram.Bot
             CancellationToken cancellationToken = default,
             ParseMode parseMode = default
         ) =>
-            MakeRequestAsync(new EditMessageCaptionRequest(chatId, messageId)
+            MakeRequestAsync(new EditMessageCaptionRequest(chatId, messageId, caption)
             {
-                Caption = caption,
                 ParseMode = parseMode,
                 ReplyMarkup = replyMarkup
             }, cancellationToken);
@@ -977,9 +976,8 @@ namespace Telegram.Bot
             CancellationToken cancellationToken = default,
             ParseMode parseMode = default
         ) =>
-            MakeRequestAsync(new EditInlineMessageCaptionRequest(inlineMessageId)
+            MakeRequestAsync(new EditInlineMessageCaptionRequest(inlineMessageId, caption)
             {
-                Caption = caption,
                 ParseMode = parseMode,
                 ReplyMarkup = replyMarkup
             }, cancellationToken);

--- a/src/Telegram.Bot/TelegramBotClient.cs
+++ b/src/Telegram.Bot/TelegramBotClient.cs
@@ -658,11 +658,13 @@ namespace Telegram.Bot
             bool disableNotification = default,
             int replyToMessageId = default,
             IReplyMarkup replyMarkup = default,
-            CancellationToken cancellationToken = default
+            CancellationToken cancellationToken = default,
+            string foursquareType = default
         ) =>
             MakeRequestAsync(new SendVenueRequest(chatId, latitude, longitude, title, address)
             {
                 FoursquareId = foursquareId,
+                FoursquareType = foursquareType,
                 DisableNotification = disableNotification,
                 ReplyToMessageId = replyToMessageId,
                 ReplyMarkup = replyMarkup

--- a/src/Telegram.Bot/TelegramBotClient.cs
+++ b/src/Telegram.Bot/TelegramBotClient.cs
@@ -677,11 +677,13 @@ namespace Telegram.Bot
             bool disableNotification = default,
             int replyToMessageId = default,
             IReplyMarkup replyMarkup = default,
-            CancellationToken cancellationToken = default
+            CancellationToken cancellationToken = default,
+            string vCard = default
         ) =>
             MakeRequestAsync(new SendContactRequest(chatId, phoneNumber, firstName)
             {
                 LastName = lastName,
+                Vcard = vCard,
                 DisableNotification = disableNotification,
                 ReplyToMessageId = replyToMessageId,
                 ReplyMarkup = replyMarkup

--- a/src/Telegram.Bot/Types/Contact.cs
+++ b/src/Telegram.Bot/Types/Contact.cs
@@ -1,4 +1,4 @@
-﻿using Newtonsoft.Json;
+using Newtonsoft.Json;
 using Newtonsoft.Json.Serialization;
 
 namespace Telegram.Bot.Types
@@ -32,5 +32,11 @@ namespace Telegram.Bot.Types
         /// </summary>
         [JsonProperty(DefaultValueHandling = DefaultValueHandling.Ignore)]
         public int UserId { get; set; }
+
+        /// <summary>
+        /// Optional. Additional data about the contact in the form of a vCard
+        /// </summary>
+        [JsonProperty(DefaultValueHandling = DefaultValueHandling.Ignore)]
+        public string Vcard { get; set; }
     }
 }

--- a/src/Telegram.Bot/Types/Enums/MessageEntityType.cs
+++ b/src/Telegram.Bot/Types/Enums/MessageEntityType.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using Newtonsoft.Json;
 using Telegram.Bot.Converters;
@@ -72,6 +72,11 @@ namespace Telegram.Bot.Types.Enums
         PhoneNumber,
 
         /// <summary>
+        /// A cashtag (e.g. $EUR, $USD) - $ followed by the short currency code
+        /// </summary>
+        Cashtag,
+
+        /// <summary>
         /// Unknown entity type
         /// </summary>
         Unknown
@@ -94,6 +99,7 @@ namespace Telegram.Bot.Types.Enums
                 { "text_link", MessageEntityType.TextLink },
                 { "text_mention", MessageEntityType.TextMention },
                 { "phone_number", MessageEntityType.PhoneNumber },
+                { "cashtag", MessageEntityType.Cashtag },
             };
 
         private static readonly IDictionary<MessageEntityType, string> EnumToString =
@@ -111,6 +117,7 @@ namespace Telegram.Bot.Types.Enums
                 { MessageEntityType.TextLink, "text_link" },
                 { MessageEntityType.TextMention, "text_mention" },
                 { MessageEntityType.PhoneNumber, "phone_number" },
+                { MessageEntityType.Cashtag, "cashtag" },
                 { MessageEntityType.Unknown, "unknown" },
             };
 

--- a/src/Telegram.Bot/Types/Enums/MessageType.cs
+++ b/src/Telegram.Bot/Types/Enums/MessageType.cs
@@ -1,5 +1,6 @@
 using Newtonsoft.Json;
 using Newtonsoft.Json.Converters;
+using System.Runtime.Serialization;
 
 namespace Telegram.Bot.Types.Enums
 {
@@ -72,6 +73,7 @@ namespace Telegram.Bot.Types.Enums
         /// <summary>
         /// The <see cref="Message"/> contains a <see cref="Types.VideoNote"/>
         /// </summary>
+        [EnumMember(Value = "video_note")]
         VideoNote,
 
         /// <summary>
@@ -82,66 +84,79 @@ namespace Telegram.Bot.Types.Enums
         /// <summary>
         /// The <see cref="Message"/> contains a <see cref="SuccessfulPayment"/>
         /// </summary>
+        [EnumMember(Value = "successful_payment")]
         SuccessfulPayment,
 
         /// <summary>
         /// The <see cref="Message"/> contains a <see cref="Message.ConnectedWebsite"/>
         /// </summary>
+        [EnumMember(Value = "website_connected")]
         WebsiteConnected,
 
         /// <summary>
         /// The <see cref="Message"/> contains a <see cref="Message.NewChatMembers"/>
         /// </summary>
+        [EnumMember(Value = "chat_members_added")]
         ChatMembersAdded,
 
         /// <summary>
         /// The <see cref="Message"/> contains a <see cref="Message.LeftChatMember"/>
         /// </summary>
+        [EnumMember(Value = "chat_member_left")]
         ChatMemberLeft,
 
         /// <summary>
         /// The <see cref="Message"/> contains a <see cref="Message.NewChatTitle"/>
         /// </summary>
+        [EnumMember(Value = "chat_title_changed")]
         ChatTitleChanged,
 
         /// <summary>
         /// The <see cref="Message"/> contains a <see cref="Message.NewChatPhoto"/>
         /// </summary>
+        [EnumMember(Value = "chat_photo_changed")]
         ChatPhotoChanged,
 
         /// <summary>
         /// The <see cref="Message"/> contains a <see cref="Message.PinnedMessage"/>
         /// </summary>
+        [EnumMember(Value = "message_pinned")]
         MessagePinned,
 
         /// <summary>
         /// The <see cref="Message"/> contains a <see cref="Message.DeleteChatPhoto"/>
         /// </summary>
+        [EnumMember(Value = "chat_photo_deleted")]
         ChatPhotoDeleted,
 
         /// <summary>
         /// The <see cref="Message"/> contains a <see cref="Message.GroupChatCreated"/>
         /// </summary>
+        [EnumMember(Value = "group_created")]
         GroupCreated,
 
         /// <summary>
         /// The <see cref="Message"/> contains a <see cref="Message.SupergroupChatCreated"/>
         /// </summary>
+        [EnumMember(Value = "supergroup_created")]
         SupergroupCreated,
 
         /// <summary>
         /// The <see cref="Message"/> contains a <see cref="Message.ChannelChatCreated"/>
         /// </summary>
+        [EnumMember(Value = "channel_created")]
         ChannelCreated,
 
         /// <summary>
         /// The <see cref="Message"/> contains non-default <see cref="Message.MigrateFromChatId"/>
         /// </summary>
+        [EnumMember(Value = "migrated_to_supergroup")]
         MigratedToSupergroup,
 
         /// <summary>
         /// The <see cref="Message"/> contains non-default <see cref="Message.MigrateToChatId"/>
         /// </summary>
+        [EnumMember(Value = "migrated_from_group")]
         MigratedFromGroup,
 
         /// <summary>

--- a/src/Telegram.Bot/Types/Enums/MessageType.cs
+++ b/src/Telegram.Bot/Types/Enums/MessageType.cs
@@ -1,3 +1,4 @@
+using System;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Converters;
 using System.Runtime.Serialization;
@@ -162,6 +163,7 @@ namespace Telegram.Bot.Types.Enums
         /// <summary>
         /// The <see cref="Message"/> contains non-default <see cref="Message.Animation"/>
         /// </summary>
+        [Obsolete("Check if Message.Animation has value instead")]
         Animation,
     }
 }

--- a/src/Telegram.Bot/Types/InlineQueryResults/InlineQueryResultContact.cs
+++ b/src/Telegram.Bot/Types/InlineQueryResults/InlineQueryResultContact.cs
@@ -33,6 +33,12 @@ namespace Telegram.Bot.Types.InlineQueryResults
         [JsonProperty(DefaultValueHandling = DefaultValueHandling.Ignore)]
         public string LastName { get; set; }
 
+        /// <summary>
+        /// Optional. Additional data about the contact in the form of a vCard, 0-2048 bytes
+        /// </summary>
+        [JsonProperty(DefaultValueHandling = DefaultValueHandling.Ignore)]
+        public string Vcard { get; set; }
+
         /// <inheritdoc />
         [JsonProperty(DefaultValueHandling = DefaultValueHandling.Ignore)]
         public string ThumbUrl { get; set; }

--- a/src/Telegram.Bot/Types/InlineQueryResults/InlineQueryResultVenue.cs
+++ b/src/Telegram.Bot/Types/InlineQueryResults/InlineQueryResultVenue.cs
@@ -41,6 +41,13 @@ namespace Telegram.Bot.Types.InlineQueryResults
         [JsonProperty(DefaultValueHandling = DefaultValueHandling.Ignore)]
         public string FoursquareId { get; set; }
 
+        /// <summary>
+        /// Optional. Foursquare type of the venue. (For example, "arts_entertainment/default",
+        /// "arts_entertainment/aquarium" or "food/icecream".)
+        /// </summary>
+        [JsonProperty(DefaultValueHandling = DefaultValueHandling.Ignore)]
+        public string FoursquareType { get; set; }
+
         /// <inheritdoc />
         [JsonProperty(DefaultValueHandling = DefaultValueHandling.Ignore)]
         public string ThumbUrl { get; set; }

--- a/src/Telegram.Bot/Types/InlineQueryResults/InputContactMessageContent.cs
+++ b/src/Telegram.Bot/Types/InlineQueryResults/InputContactMessageContent.cs
@@ -27,6 +27,12 @@ namespace Telegram.Bot.Types.InlineQueryResults
         [JsonProperty(DefaultValueHandling = DefaultValueHandling.Ignore)]
         public string LastName { get; set; }
 
+        /// <summary>
+        /// Optional. Additional data about the contact in the form of a vCard, 0-2048 bytes
+        /// </summary>
+        [JsonProperty(DefaultValueHandling = DefaultValueHandling.Ignore)]
+        public string Vcard { get; set; }
+
         private InputContactMessageContent()
         { }
 

--- a/src/Telegram.Bot/Types/InlineQueryResults/InputVenueMessageContent.cs
+++ b/src/Telegram.Bot/Types/InlineQueryResults/InputVenueMessageContent.cs
@@ -38,6 +38,12 @@ namespace Telegram.Bot.Types.InlineQueryResults
         /// </summary>
         [JsonProperty(DefaultValueHandling = DefaultValueHandling.Ignore)]
         public string FoursquareId { get; set; }
+        
+        /// <summary>
+        /// Optional. Foursquare type of the venue. (For example, “arts_entertainment/default”, “arts_entertainment/aquarium” or “food/icecream”.)
+        /// </summary>
+        [JsonProperty(DefaultValueHandling = DefaultValueHandling.Ignore)]
+        public string FoursquareType { get; set; }
 
         private InputVenueMessageContent()
         {

--- a/src/Telegram.Bot/Types/Venue.cs
+++ b/src/Telegram.Bot/Types/Venue.cs
@@ -1,4 +1,4 @@
-﻿using Newtonsoft.Json;
+using Newtonsoft.Json;
 using Newtonsoft.Json.Serialization;
 
 namespace Telegram.Bot.Types
@@ -32,5 +32,12 @@ namespace Telegram.Bot.Types
         /// </summary>
         [JsonProperty(DefaultValueHandling = DefaultValueHandling.Ignore)]
         public string FoursquareId { get; set; }
+
+        /// <summary>
+        /// Optional. Foursquare type of the venue. (For example, "arts_entertainment/default",
+        /// "arts_entertainment/aquarium" or "food/icecream".)
+        /// </summary>
+        [JsonProperty(DefaultValueHandling = DefaultValueHandling.Ignore)]
+        public string FoursquareType { get; set; }
     }
 }

--- a/test/Telegram.Bot.Tests.Integ/Sending Messages/SendingContactMessageTests.cs
+++ b/test/Telegram.Bot.Tests.Integ/Sending Messages/SendingContactMessageTests.cs
@@ -42,9 +42,45 @@ namespace Telegram.Bot.Tests.Integ.Sending_Messages
             Assert.Equal(lastName, message.Contact.LastName);
         }
 
+        [OrderedFact(DisplayName = FactTitles.ShouldSendContactWithVCardd)]
+        [Trait(Constants.MethodTraitName, Constants.TelegramBotApiMethods.SendContact)]
+        public async Task Should_Send_Contact_With_VCard()
+        {
+            await _fixture.SendTestCaseNotificationAsync(FactTitles.ShouldSendContactWithVCardd);
+
+            const string vcard =
+                "BEGIN:VCARD" + "\n" +
+                "VERSION:2.1" + "\n" +
+                "N:Gump;Forrest;;Mr." + "\n" +
+                "FN:Forrest Gump" + "\n" +
+                "ORG:Bubba Gump Shrimp Co." + "\n" +
+                "TITLE:Shrimp Man" + "\n" +
+                "PHOTO;JPEG:https://upload.wikimedia.org/wikipedia/commons/9/95/TomHanksForrestGump94.jpg" + "\n" +
+                "TEL;WORK;VOICE:(111) 555-1212" + "\n" +
+                "TEL;HOME;VOICE:(404) 555-1212" + "\n" +
+                "ADR;HOME:;;42 Plantation St.;Baytown;LA;30314;United States of America" + "\n" +
+                "LABEL;HOME;ENCODING=QUOTED-PRINTABLE;CHARSET=UTF-8:42 Plantation St.=0D=0A=" + "\n" +
+                " Baytown, LA 30314=0D=0AUnited States of America" + "\n" +
+                "EMAIL:forrestgump@example.org" + "\n" +
+                "REV:20080424T195243Z" + "\n" +
+                "END:VCARD";
+
+            Message message = await BotClient.SendContactAsync(
+                /* chatId: */ _fixture.SupergroupChat,
+                /* phoneNumber: */ "+11115551212",
+                /* firstName: */ "Forrest",
+                vCard: vcard
+            );
+
+            Assert.Equal(MessageType.Contact, message.Type);
+            Assert.Equal(vcard, message.Contact.Vcard);
+        }
+
         private static class FactTitles
         {
             public const string ShouldSendContact = "Should send a contact";
+
+            public const string ShouldSendContactWithVCardd = "Should send a contact including his vCard";
         }
     }
 }

--- a/test/Telegram.Bot.Tests.Integ/Sending Messages/SendingPhotoMessageTests.cs
+++ b/test/Telegram.Bot.Tests.Integ/Sending Messages/SendingPhotoMessageTests.cs
@@ -83,6 +83,8 @@ namespace Telegram.Bot.Tests.Integ.Sending_Messages
 
             (MessageEntityType Type, string Value)[] entityValueMappings =
             {
+                (MessageEntityType.PhoneNumber, "+386 12 345 678"),
+                (MessageEntityType.Cashtag, "$EUR"),
                 (MessageEntityType.Hashtag, "#TelegramBots"),
                 (MessageEntityType.Mention, "@BotFather"),
                 (MessageEntityType.Url, "http://github.com/TelegramBots"),

--- a/test/Telegram.Bot.Tests.Integ/Sending Messages/SendingVenueMessageTests.cs
+++ b/test/Telegram.Bot.Tests.Integ/Sending Messages/SendingVenueMessageTests.cs
@@ -1,4 +1,6 @@
 ﻿using System.Threading.Tasks;
+using Newtonsoft.Json;
+using Telegram.Bot.Requests;
 using Telegram.Bot.Tests.Integ.Framework;
 using Telegram.Bot.Types;
 using Telegram.Bot.Types.Enums;
@@ -48,9 +50,40 @@ namespace Telegram.Bot.Tests.Integ.Sending_Messages
             Assert.InRange(message.Venue.Location.Longitude, lon - 0.001f, lon + 0.001f);
         }
 
+        [OrderedFact(DisplayName = FactTitles.ShouldDeserializeSendVenue)]
+        [Trait(Constants.MethodTraitName, Constants.TelegramBotApiMethods.SendVenue)]
+        public async Task Should_Deserialize_Send_Venue()
+        {
+            await _fixture.SendTestCaseNotificationAsync(FactTitles.ShouldDeserializeSendVenue);
+
+            string json = $@"{{
+                chat_id: ""{_fixture.SupergroupChat.Id}"",
+                latitude: 48.204296,
+                longitude: 16.365514,
+                title: ""Burggarten"",
+                address: ""Opernring"",
+                foursquare_id: ""4b7ff7c3f964a5208d4730e3"",
+                foursquare_type: ""parks_outdoors/park""
+            }}";
+
+            SendVenueRequest request = JsonConvert.DeserializeObject<SendVenueRequest>(json);
+
+            Message message = await BotClient.MakeRequestAsync(request);
+
+            Assert.Equal(MessageType.Venue, message.Type);
+            Assert.Equal("Burggarten", message.Venue.Title);
+            Assert.Equal("Opernring", message.Venue.Address);
+            Assert.Equal("4b7ff7c3f964a5208d4730e3", message.Venue.FoursquareId);
+            Assert.Equal("parks_outdoors/park", message.Venue.FoursquareType);
+            Assert.InRange(message.Venue.Location.Latitude, 48.204296 - 0.001f, 48.204296 + 0.001f);
+            Assert.InRange(message.Venue.Location.Longitude, 16.365514 - 0.001f, 16.365514 + 0.001f);
+        }
+
         private static class FactTitles
         {
             public const string ShouldSendVenue = "Should send a venue";
+
+            public const string ShouldDeserializeSendVenue = "Should deserialize a sendVenue request and send it";
         }
     }
 }

--- a/test/Telegram.Bot.Tests.Integ/Sending Messages/TextMessageTests.cs
+++ b/test/Telegram.Bot.Tests.Integ/Sending Messages/TextMessageTests.cs
@@ -166,13 +166,15 @@ namespace Telegram.Bot.Tests.Integ.Sending_Messages
             ));
         }
 
-        [OrderedFact(DisplayName = FactTitles.ShouldPaseMessageEntitiesIntoValues)]
+        [OrderedFact(DisplayName = FactTitles.ShouldParseMessageEntitiesIntoValues)]
         [Trait(Constants.MethodTraitName, Constants.TelegramBotApiMethods.SendMessage)]
         public async Task Should_Parse_Message_Entities_Into_Values()
         {
-            await _fixture.SendTestCaseNotificationAsync(FactTitles.ShouldPaseMessageEntitiesIntoValues);
+            await _fixture.SendTestCaseNotificationAsync(FactTitles.ShouldParseMessageEntitiesIntoValues);
 
             (MessageEntityType Type, string Value)[] entityValueMappings = {
+                (MessageEntityType.PhoneNumber, "+386 12 345 678"),
+                (MessageEntityType.Cashtag, "$EUR"),
                 (MessageEntityType.Hashtag, "#TelegramBots"),
                 (MessageEntityType.Mention, "@BotFather"),
                 (MessageEntityType.Url, "http://github.com/TelegramBots"),
@@ -207,7 +209,7 @@ namespace Telegram.Bot.Tests.Integ.Sending_Messages
             public const string ShouldParseHtmlEntities =
                 "Should send HTML formatted text message and parse its entities. Link preview should not appear.";
 
-            public const string ShouldPaseMessageEntitiesIntoValues =
+            public const string ShouldParseMessageEntitiesIntoValues =
                 "Should send text message and parse its entity values";
         }
 


### PR DESCRIPTION
### Added

- Parameter `vCard` to method `SendContactAsync`
- Parameter `foursquareType` to method `SendVenueAsync`
- Property `SendContactRequest.Vcard`
- Property `SendVenueRequest.FoursquareType`
- Property `InlineQueryResultContact.Vcard`
- Property `InlineQueryResultVenue.FoursquareType`
- Property `InputContactMessageContent.Vcard`
- Property `InputVenueMessageContent.FoursquareType`
- Property `Contact.Vcard`
- Property `Venue.FoursquareType`
- Enum value `MessageEntityType.Cashtag`

### Changed

- Marked `MessageType.Animation` as obsolete.