### PR TITLE
Add unit test for TelegramBotClient.StartReceiving

### DIFF
--- a/test/Telegram.Bot.Tests.Unit/Framework/RequestCounterHttpClientHandler.cs
+++ b/test/Telegram.Bot.Tests.Unit/Framework/RequestCounterHttpClientHandler.cs
@@ -1,0 +1,27 @@
+using System.Net;
+using System.Net.Http;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Telegram.Bot.Tests.Unit.Framework
+{
+    internal class RequestCounterHttpClientHandler : HttpClientHandler
+    {
+        public int RequestCounter { get; private set; }
+
+        protected override Task<HttpResponseMessage> SendAsync(
+            HttpRequestMessage request,
+            CancellationToken cancellationToken)
+        {
+            RequestCounter++;
+
+            var httpResponseMessage = new HttpResponseMessage()
+            {
+                Content = new StringContent("{ \"ok\": true, \"result\": []}"),
+                StatusCode = HttpStatusCode.OK
+            };
+
+            return Task.FromResult(httpResponseMessage);
+        }
+    }
+}

--- a/test/Telegram.Bot.Tests.Unit/StartReceivingTests.cs
+++ b/test/Telegram.Bot.Tests.Unit/StartReceivingTests.cs
@@ -1,4 +1,7 @@
+using System.Net.Http;
 using System.Threading;
+using System.Threading.Tasks;
+using Telegram.Bot.Tests.Unit.Framework;
 using Xunit;
 
 namespace Telegram.Bot.Tests.Unit
@@ -9,7 +12,8 @@ namespace Telegram.Bot.Tests.Unit
         public void Should_Not_ReceiveUpdates_On_CancelledToken()
         {
             // Arrange
-            var botClient = new TelegramBotClient("1234567:4TT8bAc8GHUspu3ERYn-KGcvsvGB9u_n4ddy");
+            var httpClientCounter = new RequestCounterHttpClientHandler();
+            var botClient = new TelegramBotClient("1234567:4TT8bAc8GHUspu3ERYn-KGcvsvGB9u_n4ddy", new HttpClient(httpClientCounter));
             var tokenSource = new CancellationTokenSource();
 
             tokenSource.Cancel();
@@ -19,6 +23,24 @@ namespace Telegram.Bot.Tests.Unit
 
             // Assert
             Assert.False(botClient.IsReceiving);
+            Assert.Equal(0, httpClientCounter.RequestCounter);
+        }
+
+        [Fact]
+        public async Task Should_ReceiveUpdates_On_ActiveToken()
+        {
+            // Arrange
+            var httpClientCounter = new RequestCounterHttpClientHandler();
+            var botClient = new TelegramBotClient("1234567:4TT8bAc8GHUspu3ERYn-KGcvsvGB9u_n4ddy", new HttpClient(httpClientCounter));
+            var tokenSource = new CancellationTokenSource();
+
+            // Act
+            var cancelTokenTask = Task.Delay(500).ContinueWith((t) => tokenSource.Cancel()); // Cancel Token after 500ms
+            botClient.StartReceiving(cancellationToken: tokenSource.Token);
+            await cancelTokenTask;
+
+            // Assert
+            Assert.NotEqual(0, httpClientCounter.RequestCounter);
         }
     }
 }

--- a/test/Telegram.Bot.Tests.Unit/StartReceivingTests.cs
+++ b/test/Telegram.Bot.Tests.Unit/StartReceivingTests.cs
@@ -1,0 +1,24 @@
+using System.Threading;
+using Xunit;
+
+namespace Telegram.Bot.Tests.Unit
+{
+    public class StartReceivingTests
+    {
+        [Fact]
+        public void Should_Not_ReceiveUpdates_On_CancelledToken()
+        {
+            // Arrange
+            var botClient = new TelegramBotClient("1234567:4TT8bAc8GHUspu3ERYn-KGcvsvGB9u_n4ddy");
+            var tokenSource = new CancellationTokenSource();
+
+            tokenSource.Cancel();
+
+            // Act
+            botClient.StartReceiving(cancellationToken: tokenSource.Token);
+
+            // Assert
+            Assert.False(botClient.IsReceiving);
+        }
+    }
+}


### PR DESCRIPTION
Add test for when StartReceiving method is called with a cancelled Token passed as an argument.