### PR TITLE
Add GitHub Release integration

### DIFF
--- a/.azure-pipelines/ci.yml
+++ b/.azure-pipelines/ci.yml
@@ -25,6 +25,12 @@ stages:
         pool:
           vmImage: $(vmImage)
         steps:
+          - script: node .azure-pipelines/setVersionVariables.js
+            env:
+              VERSION_PREFIX: $(versionPrefix)
+              VERSION_SUFFIX: $(versionSuffix)
+              CI_VERSION_SUFFIX: $(ciVersionSuffix)
+            displayName: Set version variables
           - task: DotNetCoreCLI@2
             displayName: Build project with CI version
             inputs:
@@ -32,18 +38,17 @@ stages:
               projects: $(projectPath)
               arguments: >
                 --configuration $(buildConfiguration)
-                --version-suffix "$(ciVersionSuffix)"
-                /p:CI_EMBED_SYMBOLS=true
+                -p:Version=$(CI_VERSION)
+                -p:CI_EMBED_SYMBOLS=true
           - bash: >
               dotnet pack
               --no-build
-              --output "$(Build.ArtifactStagingDirectory)/packages/ci"
+              --output "$(Build.ArtifactStagingDirectory)/packages"
               --configuration $(buildConfiguration)
-              --version-suffix "$(ciVersionSuffix)"
+              -p:Version=$(CI_VERSION)
+              -p:CI_EMBED_SYMBOLS=true
               $(projectPath)
-              /p:CI_EMBED_SYMBOLS=true
             displayName: Create CI nuget package
-
           - publish: $(Build.ArtifactStagingDirectory)/packages
             artifact: packages
 
@@ -68,12 +73,8 @@ stages:
           vmImage: $(vmImage)
         steps:
           - checkout: none
-
           - download: current
             artifact: packages
-            # quotes are needed since * can't be used as the first character without quotes
-            patterns: "*/**/*.*upkg"
-
           - task: DotNetCoreCLI@2
             displayName: Publish CI package to Azure artifacts
             inputs:
@@ -81,4 +82,4 @@ stages:
               nuGetFeedType: internal
               feedPublish: $(internalFeedName)
               publishPackageMetadata: true
-              packagesToPush: $(Pipeline.Workspace)/packages/ci/*.*upkg
+              packagesToPush: $(Pipeline.Workspace)/packages/*.*upkg

--- a/.azure-pipelines/default-pipeline.yml
+++ b/.azure-pipelines/default-pipeline.yml
@@ -27,7 +27,6 @@ stages:
           projects: $(unitTestsProject)
           strategies:
             - Ubuntu: ubuntu-18.04
-
   - stage: IntegrationTests
     displayName: 🧪 Integreation tests
     jobs:

--- a/.azure-pipelines/develop-pipeline.yml
+++ b/.azure-pipelines/develop-pipeline.yml
@@ -27,7 +27,6 @@ stages:
             - Windows: windows-2019
             - Ubuntu: ubuntu-18.04
             - macOS: macOS-10.15
-
   - stage: IntegrationTests
     displayName: 🧪 Integration tests
     jobs:

--- a/.azure-pipelines/manual-pipeline.yml
+++ b/.azure-pipelines/manual-pipeline.yml
@@ -16,7 +16,6 @@ stages:
             - Ubuntu: ubuntu-18.04
             - macOS: macos-10.15
             - Windows: windows-2019
-
   - stage: FullIntegrationTests
     displayName: 🧪 Full set of integration tests
     dependsOn: UnitTest
@@ -27,7 +26,6 @@ stages:
           vmImage: $(vmImage)
           buildConfiguration: $(buildConfiguration)
           projects: $(integrationTestsProject)
-
   - stage: NonInteractiveIntegrationTests
     displayName: 🧪 Non-interactive integration tests
     dependsOn: UnitTest

--- a/.azure-pipelines/release-pipeline.yml
+++ b/.azure-pipelines/release-pipeline.yml
@@ -16,52 +16,49 @@ pr: none
 variables:
   - template: variables.yml
 
-stages:
-  - stage: Build
-    displayName: 🚧 Build
-    jobs:
-      - job: Build
-        displayName: Build with .NET Core SDK
-        pool:
-          vmImage: $(vmImage)
-        steps:
-          - task: DotNetCoreCLI@2
-            displayName: Build project with release version
-            inputs:
-              command: build
-              projects: $(projectPath)
-              arguments: >
-                --configuration $(buildConfiguration)
+pool:
+  vmImage: $(vmImage)
 
-          - bash: >
-              dotnet pack
-              --no-build
-              --output "$(Build.ArtifactStagingDirectory)/packages/release"
-              --configuration $(buildConfiguration)
-              $(projectPath)
-            displayName: Create release nuget package
-
-          - publish: $(Build.ArtifactStagingDirectory)/packages
-            artifact: packages
-
-  - stage: Release
-    displayName: 🚀 Release
-    jobs:
-      - job: Release
-        displayName: Publish package to NuGet
-        pool:
-          vmImage: $(vmImage)
-        steps:
-          - checkout: none
-
-          - download: current
-            artifact: packages
-            patterns: "*/**/*.*upkg"
-
-          - bash: >
-              dotnet nuget push
-              $(Pipeline.Workspace)/packages/release/*.nupkg
-              --api-key $(NugetApiKey)
-              --skip-duplicate
-              --source https://api.nuget.org/v3/index.json
-            displayName: Publish package to NuGet
+steps:
+  - script: node .azure-pipelines/setVersionVariables.js
+    env:
+      VERSION_PREFIX: $(versionPrefix)
+      VERSION_SUFFIX: $(versionSuffix)
+      CI_VERSION_SUFFIX: $(ciVersionSuffix)
+    displayName: Set version variables
+  - task: DotNetCoreCLI@2
+    displayName: Build project with release version
+    inputs:
+      command: build
+      projects: $(projectPath)
+      arguments: >
+        --configuration $(buildConfiguration)
+        -p:Version=$(RELEASE_VERSION)
+  - bash: >
+      dotnet pack
+      --no-build
+      --output "$(Build.ArtifactStagingDirectory)/packages"
+      --configuration $(buildConfiguration)
+      -p:Version=$(RELEASE_VERSION)
+      $(projectPath)
+    displayName: Create release nuget package
+  - bash: >
+      dotnet nuget push
+      $(Build.ArtifactStagingDirectory)/packages/*.nupkg
+      --api-key $(NugetApiKey)
+      --skip-duplicate
+      --source https://api.nuget.org/v3/index.json
+    displayName: Publish package to NuGet
+  - task: GitHubRelease@0
+    inputs:
+      action: create
+      target: $(Build.SourceVersion)
+      tagSource: manual
+      tag: v$(RELEASE_VERSION)
+      tagPattern: v$(RELEASE_VERSION)
+      title: v$(RELEASE_VERSION)
+      githubConnection: githubRelease
+      repositoryName: $(Build.Repository.Name)
+      addChangeLog: false
+      assets: $(Build.ArtifactStagingDirectory)/packages/*
+    displayName: Create Github Release

--- a/.azure-pipelines/release-pipeline.yml
+++ b/.azure-pipelines/release-pipeline.yml
@@ -59,6 +59,7 @@ steps:
       title: v$(RELEASE_VERSION)
       githubConnection: githubRelease
       repositoryName: $(Build.Repository.Name)
+      isPreRelease: $(IS_PRE_RELEASE)
       addChangeLog: false
       assets: $(Build.ArtifactStagingDirectory)/packages/*
     displayName: Create Github Release

--- a/.azure-pipelines/setVersionVariables.js
+++ b/.azure-pipelines/setVersionVariables.js
@@ -1,0 +1,34 @@
+const assert = require('assert').strict;
+
+const prefix = process.env['VERSION_PREFIX'];
+const suffix = process.env['VERSION_SUFFIX'];
+const ciSuffix = process.env['CI_VERSION_SUFFIX'];
+
+const prefixRegex = /[0-9]+\.[0-9]+\.[0-9]+/;
+const ciSuffixRegex = /ci\.[0-9]+\+git\.commit\.[0-9a-z]{40}/;
+
+assert.ok(prefix, "Version prefix is empty");
+assert.ok(ciSuffix, "CI version suffix is empty");
+assert.ok(prefixRegex.test(prefix), "Version prefix is invalid");
+assert.ok(ciSuffixRegex.test(ciSuffix), "CI version prefix is invalid");
+
+const releaseVersionCommand = createCommand(
+    'RELEASE_VERSION',
+    suffix && suffix.length > 0
+    ? `${prefix}-${suffix}`
+    : `${prefix}`
+);
+
+const ciVersionCommand = createCommand(
+    'CI_VERSION',
+    suffix && suffix.length > 0
+    ? `${prefix}-${suffix}.${ciSuffix}`
+    : `${prefix}-${ciSuffix}`
+);
+
+console.log(releaseVersionCommand);
+console.log(ciVersionCommand);
+
+function createCommand(key, value) {
+    return `##vso[task.setvariable variable=${key};]${value}`
+}

--- a/.azure-pipelines/setVersionVariables.js
+++ b/.azure-pipelines/setVersionVariables.js
@@ -26,8 +26,14 @@ const ciVersionCommand = createCommand(
     : `${prefix}-${ciSuffix}`
 );
 
+const isPreRelease = createCommand(
+    'IS_PRE_RELEASE',
+    suffix && suffix.length > 0 ? true : false
+);
+
 console.log(releaseVersionCommand);
 console.log(ciVersionCommand);
+console.log(isPreRelease);
 
 function createCommand(key, value) {
     return `##vso[task.setvariable variable=${key};]${value}`

--- a/.azure-pipelines/variables.yml
+++ b/.azure-pipelines/variables.yml
@@ -1,5 +1,11 @@
 variables:
   - group: Integration Tests Variables
+  - name: versionPrefix
+    value: 15.7.1
+  - name: versionSuffix
+    value: ""
+  - name: ciVersionSuffix
+    value: ci.$(Build.BuildId)+git.commit.$(Build.SourceVersion)
   - name: buildConfiguration
     value: Release
   - name: vmImage
@@ -8,8 +14,6 @@ variables:
     value: src/Telegram.Bot/Telegram.Bot.csproj
   - name: internalFeedName
     value: Telegram.Bot/Telegram.Bot
-  - name: ciVersionSuffix
-    value: ci.$(Build.BuildId)+git.commit.$(Build.SourceVersion)
   - name: unitTestsProject
     value: test/Telegram.Bot.Tests.Unit/Telegram.Bot.Tests.Unit.csproj
   - name: integrationTestsProject

--- a/src/Telegram.Bot/Telegram.Bot.csproj
+++ b/src/Telegram.Bot/Telegram.Bot.csproj
@@ -2,8 +2,6 @@
 
   <PropertyGroup>
     <TargetFrameworks>netstandard1.1;net45</TargetFrameworks>
-    <VersionPrefix>15.7.1</VersionPrefix>
-    <!--<VersionSuffix></VersionSuffix>-->
     <LangVersion>7.1</LangVersion>
     <GeneratePackageOnBuild>True</GeneratePackageOnBuild>
     <GenerateDocumentationFile>True</GenerateDocumentationFile>


### PR DESCRIPTION
Also an optional prerelease suffix is added. E.g. if an 5th alpha version of 16.1.0 version is to be released `versionSuffix` variable in `variables.yml` should be set to `alpha.5`. The resulting versions will be `16.1.0-alpha.5` for the release package and `16.1.0-alpha.5.ci.123+git.commit.b044f8ebafd963e683e505400d797ff133a386fe` for the CI build that goes into Azure Nuget feed.

I've had to resort to an external script that composes actual version strings as a commands for Azure agents due to lack of conditional variable declaration in Azure Pipelines yml format.