### PR TITLE
Remove defensive copying of status code

### DIFF
--- a/src/Telegram.Bot/Helpers/Extensions.cs
+++ b/src/Telegram.Bot/Helpers/Extensions.cs
@@ -1,8 +1,6 @@
 using System;
-using System.Diagnostics.CodeAnalysis;
 using System.IO;
 using System.Linq;
-using System.Net;
 using System.Net.Http;
 using System.Text;
 using System.Threading.Tasks;
@@ -67,8 +65,7 @@ namespace Telegram.Bot.Helpers
         /// </summary>
         /// <param name="stream"><see cref="Stream"/> with content</param>
         /// <typeparam name="T">Type of the resulting object</typeparam>
-        /// <returns></returns>
-        [return: MaybeNull]
+        /// <returns>Deserialized instance of <typeparam name="T" /> or <c>null</c></returns>
         private static T? DeserializeJsonFromStream<T>(this Stream stream)
             where T : class
         {
@@ -88,22 +85,23 @@ namespace Telegram.Bot.Helpers
         /// Deserialize body from HttpContent into <typeparamref name="T"/>
         /// </summary>
         /// <param name="httpResponse"><see cref="HttpResponseMessage"/> instance</param>
-        /// <param name="statusCode"><see cref="HttpStatusCode"/> of the response</param>
         /// <typeparam name="T">Type of the resulting object</typeparam>
         /// <returns></returns>
         /// <exception cref="RequestException">
         /// Thrown when body in the response can not be deserialized into <typeparamref name="T"/>
         /// </exception>
         internal static async Task<T> DeserializeContentAsync<T>(
-            this HttpResponseMessage httpResponse,
-            HttpStatusCode statusCode)
+            this HttpResponseMessage httpResponse)
             where T : class
         {
             T? deserializedObject;
             Stream? contentStream = null;
 
             if (httpResponse.Content is null)
-                throw new RequestException("Response doesn't contain any content", statusCode);
+                throw new RequestException(
+                    "Response doesn't contain any content",
+                    httpResponse.StatusCode
+                );
 
             try
             {
@@ -122,7 +120,7 @@ namespace Telegram.Bot.Helpers
 
                 throw new RequestException(
                     "Required properties not found in response.",
-                    statusCode,
+                    httpResponse.StatusCode,
                     stringifiedResponse,
                     exception
                 );
@@ -140,7 +138,7 @@ namespace Telegram.Bot.Helpers
 
                 throw new RequestException(
                     "Required properties not found in response.",
-                    statusCode,
+                    httpResponse.StatusCode,
                     stringifiedResponse
                 );
             }

--- a/src/Telegram.Bot/ITelegramBotClient.cs
+++ b/src/Telegram.Bot/ITelegramBotClient.cs
@@ -1,5 +1,6 @@
 using System;
 using System.IO;
+using System.Net.Http;
 using System.Threading;
 using System.Threading.Tasks;
 using Telegram.Bot.Args;
@@ -47,6 +48,10 @@ namespace Telegram.Bot
         /// <summary>
         /// Occurs after receiving the response to an API request
         /// </summary>
+        /// <remarks>
+        /// Don't mutate <see cref="HttpResponseMessage"/> received from <see cref="ApiResponseEventArgs"/>. If you
+        /// render it unserializable <see cref="RequestException"/> will be thrown.
+        /// </remarks>
         event EventHandler<ApiResponseEventArgs> ApiResponseReceived;
 
         #endregion Events

--- a/src/Telegram.Bot/TelegramBotClient.cs
+++ b/src/Telegram.Bot/TelegramBotClient.cs
@@ -143,10 +143,6 @@ namespace Telegram.Bot
 
             try
             {
-                // required since user might be able to set new status code using following
-                // event arg
-                var actualResponseStatusCode = httpResponse.StatusCode;
-
                 if (ApiResponseReceived != null)
                 {
                     requestEventArgs ??= new ApiRequestEventArgs(
@@ -160,12 +156,11 @@ namespace Telegram.Bot
                     ApiResponseReceived.Invoke(this, responseEventArgs);
                 }
 
-                if (actualResponseStatusCode != HttpStatusCode.OK)
+                if (httpResponse.StatusCode != HttpStatusCode.OK)
                 {
                     var failedApiResponse = await httpResponse
-                        .DeserializeContentAsync<FailedApiResponse>(
-                            actualResponseStatusCode
-                        ).ConfigureAwait(false);
+                        .DeserializeContentAsync<FailedApiResponse>()
+                        .ConfigureAwait(false);
 
                     throw ExceptionParser.Parse(
                         failedApiResponse.ErrorCode,
@@ -175,9 +170,8 @@ namespace Telegram.Bot
                 }
 
                 var successfulApiResponse = await httpResponse
-                    .DeserializeContentAsync<SuccessfulApiResponse<TResult>>(
-                        actualResponseStatusCode
-                    ).ConfigureAwait(false);
+                    .DeserializeContentAsync<SuccessfulApiResponse<TResult>>()
+                    .ConfigureAwait(false);
 
                 return successfulApiResponse.Result;
             }
@@ -240,9 +234,8 @@ namespace Telegram.Bot
                 }
 
                 var apiResponse = await httpResponse
-                    .DeserializeContentAsync<ApiResponse<TResult>>(
-                        actualResponseStatusCode
-                    ).ConfigureAwait(false);
+                    .DeserializeContentAsync<ApiResponse<TResult>>()
+                    .ConfigureAwait(false);
 
                 return apiResponse;
             }

--- a/src/Telegram.Bot/TelegramBotClient.cs
+++ b/src/Telegram.Bot/TelegramBotClient.cs
@@ -208,6 +208,15 @@ namespace Telegram.Bot
                 httpResponse = await _httpClient.SendAsync(httpRequest, cancellationToken)
                     .ConfigureAwait(false);
             }
+            catch (TaskCanceledException exception)
+            {
+                if (cancellationToken.IsCancellationRequested)
+                {
+                    throw;
+                }
+
+                throw new RequestException("Request timed out", exception);
+            }
             catch (Exception exception)
             {
                 throw new RequestException("Exception during making request", exception);
@@ -215,9 +224,6 @@ namespace Telegram.Bot
 
             try
             {
-                // required since user might be able to set new status code using following event arg
-                var actualResponseStatusCode = httpResponse.StatusCode;
-
                 if (ApiResponseReceived != null)
                 {
                     requestEventArgs ??= new ApiRequestEventArgs(

--- a/src/Telegram.Bot/TelegramBotClient.cs
+++ b/src/Telegram.Bot/TelegramBotClient.cs
@@ -103,8 +103,7 @@ namespace Telegram.Bot
             IRequest<TResult> request,
             CancellationToken cancellationToken = default)
         {
-            var url = _baseRequestUrl + request.MethodName;
-
+            var url = new Uri($"{_baseRequestUrl}{request.MethodName}", UriKind.Absolute);
             var httpRequest = new HttpRequestMessage(request.Method, url)
             {
                 Content = request.ToHttpContent()
@@ -186,8 +185,7 @@ namespace Telegram.Bot
             IRequest<TResult> request,
             CancellationToken cancellationToken = default)
         {
-            var url = _baseRequestUrl + request.MethodName;
-
+            var url = new Uri($"{_baseRequestUrl}{request.MethodName}", UriKind.Absolute);
             var httpRequest = new HttpRequestMessage(request.Method, url)
             {
                 Content = request.ToHttpContent()

--- a/src/Telegram.Bot/TelegramBotClient.cs
+++ b/src/Telegram.Bot/TelegramBotClient.cs
@@ -286,18 +286,16 @@ namespace Telegram.Bot
                 throw new ArgumentNullException(nameof(destination));
             }
 
-            var fileUri = new Uri($"{_baseFileUrl}{filePath}");
+            var fileUri = new Uri($"{_baseFileUrl}{filePath}", UriKind.Absolute);
 
-            var response = await _httpClient
+            using var response = await _httpClient
                 .GetAsync(fileUri, HttpCompletionOption.ResponseHeadersRead, cancellationToken)
                 .ConfigureAwait(false);
+
             response.EnsureSuccessStatusCode();
 
-            using (response)
-            {
-                await response.Content.CopyToAsync(destination)
-                    .ConfigureAwait(false);
-            }
+            await response.Content.CopyToAsync(destination)
+                .ConfigureAwait(false);
         }
 
         /// <inheritdoc />


### PR DESCRIPTION
Also in PR:
- Ensure the response is disposed in `DownloadFileAsync` in case of exception
- Handle `TaskCancelledException` in `SendRequestAsync`