### PR TITLE
ChatId changes

### DIFF
--- a/src/Telegram.Bot/Types/ChatId.cs
+++ b/src/Telegram.Bot/Types/ChatId.cs
@@ -1,4 +1,5 @@
-﻿using Newtonsoft.Json;
+﻿using System;
+using Newtonsoft.Json;
 using Telegram.Bot.Converters;
 
 namespace Telegram.Bot.Types
@@ -41,19 +42,20 @@ namespace Telegram.Bot.Types
         /// Create a <see cref="ChatId"/> using an user name
         /// </summary>
         /// <param name="username">The user name</param>
+        /// <exception cref="ArgumentException">Thrown when string value isn`t number and doesn't start with @</exception>
         public ChatId(string username)
         {
-            if (username.Length > 1 && username.Substring(0, 1) == "@")
+            if (username.Length > 1 && username.StartsWith("@"))
             {
                 Username = username;
-            }
-            else if (int.TryParse(username, out int chatId))
-            {
-                Identifier = chatId;
             }
             else if (long.TryParse(username, out long identifier))
             {
                 Identifier = identifier;
+            }
+            else
+            {
+                throw new ArgumentException($"Username value should be Identifier or Username that starts with @");
             }
         }
 

--- a/src/Telegram.Bot/Types/ChatId.cs
+++ b/src/Telegram.Bot/Types/ChatId.cs
@@ -64,10 +64,18 @@ namespace Telegram.Bot.Types
         /// </summary>
         /// <param name="obj">The object to compare with the current object.</param>
         /// <returns>true if the specified object is equal to the current object; otherwise, false.</returns>
-        public override bool Equals(object obj) => ((string)this).Equals(obj);
+        public override bool Equals(object obj)
+        {
+            if (obj is ChatId chatId)
+            {
+                return this == chatId;
+            }
+
+            return ((string) this).Equals(obj?.ToString());
+        }
 
         /// <summary>
-        /// Gets the hash code of this object 
+        /// Gets the hash code of this object
         /// </summary>
         /// <returns>A hash code for the current object.</returns>
         public override int GetHashCode() => ((string)this).GetHashCode();
@@ -101,6 +109,39 @@ namespace Telegram.Bot.Types
         /// </summary>
         /// <param name="chatid">The <see cref="ChatId"/>The ChatId</param>
         public static implicit operator string(ChatId chatid) => chatid.Username ?? chatid.Identifier.ToString();
+
+        /// <summary>
+        /// Compares 2 ChatId objects
+        /// </summary>
+        public static bool operator ==(ChatId obj1, ChatId obj2)
+        {
+            if (ReferenceEquals(obj1, obj2))
+            {
+                return true;
+            }
+            if (ReferenceEquals(obj1, null) || ReferenceEquals(obj2, null))
+            {
+                return false;
+            }
+
+            // checking by Identifier is more consistent but we should check that its value isn`t default
+            if (obj1.Identifier != 0)
+            {
+                return obj1.Identifier == obj2.Identifier || obj1.Username == obj2.Username;
+            }
+            return obj1.Identifier == obj2.Identifier && obj1.Username == obj2.Username;
+        }
+
+        /// <summary>
+        /// Compares 2 ChatId objects
+        /// </summary>
+        /// <param name="obj1"></param>
+        /// <param name="obj2"></param>
+        /// <returns></returns>
+        public static bool operator !=(ChatId obj1, ChatId obj2)
+        {
+            return !(obj1 == obj2);
+        }
 
         /// <summary>
         /// Convert a Chat Object to a <see cref="ChatId"/>

--- a/test/Telegram.Bot.Tests.Unit/ChatIdTests.cs
+++ b/test/Telegram.Bot.Tests.Unit/ChatIdTests.cs
@@ -1,0 +1,82 @@
+using System;
+using Telegram.Bot.Types;
+using Xunit;
+
+namespace Telegram.Bot.Tests.Unit
+{
+    public class ChatIdTests
+    {
+        [Fact]
+        public void Check_Constructor()
+        {
+            var chatId = new ChatId(123);
+
+            //check int & long
+            Assert.Null(chatId.Username);
+            Assert.Equal(123, chatId.Identifier);
+
+            chatId = new ChatId(123L);
+            Assert.Null(chatId.Username);
+            Assert.Equal(123L, chatId.Identifier);
+
+            // check string values
+            chatId = new ChatId(123.ToString());
+            Assert.Null(chatId.Username);
+            Assert.Equal(123, chatId.Identifier);
+
+            chatId = new ChatId(123L.ToString());
+            Assert.Null(chatId.Username);
+            Assert.Equal(123L, chatId.Identifier);
+
+            chatId = new ChatId("@valid_username");
+            Assert.Equal("@valid_username", chatId.Username);
+            Assert.Equal(0, chatId.Identifier);
+
+            Assert.Throws<ArgumentException>(() => new ChatId("username"));
+        }
+
+
+        [Fact]
+        public void Should_ToString()
+        {
+            //int
+            Assert.Equal("123", new ChatId("123").ToString());
+            Assert.Equal("123", new ChatId(123).ToString());
+
+            //long
+            Assert.Equal("123456789012", new ChatId((123456789012)).ToString());
+            Assert.Equal("123456789012", new ChatId("123456789012").ToString());
+
+            //username
+            Assert.Equal("@valid_username", new ChatId("@valid_username").ToString());
+        }
+
+        [Fact]
+        public void Equals_Test()
+        {
+            //with Identifier
+            var chatId = new ChatId(123);
+            Assert.True(chatId.Equals(123));
+            Assert.False(123.Equals(chatId)); // to be aware
+            Assert.True(chatId == 123);
+            Assert.True(123 == chatId);
+
+            chatId = new ChatId("123");
+            Assert.True(chatId.Equals(123));
+            Assert.False(123.Equals(chatId)); // to be aware
+            Assert.True(chatId == 123);
+            Assert.True(123 == chatId);
+
+            //with username
+            chatId = new ChatId("@username");
+            Assert.True(chatId.Equals("@username"));
+            Assert.True("@username".Equals(chatId));
+            Assert.True(chatId == "@username");
+            Assert.True("@username" == chatId);
+
+            //with other ChatId
+            Assert.Equal(chatId, chatId);
+            Assert.Equal(new ChatId(123), new ChatId(123));
+        }
+    }
+}

--- a/test/Telegram.Bot.Tests.Unit/UserTests.cs
+++ b/test/Telegram.Bot.Tests.Unit/UserTests.cs
@@ -11,6 +11,7 @@ namespace Telegram.Bot.Tests.Unit
         [Fact]
         public void Should_ToString()
         {
+            Assert.Equal("111", new ChatId(111));
             Assert.Equal("@alicebot (12345)", new User
             {
                 Id = 12345,


### PR DESCRIPTION
### ChatId comparison
Fixes inconsistent ChatId comparison with different types and between two identical ChatId objects.
For example before:

`Assert.NotEqual(new ChatId(123), new ChatId(123));
Assert.Equal(new ChatId(123), "123" );
Assert.NotEqual(new ChatId(123), 123);`

Now it is more consistent, full list in tests: ChatIdTests.cs

Implemented == operator

### ChatId constructor (possible breaking change)
previously constructor new ChatId("username") produced default object where
chatId.Username == null and chatId.Identifier == 0
which is really unobvious and could result various bugs in comparing.

Now it 
`throw new ArgumentException($"Username value should be Identifier or Username that starts with @");`
 I`ve done most of Integ tests and haven`t found any issues... 