### PR TITLE
Add constructor decoupled configuration options

### DIFF
--- a/src/Telegram.Bot/Helpers/TelegramBotClientOptions.cs
+++ b/src/Telegram.Bot/Helpers/TelegramBotClientOptions.cs
@@ -1,0 +1,23 @@
+using System;
+using System.Collections.Generic;
+using System.Net.Http;
+using System.Text;
+
+namespace Telegram.Bot.Helpers
+{
+    /// <summary>
+    /// Used for configuring the bot 
+    /// </summary>
+    public class TelegramBotClientOptions
+    {
+        /// <summary>
+        /// The telegram bot token. Ask @botfather about it. 
+        /// </summary>
+        public string Token { get; set; } = "";
+        /// <summary>
+        /// An HttpBotClient instance that will be used for the bot. If not provided, a new one
+        /// will be created. 
+        /// </summary>
+        public HttpClient HttpClient { get; set; } = null;
+    }
+}


### PR DESCRIPTION
With this PR configuration and construction is decoupled for better compatibility with IoC containers. We can continue using the TelegramBotClient as always, using its constructor:

`MyClient = new TelegramBotClient("1234567:myApiKey")`

Or now we can decouple configuration from constructor, allowing services to configure it from a dependency injection:

```
class MyService : IMyService {
    private readonly ITelegramBotClient _telegramBotClient;
    
    MyService(ITelegramBotClient telegramBotClient) {
        _telegramBotClient = telegramBotClient;

        _telegramBotClient.Configure(options =>
        {
            options.Token = "1234567:myApiKey";
        });
    }
}
```

This PR mantains the Bot client immutable, not allowing it to be configured twice. If you try to call TelegramBotClient.Configure after calling a parameterful constructor you will get a InvalidOperationException with this message: "**BotClient is already configured. This will happen if you used a constructor with parameters or if you called this method previously when using a parameterless constructor.**"

