### PR TITLE
Add unit test for TelegramBotClient.StartReceiving

### DIFF
--- a/test/Telegram.Bot.Tests.Unit/StartReceivingTests.cs
+++ b/test/Telegram.Bot.Tests.Unit/StartReceivingTests.cs
@@ -1,0 +1,24 @@
+using System.Threading;
+using Xunit;
+
+namespace Telegram.Bot.Tests.Unit
+{
+    public class StartReceivingTests
+    {
+        [Fact]
+        public void Should_Not_ReceiveUpdates_On_CancelledToken()
+        {
+            // Arrange
+            var botClient = new TelegramBotClient("1234567:4TT8bAc8GHUspu3ERYn-KGcvsvGB9u_n4ddy");
+            var tokenSource = new CancellationTokenSource();
+
+            tokenSource.Cancel();
+
+            // Act
+            botClient.StartReceiving(cancellationToken: tokenSource.Token);
+
+            // Assert
+            Assert.False(botClient.IsReceiving);
+        }
+    }
+}


### PR DESCRIPTION
Add test for when StartReceiving method is called with a cancelled Token passed as an argument.