### PR TITLE
Replace publish-artifacts pipeline with a unified ci pipeline

### DIFF
--- a/.azure-pipelines/ci.yml
+++ b/.azure-pipelines/ci.yml
@@ -5,8 +5,11 @@ trigger:
       - gh-pages
   paths:
     exclude:
+      - ".github/"
       - docs/
-      - "*/**/*.md"
+      - README.md
+      - CHANGELOG.md
+      - CONTRIBUTING.md
 
 pr: none
 

--- a/.azure-pipelines/ci.yml
+++ b/.azure-pipelines/ci.yml
@@ -41,6 +41,7 @@ stages:
               --configuration $(buildConfiguration)
               --version-suffix "$(ciVersionSuffix)"
               $(projectPath)
+              /p:CI_EMBED_SYMBOLS=true
             displayName: Create CI nuget package
 
           - publish: $(Build.ArtifactStagingDirectory)/packages

--- a/.azure-pipelines/ci.yml
+++ b/.azure-pipelines/ci.yml
@@ -33,7 +33,7 @@ stages:
               arguments: >
                 --configuration $(buildConfiguration)
                 --version-suffix "$(ciVersionSuffix)"
-
+                /p:CI_EMBED_SYMBOLS=true
           - bash: >
               dotnet pack
               --no-build

--- a/.azure-pipelines/ci.yml
+++ b/.azure-pipelines/ci.yml
@@ -5,8 +5,8 @@ trigger:
       - gh-pages
   paths:
     exclude:
-      - docs/*
-      - "**/*.md"
+      - docs/
+      - "*/**/*.md"
 
 pr: none
 
@@ -42,6 +42,17 @@ stages:
 
           - publish: $(Build.ArtifactStagingDirectory)/packages
             artifact: packages
+
+  - stage: UnitTest
+    dependsOn: Build
+    displayName: 🧪 Unit test
+    jobs:
+      - template: jobs/run-unit-tests.yml
+        parameters:
+          buildConfiguration: $(buildConfiguration)
+          projects: $(unitTestsProject)
+          strategies:
+            - Ubuntu: ubuntu-18.04
 
   - stage: PublishArtifacts
     dependsOn: Build

--- a/.azure-pipelines/default-pipeline.yml
+++ b/.azure-pipelines/default-pipeline.yml
@@ -6,6 +6,10 @@ pr:
       - master
       - develop
       - gh-pages
+  paths:
+    exclude:
+      - docs/
+      - "*/**/*.md"
 
 variables:
   - template: variables.yml

--- a/.azure-pipelines/default-pipeline.yml
+++ b/.azure-pipelines/default-pipeline.yml
@@ -8,8 +8,11 @@ pr:
       - gh-pages
   paths:
     exclude:
+      - ".github/"
       - docs/
-      - "*/**/*.md"
+      - README.md
+      - CHANGELOG.md
+      - CONTRIBUTING.md
 
 variables:
   - template: variables.yml

--- a/.azure-pipelines/develop-pipeline.yml
+++ b/.azure-pipelines/develop-pipeline.yml
@@ -6,8 +6,11 @@ pr:
       - develop
   paths:
     exclude:
+      - ".github/"
       - docs/
-      - "*/**/*.md"
+      - README.md
+      - CHANGELOG.md
+      - CONTRIBUTING.md
 
 variables:
   - template: variables.yml

--- a/.azure-pipelines/develop-pipeline.yml
+++ b/.azure-pipelines/develop-pipeline.yml
@@ -1,7 +1,13 @@
 trigger: none
 
 pr:
-  - develop
+  branches:
+    include:
+      - develop
+  paths:
+    exclude:
+      - docs/
+      - "*/**/*.md"
 
 variables:
   - template: variables.yml

--- a/.azure-pipelines/release-pipeline.yml
+++ b/.azure-pipelines/release-pipeline.yml
@@ -65,11 +65,3 @@ stages:
               --skip-duplicate
               --source https://api.nuget.org/v3/index.json
             displayName: Publish package to NuGet
-
-          - bash: >
-              dotnet nuget push
-              $(Pipeline.Workspace)/packages/release/*.snupkg
-              --api-key $(NugetApiKey)
-              --skip-duplicate
-              --source https://nuget.org
-            displayName: Publish symbols to NuGet

--- a/.azure-pipelines/release-pipeline.yml
+++ b/.azure-pipelines/release-pipeline.yml
@@ -63,7 +63,7 @@ stages:
               $(Pipeline.Workspace)/packages/release/*.nupkg
               --api-key $(NugetApiKey)
               --skip-duplicate
-              --source https://nuget.org
+              --source https://api.nuget.org/v3/index.json
             displayName: Publish package to NuGet
 
           - bash: >

--- a/.azure-pipelines/release-pipeline.yml
+++ b/.azure-pipelines/release-pipeline.yml
@@ -5,8 +5,8 @@ trigger:
       - master
   paths:
     exclude:
-      - docs/*
-      - "**/*.md"
+      - docs/
+      - "*/**/*.md"
 
 pr: none
 

--- a/.azure-pipelines/release-pipeline.yml
+++ b/.azure-pipelines/release-pipeline.yml
@@ -5,8 +5,11 @@ trigger:
       - master
   paths:
     exclude:
+      - ".github/"
       - docs/
-      - "*/**/*.md"
+      - README.md
+      - CHANGELOG.md
+      - CONTRIBUTING.md
 
 pr: none
 

--- a/README.md
+++ b/README.md
@@ -4,11 +4,13 @@
 [![documentations](https://img.shields.io/badge/Documentations-Book-orange.svg?style=flat-square)](https://telegrambots.github.io/book/)
 [![telegram chat](https://img.shields.io/badge/Support_Chat-Telegram-blue.svg?style=flat-square)](https://t.me/joinchat/B35YY0QbLfd034CFnvCtCA)
 
-[![build](https://img.shields.io/azure-devops/build/tgbots/14f9ab3f-313a-4339-8534-e8b96c7763cc/6?style=flat-square)](https://dev.azure.com/tgbots/Telegram.Bot/_build?definitionId=6)
 [![downloads](https://img.shields.io/nuget/dt/Telegram.Bot.svg?style=flat-square&label=Package%20Downloads)](https://www.nuget.org/packages/Telegram.Bot)
 [![contributors](https://img.shields.io/github/contributors/TelegramBots/Telegram.Bot.svg?style=flat-square&label=Contributors)](https://github.com/TelegramBots/Telegram.Bot/graphs/contributors)
 [![license](https://img.shields.io/github/license/TelegramBots/telegram.bot.svg?style=flat-square&maxAge=2592000&label=License)](https://raw.githubusercontent.com/TelegramBots/telegram.bot/master/LICENSE)
 
+|Master|Develop|
+|------|-------|
+|[![build](https://img.shields.io/azure-devops/build/tgbots/14f9ab3f-313a-4339-8534-e8b96c7763cc/6?style=flat-square)](https://dev.azure.com/tgbots/Telegram.Bot/_build?definitionId=6)|[![build](https://img.shields.io/azure-devops/build/tgbots/14f9ab3f-313a-4339-8534-e8b96c7763cc/8/develop?style=flat-square)](https://dev.azure.com/tgbots/Telegram.Bot/_build?definitionId=8&branchName=develop)|
 **Telegram.Bot** is the most popular .NET Client for 🤖 [Telegram Bot API].
 
 The Bot API is an HTTP-based interface created for developers keen on building bots for [Telegram].

--- a/README.md
+++ b/README.md
@@ -10,7 +10,9 @@
 
 |Master|Develop|
 |------|-------|
-|[![build](https://img.shields.io/azure-devops/build/tgbots/14f9ab3f-313a-4339-8534-e8b96c7763cc/6?style=flat-square)](https://dev.azure.com/tgbots/Telegram.Bot/_build?definitionId=6)|[![build](https://img.shields.io/azure-devops/build/tgbots/14f9ab3f-313a-4339-8534-e8b96c7763cc/8/develop?style=flat-square)](https://dev.azure.com/tgbots/Telegram.Bot/_build?definitionId=8&branchName=develop)|
+|[![build](https://img.shields.io/azure-devops/build/tgbots/14f9ab3f-313a-4339-8534-e8b96c7763cc/6?style=flat-square)](https://dev.azure.com/tgbots/Telegram.Bot/_build/latest?definitionId=6&branchName=master)|[![build](https://img.shields.io/azure-devops/build/tgbots/14f9ab3f-313a-4339-8534-e8b96c7763cc/10/develop?style=flat-square)](https://dev.azure.com/tgbots/Telegram.Bot/_build/latest?definitionId=10&branchName=develop)|
+
+
 **Telegram.Bot** is the most popular .NET Client for 🤖 [Telegram Bot API].
 
 The Bot API is an HTTP-based interface created for developers keen on building bots for [Telegram].

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # .NET Client for Telegram Bot API
 
 [![package](https://img.shields.io/nuget/vpre/Telegram.Bot.svg?label=Telegram.Bot&style=flat-square)](https://www.nuget.org/packages/Telegram.Bot)
-[![documentations](https://img.shields.io/badge/Documentations-Book-orange.svg?style=flat-square)](https://telegrambots.github.io/book)
+[![documentations](https://img.shields.io/badge/Documentations-Book-orange.svg?style=flat-square)](https://telegrambots.github.io/book/)
 [![telegram chat](https://img.shields.io/badge/Support_Chat-Telegram-blue.svg?style=flat-square)](https://t.me/joinchat/B35YY0QbLfd034CFnvCtCA)
 
 [![build](https://img.shields.io/azure-devops/build/tgbots/14f9ab3f-313a-4339-8534-e8b96c7763cc/6?style=flat-square)](https://dev.azure.com/tgbots/Telegram.Bot/_build?definitionId=6)
@@ -19,7 +19,7 @@ We, the [Telegram Bots team], mainly focus on developing multiple [NuGet package
 
 |Package|Documentation|News Channel|Team|Group Chat|
 |:-----:|:-----------:|:----------:|:--:|:--------:|
-| [![package](docs/logo-nuget.png)](https://www.nuget.org/packages/Telegram.Bot) | [![documentations](docs/logo-docs.png)](https://telegrambots.github.io/book) | [![News Channel](docs/logo-channel.jpg)](https://t.me/tgbots_dotnet) | [![Team](docs/logo-gh.png)](https://github.com/orgs/TelegramBots/people) | [![Group Chat](docs/logo-chat.jpg)](https://t.me/joinchat/B35YY0QbLfd034CFnvCtCA) |
+| [![package](docs/logo-nuget.png)](https://www.nuget.org/packages/Telegram.Bot) | [![documentations](docs/logo-docs.png)](https://telegrambots.github.io/book/) | [![News Channel](docs/logo-channel.jpg)](https://t.me/tgbots_dotnet) | [![Team](docs/logo-gh.png)](https://github.com/orgs/TelegramBots/people) | [![Group Chat](docs/logo-chat.jpg)](https://t.me/joinchat/B35YY0QbLfd034CFnvCtCA) |
 | This package on NuGet | Telegram bots book | Subscribe to 📣 [`@tgbots_dotnet`] channel to get our latest news | The team contributing to this work | [Join our chat] 💬 to talk about bots and ask questions |
 
 ## 🔨 Getting Started
@@ -48,7 +48,7 @@ use it in your own bot projects.
 ## 🗂 References
 
 - [Changelog](CHANGELOG.md)
-- [Documentation](https://telegrambots.github.io/book)
+- [Documentation](https://telegrambots.github.io/book/)
 - [Examples](https://github.com/TelegramBots/telegram.bot.examples)
 
 <!-- ---- -->

--- a/src/Telegram.Bot/Telegram.Bot.csproj
+++ b/src/Telegram.Bot/Telegram.Bot.csproj
@@ -28,6 +28,13 @@
     <Deterministic>true</Deterministic>
   </PropertyGroup>
 
+  <!-- Embed PBD files into test package built in CI because Azure Pipelines don't have symbols server yet -->
+  <PropertyGroup Condition="'$(CI_EMBED_SYMBOLS)' == 'true'">
+    <AllowedOutputExtensionsInPackageBuildOutputFolder>
+      $(AllowedOutputExtensionsInPackageBuildOutputFolder);.pdb
+    </AllowedOutputExtensionsInPackageBuildOutputFolder>
+  </PropertyGroup>
+
   <ItemGroup>
     <PackageReference Include="Newtonsoft.Json" Version="11.0.2" />
     <PackageReference Include="System.Net.Requests" Version="4.3.0" />

--- a/src/Telegram.Bot/Telegram.Bot.csproj
+++ b/src/Telegram.Bot/Telegram.Bot.csproj
@@ -1,4 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
+
   <PropertyGroup>
     <TargetFrameworks>netstandard1.1;net45</TargetFrameworks>
     <VersionPrefix>15.7.0</VersionPrefix>
@@ -8,6 +9,8 @@
     <GenerateDocumentationFile>True</GenerateDocumentationFile>
     <IncludeSymbols>true</IncludeSymbols>
     <SymbolPackageFormat>snupkg</SymbolPackageFormat>
+    <PublishRepositoryUrl>true</PublishRepositoryUrl>
+    <EmbedUntrackedSources>true</EmbedUntrackedSources>
     <Title>Telegram Bot API Client</Title>
     <Description>The Bot API is an HTTP-based interface created for developers keen on building bots for Telegram.</Description>
     <PackageId>Telegram.Bot</PackageId>
@@ -19,14 +22,13 @@
     <RepositoryUrl>https://github.com/TelegramBots/telegram.bot.git</RepositoryUrl>
     <PackageTags>Telegram;Bot;Api;Payment;Inline;Games</PackageTags>
   </PropertyGroup>
-  <!-- when building on AppVeyor -->
-  <PropertyGroup Condition="'$(AppVeyor)' == 'True'">
-    <VersionSuffix Condition="'$(VersionSuffix)' != ''">$(VersionSuffix)-$(APPVEYOR_BUILD_NUMBER)</VersionSuffix>
-  </PropertyGroup>
+
   <ItemGroup>
     <PackageReference Include="Newtonsoft.Json" Version="11.0.2" />
     <PackageReference Include="System.Net.Requests" Version="4.3.0" />
+    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0" PrivateAssets="All"/>
   </ItemGroup>
+
   <ItemGroup Condition="'$(TargetFramework)'=='net45'">
     <Reference Include="System.Net.Http" />
     <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies.net45" Version="1.0.0">
@@ -34,4 +36,5 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
     </PackageReference>
   </ItemGroup>
+
 </Project>

--- a/src/Telegram.Bot/Telegram.Bot.csproj
+++ b/src/Telegram.Bot/Telegram.Bot.csproj
@@ -23,6 +23,11 @@
     <PackageTags>Telegram;Bot;Api;Payment;Inline;Games</PackageTags>
   </PropertyGroup>
 
+  <PropertyGroup Condition="'$(TF_BUILD)' == 'true'">
+    <ContinuousIntegrationBuild>true</ContinuousIntegrationBuild>
+    <Deterministic>true</Deterministic>
+  </PropertyGroup>
+
   <ItemGroup>
     <PackageReference Include="Newtonsoft.Json" Version="11.0.2" />
     <PackageReference Include="System.Net.Requests" Version="4.3.0" />


### PR DESCRIPTION
`ci` pipeline runs only on CI triggers (i.e. pushes) on every branch except `master` and `gh-pages`. It builds the library, executes unit tests and publishes artifacts to Azure Nuget feed.

Also in the PR:
- Enable [Source Link](https://github.com/dotnet/sourcelink) integration
- Replace recursive wildcard paths with the most often changed direct filenames because Azure Pipelines doesn't support recursive wildcard patterns in triggers
- Add additional badge to `ci` pipeline builds for `develop` branch
- Fully deterministic build
- Include PDB files with symbols into test artifacts on Azure Nuget feed