### PR TITLE
Make TelegramBotClient disposable

### DIFF
--- a/src/Telegram.Bot/TelegramBotClient.cs
+++ b/src/Telegram.Bot/TelegramBotClient.cs
@@ -178,6 +178,7 @@ namespace Telegram.Bot
 
             _baseRequestUrl = $"{BaseUrl}{_token}/";
             _httpClient = httpClient ?? new HttpClient();
+            _isCustomHttpClientUsed = httpClient != null;
         }
 
         /// <summary>
@@ -212,6 +213,7 @@ namespace Telegram.Bot
         }
 
         private bool _isDisposed;
+        private readonly bool _isCustomHttpClientUsed;
 
         /// <summary>
         /// Allows a <see cref="TelegramBotClient"/> to try to free resources and perform other cleanup operations before it is reclaimed by garbage collection.
@@ -232,7 +234,8 @@ namespace Telegram.Bot
             if (_isDisposed)
                 return;
 
-            _httpClient.Dispose();
+            if (!_isCustomHttpClientUsed)
+                _httpClient.Dispose();
 
             _isDisposed = true;
         }

--- a/src/Telegram.Bot/TelegramBotClient.cs
+++ b/src/Telegram.Bot/TelegramBotClient.cs
@@ -24,7 +24,7 @@ namespace Telegram.Bot
     /// <summary>
     /// A client to use the Telegram Bot API
     /// </summary>
-    public class TelegramBotClient : ITelegramBotClient
+    public class TelegramBotClient : ITelegramBotClient, IDisposable
     {
         /// <inheritdoc/>
         public int BotId { get; }
@@ -152,6 +152,8 @@ namespace Telegram.Bot
 
         #endregion
 
+        #region Construction and disposal
+
         /// <summary>
         /// Create a new <see cref="TelegramBotClient"/> instance.
         /// </summary>
@@ -208,6 +210,34 @@ namespace Telegram.Bot
             };
             _httpClient = new HttpClient(httpClientHander);
         }
+
+        private bool _isDisposed;
+
+        /// <summary>
+        /// Allows a <see cref="TelegramBotClient"/> to try to free resources and perform other cleanup operations before it is reclaimed by garbage collection.
+        /// </summary>
+        ~TelegramBotClient() => dispose();
+
+        /// <summary>
+        /// Disposes this <see cref="TelegramBotClient"/>
+        /// </summary>
+        public void Dispose()
+        {
+            dispose();
+            GC.SuppressFinalize(this);
+        }
+
+        private void dispose()
+        {
+            if (_isDisposed)
+                return;
+
+            _httpClient.Dispose();
+
+            _isDisposed = true;
+        }
+
+        #endregion
 
         #region Helpers
 


### PR DESCRIPTION
As far as I see, there is a `HttpClient` instance creation under the hood of a `TelegramBotClient`. Since `HttpClient` is `IDisposable`, I guess we should call `_httpClient.Dispose()` at some point.