### PR TITLE
Add support for requests in webhook responses

### DIFF
--- a/src/Telegram.Bot/Requests/Abstractions/IRequest.cs
+++ b/src/Telegram.Bot/Requests/Abstractions/IRequest.cs
@@ -24,5 +24,10 @@ namespace Telegram.Bot.Requests.Abstractions
         /// </summary>
         /// <returns>Content of HTTP request</returns>
         HttpContent ToHttpContent();
+
+        /// <summary>
+        /// Allows this object to be used as a response in webhooks
+        /// </summary>
+        bool IsWebhookResponse { get; set; }
     }
 }

--- a/src/Telegram.Bot/Requests/Abstractions/IRequest.cs
+++ b/src/Telegram.Bot/Requests/Abstractions/IRequest.cs
@@ -24,10 +24,5 @@ namespace Telegram.Bot.Requests.Abstractions
         /// </summary>
         /// <returns>Content of HTTP request</returns>
         HttpContent ToHttpContent();
-
-        /// <summary>
-        /// Allows this object to be used as a response in webhooks
-        /// </summary>
-        bool IsWebhookResponse { get; set; }
     }
 }

--- a/src/Telegram.Bot/Requests/Available Methods/GetMeRequest.cs
+++ b/src/Telegram.Bot/Requests/Available Methods/GetMeRequest.cs
@@ -1,4 +1,6 @@
-﻿using Telegram.Bot.Types;
+﻿using Newtonsoft.Json;
+using Newtonsoft.Json.Serialization;
+using Telegram.Bot.Types;
 
 // ReSharper disable once CheckNamespace
 namespace Telegram.Bot.Requests
@@ -6,6 +8,7 @@ namespace Telegram.Bot.Requests
     /// <summary>
     /// A simple method for testing your bot's auth token.
     /// </summary>
+    [JsonObject(MemberSerialization.OptIn, NamingStrategyType = typeof(SnakeCaseNamingStrategy))]
     public class GetMeRequest : ParameterlessRequest<User>
     {
         /// <summary>

--- a/src/Telegram.Bot/Requests/Getting Updates/DeleteWebhookRequest.cs
+++ b/src/Telegram.Bot/Requests/Getting Updates/DeleteWebhookRequest.cs
@@ -1,9 +1,13 @@
 ﻿// ReSharper disable once CheckNamespace
+using Newtonsoft.Json;
+using Newtonsoft.Json.Serialization;
+
 namespace Telegram.Bot.Requests
 {
     /// <summary>
     /// Remove webhook integration if you decide to switch back to getUpdates.
     /// </summary>
+    [JsonObject(MemberSerialization.OptIn, NamingStrategyType = typeof(SnakeCaseNamingStrategy))]
     public class DeleteWebhookRequest : ParameterlessRequest<bool>
     {
         /// <summary>

--- a/src/Telegram.Bot/Requests/Getting Updates/GetWebhookInfoRequest.cs
+++ b/src/Telegram.Bot/Requests/Getting Updates/GetWebhookInfoRequest.cs
@@ -1,4 +1,6 @@
-﻿using Telegram.Bot.Types;
+﻿using Newtonsoft.Json;
+using Newtonsoft.Json.Serialization;
+using Telegram.Bot.Types;
 
 // ReSharper disable once CheckNamespace
 namespace Telegram.Bot.Requests
@@ -6,6 +8,7 @@ namespace Telegram.Bot.Requests
     /// <summary>
     /// Get current webhook status.
     /// </summary>
+    [JsonObject(MemberSerialization.OptIn, NamingStrategyType = typeof(SnakeCaseNamingStrategy))]
     public class GetWebhookInfoRequest : ParameterlessRequest<WebhookInfo>
     {
         /// <summary>

--- a/src/Telegram.Bot/Requests/ParameterlessRequest.cs
+++ b/src/Telegram.Bot/Requests/ParameterlessRequest.cs
@@ -28,6 +28,8 @@ namespace Telegram.Bot.Requests
         }
 
         /// <inheritdoc cref="RequestBase{TResponse}.ToHttpContent"/>
-        public override HttpContent ToHttpContent() => null;
+        public override HttpContent ToHttpContent() => IsWebhookResponse
+            ? base.ToHttpContent()
+            : null;
     }
 }

--- a/src/Telegram.Bot/Requests/RequestBase.cs
+++ b/src/Telegram.Bot/Requests/RequestBase.cs
@@ -46,9 +46,7 @@ namespace Telegram.Bot.Requests
             return new StringContent(payload, Encoding.UTF8, "application/json");
         }
 
-        /// <summary>
-        /// Allows this object to be used as a response in webhooks
-        /// </summary>
+        /// <inheritdoc />
         public bool IsWebhookResponse { get; set; }
 
         /// <summary>

--- a/src/Telegram.Bot/Requests/RequestBase.cs
+++ b/src/Telegram.Bot/Requests/RequestBase.cs
@@ -46,7 +46,9 @@ namespace Telegram.Bot.Requests
             return new StringContent(payload, Encoding.UTF8, "application/json");
         }
 
-        /// <inheritdoc />
+        /// <summary>
+        /// Allows this object to be used as a response in webhooks
+        /// </summary>
         public bool IsWebhookResponse { get; set; }
 
         /// <summary>

--- a/src/Telegram.Bot/Requests/RequestBase.cs
+++ b/src/Telegram.Bot/Requests/RequestBase.cs
@@ -45,5 +45,18 @@ namespace Telegram.Bot.Requests
             string payload = JsonConvert.SerializeObject(this);
             return new StringContent(payload, Encoding.UTF8, "application/json");
         }
+
+        /// <summary>
+        /// Allows this object to be used as a response in webhooks
+        /// </summary>
+        public bool IsWebhookResponse { get; set; }
+
+        /// <summary>
+        /// If <see cref="IsWebhookResponse"/> is set to <see langword="true"/> is set to the method
+        /// name, otherwise it won't be serialized
+        /// </summary>
+
+        [JsonProperty("method", DefaultValueHandling = DefaultValueHandling.Ignore)]
+        internal string WebHookMethodName => IsWebhookResponse ? MethodName : default;
     }
 }

--- a/test/Telegram.Bot.Tests.Unit/Serialization/MethodNameTests.cs
+++ b/test/Telegram.Bot.Tests.Unit/Serialization/MethodNameTests.cs
@@ -14,19 +14,19 @@ namespace Telegram.Bot.Tests.Unit.Serialization
                 IsWebhookResponse = true
             };
 
-            var request = JsonConvert.SerializeObject(sendMessageRequest);
+            string request = JsonConvert.SerializeObject(sendMessageRequest);
             Assert.Contains(@"""method"":""sendMessage""", request);
         }
 
-        [Fact(DisplayName = "Should not serialize method name in webhook responses")]
-        public void Should_Not_Serialize_MethodName_In_Webhook_Responses()
+        [Fact(DisplayName = "Should not serialize method name when not a webhook responses")]
+        public void Should_Not_Serialize_MethodName_When_Not_In_Webhook_Responses()
         {
             SendMessageRequest sendMessageRequest = new SendMessageRequest(1, "text")
             {
                 IsWebhookResponse = false
             };
 
-            var request = JsonConvert.SerializeObject(sendMessageRequest);
+            string request = JsonConvert.SerializeObject(sendMessageRequest);
             Assert.DoesNotContain(@"""method"":""sendMessage""", request);
         }
     }

--- a/test/Telegram.Bot.Tests.Unit/Serialization/MethodNameTests.cs
+++ b/test/Telegram.Bot.Tests.Unit/Serialization/MethodNameTests.cs
@@ -1,3 +1,5 @@
+using System.Net.Http;
+using System.Threading.Tasks;
 using Newtonsoft.Json;
 using Telegram.Bot.Requests;
 using Xunit;
@@ -28,6 +30,69 @@ namespace Telegram.Bot.Tests.Unit.Serialization
 
             string request = JsonConvert.SerializeObject(sendMessageRequest);
             Assert.DoesNotContain(@"""method"":""sendMessage""", request);
+        }
+
+        [Fact(DisplayName = "Should serialize only the method name in parameterless webhook responses")]
+        public void Should_Serialize_MethodName_In_Parameterless_Webhook_Responses()
+        {
+            DeleteWebhookRequest deleteWebhookRequest = new DeleteWebhookRequest
+            {
+                IsWebhookResponse = true
+            };
+
+            string request = JsonConvert.SerializeObject(deleteWebhookRequest);
+            Assert.Equal(@"{""method"":""deleteWebhook""}", request);
+        }
+
+        [Fact(DisplayName = "Should serialize an empty object when not a parameterless webhook response")]
+        public void Should_Serialize_Empty_Object_When_Not_Parameterless_Webhook_Response()
+        {
+            DeleteWebhookRequest deleteWebhookRequest = new DeleteWebhookRequest
+            {
+                IsWebhookResponse = false
+            };
+
+            string request = JsonConvert.SerializeObject(deleteWebhookRequest);
+            Assert.Equal("{}", request);
+        }
+
+        [Fact(DisplayName = "Should build a HttpContent in parameterless webhook responses")]
+        public void Should_Build_HttpContent_In_Parameterless_Webhook_Response()
+        {
+            DeleteWebhookRequest deleteWebhookRequest = new DeleteWebhookRequest
+            {
+                IsWebhookResponse = true
+            };
+
+            HttpContent content = deleteWebhookRequest.ToHttpContent();
+            Assert.NotNull(content);
+        }
+
+        [Fact(DisplayName = "Should build a StringContent with method name in parameterless webhook responses")]
+        public async Task Should_Build_StringContent_With_MethodName_In_Parameterless_Webhook_ResponseAsync()
+        {
+            DeleteWebhookRequest deleteWebhookRequest = new DeleteWebhookRequest
+            {
+                IsWebhookResponse = true
+            };
+
+            HttpContent content = deleteWebhookRequest.ToHttpContent();
+            Assert.IsType<StringContent>(content);
+            StringContent stringContent = (StringContent) content;
+            string body = await stringContent.ReadAsStringAsync();
+            Assert.Equal(@"{""method"":""deleteWebhook""}", body);
+        }
+
+        [Fact(DisplayName = "Should not build an HttpContent when not a parameterless webhook responses")]
+        public void Should_Not_Serialize_MethodName_When_Not_Parameterless_Webhook_Responses()
+        {
+            DeleteWebhookRequest deleteWebhookRequest = new DeleteWebhookRequest
+            {
+                IsWebhookResponse = false
+            };
+
+            HttpContent content = deleteWebhookRequest.ToHttpContent();
+            Assert.Null(content);
         }
     }
 }

--- a/test/Telegram.Bot.Tests.Unit/Serialization/MethodNameTests.cs
+++ b/test/Telegram.Bot.Tests.Unit/Serialization/MethodNameTests.cs
@@ -9,7 +9,7 @@ namespace Telegram.Bot.Tests.Unit.Serialization
         [Fact(DisplayName = "Should serialize method name in webhook responses")]
         public void Should_Serialize_MethodName_In_Webhook_Responses()
         {
-            var sendMessageRequest = new SendMessageRequest(1, "text")
+            SendMessageRequest sendMessageRequest = new SendMessageRequest(1, "text")
             {
                 IsWebhookResponse = true
             };
@@ -21,7 +21,7 @@ namespace Telegram.Bot.Tests.Unit.Serialization
         [Fact(DisplayName = "Should not serialize method name in webhook responses")]
         public void Should_Not_Serialize_MethodName_In_Webhook_Responses()
         {
-            var sendMessageRequest = new SendMessageRequest(1, "text")
+            SendMessageRequest sendMessageRequest = new SendMessageRequest(1, "text")
             {
                 IsWebhookResponse = false
             };

--- a/test/Telegram.Bot.Tests.Unit/Serialization/MethodNameTests.cs
+++ b/test/Telegram.Bot.Tests.Unit/Serialization/MethodNameTests.cs
@@ -1,0 +1,33 @@
+using Newtonsoft.Json;
+using Telegram.Bot.Requests;
+using Xunit;
+
+namespace Telegram.Bot.Tests.Unit.Serialization
+{
+    public class MethodNameTests
+    {
+        [Fact(DisplayName = "Should serialize method name in webhook responses")]
+        public void Should_Serialize_MethodName_In_Webhook_Responses()
+        {
+            var sendMessageRequest = new SendMessageRequest(1, "text")
+            {
+                IsWebhookResponse = true
+            };
+
+            var request = JsonConvert.SerializeObject(sendMessageRequest);
+            Assert.Contains(@"""method"":""sendMessage""", request);
+        }
+
+        [Fact(DisplayName = "Should not serialize method name in webhook responses")]
+        public void Should_Not_Serialize_MethodName_In_Webhook_Responses()
+        {
+            var sendMessageRequest = new SendMessageRequest(1, "text")
+            {
+                IsWebhookResponse = false
+            };
+
+            var request = JsonConvert.SerializeObject(sendMessageRequest);
+            Assert.DoesNotContain(@"""method"":""sendMessage""", request);
+        }
+    }
+}


### PR DESCRIPTION
This PR tries to solve #36 by adding two internal properties to RequestBase: the public boolean one controls the value returned by the internal one.
When serializing the request, if IsWebhookResponse is set to true, the internal property will have the same value as MethodName, so the serialized payload will include the correct `method` field. If it's set to false, `WebHookMethodName` will be equal to null and ignored by Json.Net.

It would be used like this:

```csharp
var request = new SendMessageRequest(chatId, text)
{
    IsWebhookResponse = true
};

return new OkObjectResult(request);
```

One could even create a special "OkWebhookRequestResult" that takes an IRequest<T> and automatically sets the property to true.

I've added two basic tests, is there anything else I would need to change/update?