### PR TITLE
Fix error handling for file downloads

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -65,6 +65,9 @@ except `TaskCancelledException` that is triggered by token cancellation and erro
 `MakingApiRequest` and `ApiResponseReceived` event handlers
 - Interface `IChatMessage` renamed into `IChatTargetable`
 - Requests with a property `long ChatId { get; }` explicitly implement `IChatTargetable`
+- Changed error handling in `DownloadFileAsync`: `ApiRequestException` will be thrown when 
+correct error response is received from Bot API, otherwise `RequestException` is thrown,
+`TaskCancelledException` is thrown when cancellation is requested 
 
 ### Removed
 - Enum member `ParseMode.Default`

--- a/src/Telegram.Bot/Exceptions/RequestException.cs
+++ b/src/Telegram.Bot/Exceptions/RequestException.cs
@@ -81,6 +81,25 @@ namespace Telegram.Bot.Exceptions
         /// <param name="httpStatusCode">
         /// <see cref="HttpStatusCode"/> of the received response
         /// </param>
+        /// <param name="innerException">
+        /// The exception that is the cause of the current exception, or a null reference
+        /// (Nothing in Visual Basic) if no inner exception is specified.
+        /// </param>
+        public RequestException(string message, HttpStatusCode httpStatusCode, Exception innerException)
+            : base(message, innerException)
+        {
+            HttpStatusCode = httpStatusCode;
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="RequestException"/> class.
+        /// </summary>
+        /// <param name="message">
+        /// The error message that explains the reason for the exception.
+        /// </param>
+        /// <param name="httpStatusCode">
+        /// <see cref="HttpStatusCode"/> of the received response
+        /// </param>
         /// <param name="body">Body of the received response</param>
         /// <param name="innerException">
         /// The exception that is the cause of the current exception, or a null reference

--- a/src/Telegram.Bot/Helpers/Extensions.cs
+++ b/src/Telegram.Bot/Helpers/Extensions.cs
@@ -85,13 +85,17 @@ namespace Telegram.Bot.Helpers
         /// Deserialize body from HttpContent into <typeparamref name="T"/>
         /// </summary>
         /// <param name="httpResponse"><see cref="HttpResponseMessage"/> instance</param>
+        /// <param name="includeBody">
+        /// Specifies if stringified body should be included in <see cref="RequestException"/>
+        /// </param>
         /// <typeparam name="T">Type of the resulting object</typeparam>
         /// <returns></returns>
         /// <exception cref="RequestException">
         /// Thrown when body in the response can not be deserialized into <typeparamref name="T"/>
         /// </exception>
         internal static async Task<T> DeserializeContentAsync<T>(
-            this HttpResponseMessage httpResponse)
+            this HttpResponseMessage httpResponse,
+            bool includeBody = true)
             where T : class
         {
             T? deserializedObject;
@@ -114,16 +118,27 @@ namespace Telegram.Bot.Helpers
             }
             catch (Exception exception)
             {
-                var stringifiedResponse = await httpResponse.Content
-                    .ReadAsStringAsync()
-                    .ConfigureAwait(false);
+                if (includeBody)
+                {
+                    var stringifiedResponse = await httpResponse.Content
+                        .ReadAsStringAsync()
+                        .ConfigureAwait(false);
 
-                throw new RequestException(
-                    "Required properties not found in response.",
-                    httpResponse.StatusCode,
-                    stringifiedResponse,
-                    exception
-                );
+                    throw new RequestException(
+                        "Required properties not found in response.",
+                        httpResponse.StatusCode,
+                        stringifiedResponse,
+                        exception
+                    );
+                }
+                else
+                {
+                    throw new RequestException(
+                        "Required properties not found in response.",
+                        httpResponse.StatusCode,
+                        exception
+                    );
+                }
             }
             finally
             {

--- a/src/Telegram.Bot/ITelegramBotClient.cs
+++ b/src/Telegram.Bot/ITelegramBotClient.cs
@@ -114,6 +114,18 @@ namespace Telegram.Bot
         /// <param name="filePath">Path to file on server</param>
         /// <param name="destination">Destination stream to write file to</param>
         /// <param name="cancellationToken">The cancellation token to cancel operation</param>
+        /// <exception cref="ArgumentException">
+        /// Thrown when <paramref name="filePath"/> is null or invalid
+        /// </exception>
+        /// <exception cref="ArgumentNullException">
+        /// Thrown when <paramref name="destination"/> is <c>null</c>
+        /// </exception>
+        /// <exception cref="RequestException">
+        /// Thrown when response is not successful
+        /// </exception>
+        /// <exception cref="TaskCanceledException">
+        /// Thrown when cancellation is requested
+        /// </exception>
         Task DownloadFileAsync(
             string filePath,
             Stream destination,
@@ -129,6 +141,21 @@ namespace Telegram.Bot
         /// of cancellation.
         /// </param>
         /// <returns>File info</returns>
+        /// <exception cref="ArgumentException">
+        /// Thrown when file path received from Bot API is <c>null</c> or invalid
+        /// </exception>
+        /// <exception cref="ArgumentNullException">
+        /// Thrown when <paramref name="destination"/> is <c>null</c>
+        /// </exception>
+        /// <exception cref="ApiRequestException">
+        /// Thrown when the response contains a valid JSON string with an error and description
+        /// </exception>
+        /// <exception cref="RequestException">
+        /// Thrown when the response is not successful
+        /// </exception>
+        /// <exception cref="TaskCanceledException">
+        /// Thrown when cancellation is requested
+        /// </exception>
         Task<File> GetInfoAndDownloadFileAsync(
             string fileId,
             Stream destination,

--- a/src/Telegram.Bot/ITelegramBotClient.cs
+++ b/src/Telegram.Bot/ITelegramBotClient.cs
@@ -120,6 +120,9 @@ namespace Telegram.Bot
         /// <exception cref="ArgumentNullException">
         /// Thrown when <paramref name="destination"/> is <c>null</c>
         /// </exception>
+        /// <exception cref="ApiRequestException">
+        /// Thrown when error response contains a valid JSON string with an error and description
+        /// </exception>
         /// <exception cref="RequestException">
         /// Thrown when response is not successful
         /// </exception>
@@ -148,7 +151,7 @@ namespace Telegram.Bot
         /// Thrown when <paramref name="destination"/> is <c>null</c>
         /// </exception>
         /// <exception cref="ApiRequestException">
-        /// Thrown when the response contains a valid JSON string with an error and description
+        /// Thrown when error response contains a valid JSON string with an error and description
         /// </exception>
         /// <exception cref="RequestException">
         /// Thrown when the response is not successful

--- a/src/Telegram.Bot/TelegramBotClient.cs
+++ b/src/Telegram.Bot/TelegramBotClient.cs
@@ -288,26 +288,11 @@ namespace Telegram.Bot
 
             var fileUri = new Uri($"{_baseFileUrl}{filePath}", UriKind.Absolute);
 
+            HttpResponseMessage? httpResponse;
             try
             {
-                using var httpResponse = await _httpClient
+                httpResponse = await _httpClient
                     .GetAsync(fileUri, HttpCompletionOption.ResponseHeadersRead, cancellationToken)
-                    .ConfigureAwait(false);
-
-                if (!httpResponse.IsSuccessStatusCode)
-                {
-                    var failedApiResponse = await httpResponse
-                        .DeserializeContentAsync<FailedApiResponse>(includeBody: false)
-                        .ConfigureAwait(false);
-
-                    throw ExceptionParser.Parse(
-                        failedApiResponse.ErrorCode,
-                        failedApiResponse.Description,
-                        failedApiResponse.Parameters
-                    );
-                }
-
-                await httpResponse.Content.CopyToAsync(destination)
                     .ConfigureAwait(false);
             }
             catch (TaskCanceledException exception)
@@ -322,6 +307,46 @@ namespace Telegram.Bot
             catch (Exception exception)
             {
                 throw new RequestException("Exception during file download", exception);
+            }
+
+            try
+            {
+                if (!httpResponse.IsSuccessStatusCode)
+                {
+                    var failedApiResponse = await httpResponse
+                        .DeserializeContentAsync<FailedApiResponse>(includeBody: false)
+                        .ConfigureAwait(false);
+
+                    throw ExceptionParser.Parse(
+                        failedApiResponse.ErrorCode,
+                        failedApiResponse.Description,
+                        failedApiResponse.Parameters
+                    );
+                }
+
+                if (httpResponse.Content is null)
+                    throw new RequestException(
+                        "Response doesn't contain any content",
+                        httpResponse.StatusCode
+                    );
+
+                try
+                {
+                    await httpResponse.Content.CopyToAsync(destination)
+                        .ConfigureAwait(false);
+                }
+                catch (Exception exception)
+                {
+                    throw new RequestException(
+                        "Exception during file download",
+                        httpResponse.StatusCode,
+                        exception
+                    );
+                }
+            }
+            finally
+            {
+                httpResponse?.Dispose();
             }
         }
 

--- a/src/Telegram.Bot/TelegramBotClient.cs
+++ b/src/Telegram.Bot/TelegramBotClient.cs
@@ -296,10 +296,15 @@ namespace Telegram.Bot
 
                 if (!httpResponse.IsSuccessStatusCode)
                 {
-                    var body = await httpResponse.Content.ReadAsStringAsync()
+                    var failedApiResponse = await httpResponse
+                        .DeserializeContentAsync<FailedApiResponse>(includeBody: false)
                         .ConfigureAwait(false);
 
-                    throw new RequestException("Resulting response is unsuccessful", httpResponse.StatusCode, body);
+                    throw ExceptionParser.Parse(
+                        failedApiResponse.ErrorCode,
+                        failedApiResponse.Description,
+                        failedApiResponse.Parameters
+                    );
                 }
 
                 await httpResponse.Content.CopyToAsync(destination)

--- a/test/Telegram.Bot.Tests.Integ/Other/FileDownloadTests.cs
+++ b/test/Telegram.Bot.Tests.Integ/Other/FileDownloadTests.cs
@@ -1,5 +1,4 @@
 using System.IO;
-using System.Net.Http;
 using System.Threading.Tasks;
 using Newtonsoft.Json.Linq;
 using Telegram.Bot.Exceptions;
@@ -123,24 +122,29 @@ namespace Telegram.Bot.Tests.Integ.Other
             Assert.Contains("file_id", exception.Message);
         }
 
-        [OrderedFact("Should throw HttpRequestException while trying to download file using wrong file_path")]
+        [OrderedFact("Should throw RequestException with ApiRequestException inner exception " +
+            "while trying to download file using wrong file_path")]
         public async Task Should_Throw_FilePath_HttpRequestException()
         {
             await using MemoryStream destinationStream = new MemoryStream();
 
-            HttpRequestException exception = await Assert.ThrowsAnyAsync<HttpRequestException>(
-                async () =>
-                {
-                    await BotClient.DownloadFileAsync(
-                        filePath: "Invalid_File_Path",
-                        destination: destinationStream
-                    );
-                }
+            RequestException exception = await Assert.ThrowsAnyAsync<RequestException>(
+                () => BotClient.DownloadFileAsync(
+                    filePath: "Invalid_File_Path",
+                    destination: destinationStream
+                )
             );
+            ApiRequestException innerException = (ApiRequestException)exception.InnerException;
 
             Assert.Equal(0, destinationStream.Length);
             Assert.Equal(0, destinationStream.Position);
-            Assert.Contains("404", exception.Message);
+
+            Assert.IsType<RequestException>(exception);
+            Assert.Contains("Exception during file download", exception.Message);
+
+            Assert.IsType<ApiRequestException>(innerException);
+            Assert.Equal(404, innerException.ErrorCode);
+            Assert.Contains("Not Found", innerException.Message);
         }
 
         public class Fixture

--- a/test/Telegram.Bot.Tests.Integ/Other/FileDownloadTests.cs
+++ b/test/Telegram.Bot.Tests.Integ/Other/FileDownloadTests.cs
@@ -122,29 +122,23 @@ namespace Telegram.Bot.Tests.Integ.Other
             Assert.Contains("file_id", exception.Message);
         }
 
-        [OrderedFact("Should throw RequestException with ApiRequestException inner exception " +
-            "while trying to download file using wrong file_path")]
+        [OrderedFact("Should throw ApiRequestException while trying to download file using wrong file_path")]
         public async Task Should_Throw_FilePath_HttpRequestException()
         {
             await using MemoryStream destinationStream = new MemoryStream();
 
-            RequestException exception = await Assert.ThrowsAnyAsync<RequestException>(
+            ApiRequestException exception = await Assert.ThrowsAnyAsync<ApiRequestException>(
                 () => BotClient.DownloadFileAsync(
                     filePath: "Invalid_File_Path",
                     destination: destinationStream
                 )
             );
-            ApiRequestException innerException = (ApiRequestException)exception.InnerException;
 
             Assert.Equal(0, destinationStream.Length);
             Assert.Equal(0, destinationStream.Position);
 
-            Assert.IsType<RequestException>(exception);
-            Assert.Contains("Exception during file download", exception.Message);
-
-            Assert.IsType<ApiRequestException>(innerException);
-            Assert.Equal(404, innerException.ErrorCode);
-            Assert.Contains("Not Found", innerException.Message);
+            Assert.Equal(404, exception.ErrorCode);
+            Assert.Contains("Not Found", exception.Message);
         }
 
         public class Fixture

--- a/test/Telegram.Bot.Tests.Unit/FileDownloadExceptionsTests.cs
+++ b/test/Telegram.Bot.Tests.Unit/FileDownloadExceptionsTests.cs
@@ -1,0 +1,161 @@
+using System.IO;
+using System.Net;
+using System.Net.Http;
+using System.Threading;
+using System.Threading.Tasks;
+using Newtonsoft.Json;
+using Telegram.Bot.Exceptions;
+using Xunit;
+
+namespace Telegram.Bot.Tests.Unit
+{
+    public class FileDownloadExceptionsTests
+    {
+        [Fact]
+        public async Task Should_Throw_RequestException_On_Incorrect_Proxy()
+        {
+            var httpClientHandler = new HttpClientHandler
+            {
+                Proxy = new WebProxy("http://proxy.test")
+            };
+            var httpClient = new HttpClient(httpClientHandler);
+            var botClient = new TelegramBotClient(
+                "1234567:4TT8bAc8GHUspu3ERYn-KGcvsvGB9u_n4ddy",
+                httpClient
+            );
+
+            await using var memoryStream = new MemoryStream();
+
+            var requestException =  await Assert.ThrowsAsync<RequestException>(
+                async () => await botClient.DownloadFileAsync("file/path", memoryStream)
+            );
+
+            Assert.Null(requestException.HttpStatusCode);
+            Assert.Null(requestException.Body);
+            Assert.Equal("Exception during file download", requestException.Message);
+            Assert.Equal(0, memoryStream.Length);
+            Assert.Equal(0, memoryStream.Position);
+
+            Assert.NotNull(requestException.InnerException);
+            Assert.IsType<HttpRequestException>(requestException.InnerException);
+        }
+
+        [Fact]
+        public async Task Should_Throw_TaskCancelledException_On_Cancelled_Token()
+        {
+            var botClient = new TelegramBotClient("1234567:4TT8bAc8GHUspu3ERYn-KGcvsvGB9u_n4ddy");
+
+            using var cts = new CancellationTokenSource();
+            var token = cts.Token;
+            cts.Cancel();
+
+            await using var memoryStream = new MemoryStream();
+
+            await Assert.ThrowsAsync<TaskCanceledException>(
+                async () => await botClient.DownloadFileAsync("file/path", memoryStream, cancellationToken: token)
+            );
+
+            Assert.Equal(0, memoryStream.Length);
+            Assert.Equal(0, memoryStream.Position);
+        }
+
+        [Fact]
+        public async Task Should_Throw_RequestException_On_Timed_Out_Request()
+        {
+            var httpClientHandler = new MockHttpMessageHandler(
+                _ => throw new TaskCanceledException()
+            );
+            var httpClient = new HttpClient(httpClientHandler);
+            var botClient = new TelegramBotClient(
+                "1234567:4TT8bAc8GHUspu3ERYn-KGcvsvGB9u_n4ddy",
+                httpClient
+            );
+
+            await using var memoryStream = new MemoryStream();
+
+            var requestException = await Assert.ThrowsAsync<RequestException>(
+                async () => await botClient.DownloadFileAsync("file/path", memoryStream)
+            );
+
+            Assert.NotNull(requestException.InnerException);
+            Assert.IsType<TaskCanceledException>(requestException.InnerException);
+            Assert.Equal("Request timed out", requestException.Message);
+            Assert.Equal(0, memoryStream.Length);
+            Assert.Equal(0, memoryStream.Position);
+        }
+
+        [Fact]
+        public async Task Should_Throw_RequestException_With_Null_Response_Content()
+        {
+            var httpClientHandler = new MockHttpMessageHandler(HttpStatusCode.OK);
+            var httpClient = new HttpClient(httpClientHandler);
+
+            var botClient = new TelegramBotClient(
+                "1234567:4TT8bAc8GHUspu3ERYn-KGcvsvGB9u_n4ddy",
+                httpClient
+            );
+
+            await using var memoryStream = new MemoryStream();
+
+            var requestException = await Assert.ThrowsAsync<RequestException>(
+                async () => await botClient.DownloadFileAsync("file/path", memoryStream)
+            );
+
+            Assert.Equal(HttpStatusCode.OK, requestException.HttpStatusCode);
+            Assert.Null(requestException.Body);
+            Assert.NotNull(requestException.Message);
+            Assert.Equal("Response doesn't contain any content", requestException.Message);
+            Assert.Null(requestException.InnerException);
+        }
+
+        [Fact]
+        public async Task Should_Throw_RequestException_With_JsonSerializationException_On_Failed_Response()
+        {
+            var httpClientHandler = new MockHttpMessageHandler(
+                HttpStatusCode.NotFound,
+                new StringContent("{}")
+            );
+
+            var httpClient = new HttpClient(httpClientHandler);
+            var botClient = new TelegramBotClient(
+                "1234567:4TT8bAc8GHUspu3ERYn-KGcvsvGB9u_n4ddy",
+                httpClient
+            );
+
+            await using var memoryStream = new MemoryStream();
+
+            var requestException = await Assert.ThrowsAsync<RequestException>(
+                async () => await botClient.DownloadFileAsync("file/path", memoryStream)
+            );
+
+            Assert.Equal(HttpStatusCode.NotFound, requestException.HttpStatusCode);
+            Assert.Null(requestException.Body);
+            Assert.Null(requestException.Body);
+
+            Assert.NotNull(requestException.InnerException);
+            Assert.IsType<JsonSerializationException>(requestException.InnerException);
+        }
+
+        [Fact]
+        public async Task Should_Throw_ApiRequestException_With_JsonSerializationException_On_Failed_Response()
+        {
+            var httpClientHandler = new MockHttpMessageHandler(
+                HttpStatusCode.NotFound,
+                new StringContent(@"{""ok"":false,""description"":""Not Found"",""error_code"":404}")
+            );
+
+            var httpClient = new HttpClient(httpClientHandler);
+            var botClient = new TelegramBotClient(
+                "1234567:4TT8bAc8GHUspu3ERYn-KGcvsvGB9u_n4ddy",
+                httpClient
+            );
+
+            var apiRequestException =  await Assert.ThrowsAsync<ApiRequestException>(
+                async () => await botClient.GetUpdatesAsync()
+            );
+
+            Assert.Equal(404, apiRequestException.ErrorCode);
+            Assert.Equal("Not Found", apiRequestException.Message);
+        }
+    }
+}

--- a/test/Telegram.Bot.Tests.Unit/RequestExceptionsTests.cs
+++ b/test/Telegram.Bot.Tests.Unit/RequestExceptionsTests.cs
@@ -1,4 +1,3 @@
-using System;
 using System.Net;
 using System.Net.Http;
 using System.Threading;
@@ -10,7 +9,7 @@ using Xunit;
 
 namespace Telegram.Bot.Tests.Unit
 {
-    public class BotClientTests
+    public class RequestExceptionsTests
     {
         [Fact]
         public async Task Should_Throw_RequestException_On_Incorrect_Proxy()


### PR DESCRIPTION
This PR changes how errors are handled for file downloads:
- Since Bot API returns correct error message on invalid file paths the client first tries to deserialize `FailedApiResonse` from the response to construct `ApiRequestException`
- If deserialization is unsuccessful it skips reading the response body and throws `RequestException` including only `HttpStatusCode` inside because `HttpCompletionOption.ResponseHeadersRead` option is used and the response body can't be read again
- Token cancellation is accompanied by `TaskCanceledException `
- Timeout exception and every other error is wrapped inside `RequestException`