### PR TITLE
Add parameters support for library methods

### DIFF
--- a/src/Telegram.Bot/ITelegramBotClient.cs
+++ b/src/Telegram.Bot/ITelegramBotClient.cs
@@ -5,6 +5,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using Telegram.Bot.Args;
 using Telegram.Bot.Requests.Abstractions;
+using Telegram.Bot.Requests.Parameters;
 using Telegram.Bot.Types;
 using Telegram.Bot.Types.Enums;
 using Telegram.Bot.Types.InlineQueryResults;
@@ -1717,6 +1718,725 @@ namespace Telegram.Bot
         /// <see href="https://core.telegram.org/bots/api#deletechatstickerset"/>
         Task DeleteChatStickerSetAsync(
             ChatId chatId,
+            CancellationToken cancellationToken = default);
+
+        #endregion
+
+        #region Methods with parameters support
+
+  /// <summary>
+        ///     Send a request to Bot API
+        /// </summary>
+        /// <param name="makeRequestParameters">Request parameters.</param>
+        /// <param name="cancellationToken">A cancellation token that can be used by other objects or threads to receive notice of cancellation.</param>
+        Task<TResponse> MakeRequestAsync<TResponse>(MakeRequestParameters<TResponse> makeRequestParameters,
+            CancellationToken cancellationToken = default);
+
+        /// <summary>
+        ///     Start update receiving
+        /// </summary>
+        /// <param name="startReceivingParameters">Request parameters.</param>
+        /// <param name="cancellationToken">A cancellation token that can be used by other objects or threads to receive notice of cancellation.</param>
+        void StartReceiving(StartReceivingParameters startReceivingParameters,
+            CancellationToken cancellationToken = default);
+
+        /// <summary>
+        ///     Use this method to receive incoming updates using long polling (wiki).
+        /// </summary>
+        /// <param name="getUpdatesParameters">Request parameters.</param>
+        /// <param name="cancellationToken">A cancellation token that can be used by other objects or threads to receive notice of cancellation.</param>
+        Task<Update[]> GetUpdatesAsync(GetUpdatesParameters getUpdatesParameters,
+            CancellationToken cancellationToken = default);
+
+        /// <summary>
+        ///     Use this method to specify a url and receive incoming updates via an outgoing webhook.
+        ///     Whenever there is an <see cref="Update" /> for the bot, we will send an HTTPS POST request to the specified url,
+        ///     containing a JSON-serialized Update. In case of an unsuccessful request, we will give up after a reasonable
+        ///     amount of attempts.
+        ///     If you'd like to make sure that the Webhook request comes from Telegram, we recommend using a secret path
+        ///     in the URL, e.g. https://www.example.com/&lt;token&gt;. Since nobody else knows your bot's token, you can be
+        ///     pretty sure it's us.
+        /// </summary>
+        /// <param name="setWebhookParameters">Request parameters.</param>
+        /// <param name="cancellationToken">A cancellation token that can be used by other objects or threads to receive notice of cancellation.</param>
+        Task SetWebhookAsync(SetWebhookParameters setWebhookParameters, CancellationToken cancellationToken = default);
+
+        /// <summary>
+        ///     Use this method to send text messages. On success, the sent Description is returned.
+        /// </summary>
+        /// <param name="sendTextMessageParameters">Request parameters.</param>
+        /// <param name="cancellationToken">A cancellation token that can be used by other objects or threads to receive notice of cancellation.</param>
+        Task<Message> SendTextMessageAsync(SendTextMessageParameters sendTextMessageParameters,
+            CancellationToken cancellationToken = default);
+
+        /// <summary>
+        ///     Use this method to forward messages of any kind. On success, the sent Description is returned.
+        /// </summary>
+        /// <param name="forwardMessageParameters">Request parameters.</param>
+        /// <param name="cancellationToken">A cancellation token that can be used by other objects or threads to receive notice of cancellation.</param>
+        Task<Message> ForwardMessageAsync(ForwardMessageParameters forwardMessageParameters,
+            CancellationToken cancellationToken = default);
+
+        /// <summary>
+        ///     Use this method to send photos. On success, the sent Description is returned.
+        /// </summary>
+        /// <param name="sendPhotoParameters">Request parameters.</param>
+        /// <param name="cancellationToken">A cancellation token that can be used by other objects or threads to receive notice of cancellation.</param>
+        Task<Message> SendPhotoAsync(SendPhotoParameters sendPhotoParameters,
+            CancellationToken cancellationToken = default);
+
+        /// <summary>
+        ///     Use this method to send audio files, if you want Telegram clients to display them in the music player. Your
+        ///     audio must be in the .mp3 format. On success, the sent Description is returned. Bots can currently send
+        ///     audio files of up to 50 MB in size, this limit may be changed in the future.
+        /// </summary>
+        /// <param name="sendAudioParameters">Request parameters.</param>
+        /// <param name="cancellationToken">A cancellation token that can be used by other objects or threads to receive notice of cancellation.</param>
+        Task<Message> SendAudioAsync(SendAudioParameters sendAudioParameters,
+            CancellationToken cancellationToken = default);
+
+        /// <summary>
+        ///     Use this method to send general files. On success, the sent Description is returned. Bots can send files of
+        ///     any type of up to 50 MB in size.
+        /// </summary>
+        /// <param name="sendDocumentParameters">Request parameters.</param>
+        /// <param name="cancellationToken">A cancellation token that can be used by other objects or threads to receive notice of cancellation.</param>
+        Task<Message> SendDocumentAsync(SendDocumentParameters sendDocumentParameters,
+            CancellationToken cancellationToken = default);
+
+        /// <summary>
+        ///     Use this method to send .webp stickers. On success, the sent Description is returned.
+        /// </summary>
+        /// <param name="sendStickerParameters">Request parameters.</param>
+        /// <param name="cancellationToken">A cancellation token that can be used by other objects or threads to receive notice of cancellation.</param>
+        Task<Message> SendStickerAsync(SendStickerParameters sendStickerParameters,
+            CancellationToken cancellationToken = default);
+
+        /// <summary>
+        ///     Use this method to send video files, Telegram clients support mp4 videos (other formats may be sent as
+        ///     Document). On success, the sent Description is returned. Bots can send video files of up to 50 MB in size.
+        /// </summary>
+        /// <param name="sendVideoParameters">Request parameters.</param>
+        /// <param name="cancellationToken">A cancellation token that can be used by other objects or threads to receive notice of cancellation.</param>
+        Task<Message> SendVideoAsync(SendVideoParameters sendVideoParameters,
+            CancellationToken cancellationToken = default);
+
+        /// <summary>
+        ///     Use this method to send animation files (GIF or H.264/MPEG-4 AVC video without sound). On success, the sent
+        ///     Message is returned. Bots can currently send animation files of up to 50 MB in size, this limit may be
+        ///     changed in the future.
+        /// </summary>
+        /// <param name="sendAnimationParameters">Request parameters.</param>
+        /// <param name="cancellationToken">A cancellation token that can be used by other objects or threads to receive notice of cancellation.</param>
+        Task<Message> SendAnimationAsync(SendAnimationParameters sendAnimationParameters,
+            CancellationToken cancellationToken = default);
+
+        /// <summary>
+        ///     Use this method to send audio files, if you want Telegram clients to display the file as a playable voice message.
+        ///     For this to work, your audio must be in an .ogg file encoded with OPUS (other formats may be sent as Audio or
+        ///     Document). On success, the sent Description is returned. Bots can currently send voice messages of up to 50 MB in
+        ///     size, this limit may be changed in the future.
+        /// </summary>
+        /// <param name="sendVoiceParameters">Request parameters.</param>
+        /// <param name="cancellationToken">A cancellation token that can be used by other objects or threads to receive notice of cancellation.</param>
+        Task<Message> SendVoiceAsync(SendVoiceParameters sendVoiceParameters,
+            CancellationToken cancellationToken = default);
+
+        /// <summary>
+        ///     As of v.4.0, Telegram clients support rounded square mp4 videos of up to 1 minute long. Use this method to
+        ///     send video messages.
+        /// </summary>
+        /// <param name="sendVideoNoteParameters">Request parameters.</param>
+        /// <param name="cancellationToken">A cancellation token that can be used by other objects or threads to receive notice of cancellation.</param>
+        Task<Message> SendVideoNoteAsync(SendVideoNoteParameters sendVideoNoteParameters,
+            CancellationToken cancellationToken = default);
+
+        /// <summary>
+        ///     Use this method to send a group of photos or videos as an album. On success, an array of the sent Messages is
+        ///     returned.
+        /// </summary>
+        /// <param name="sendMediaGroupParameters">Request parameters.</param>
+        /// <param name="cancellationToken">A cancellation token that can be used by other objects or threads to receive notice of cancellation.</param>
+        Task<Message[]> SendMediaGroupAsync(SendMediaGroupParameters sendMediaGroupParameters,
+            CancellationToken cancellationToken = default);
+
+        /// <summary>
+        ///     Use this method to send a group of photos or videos as an album. On success, an array of the sent Messages is
+        ///     returned.
+        /// </summary>
+        /// <param name="sendMediaGroupExtendedParameters">Request parameters.</param>
+        /// <param name="cancellationToken">A cancellation token that can be used by other objects or threads to receive notice of cancellation.</param>
+        Task<Message[]> SendMediaGroupAsync(SendMediaGroupExtendedParameters sendMediaGroupExtendedParameters,
+            CancellationToken cancellationToken = default);
+
+        /// <summary>
+        ///     Use this method to send point on the map. On success, the sent Description is returned.
+        /// </summary>
+        /// <param name="sendLocationParameters">Request parameters.</param>
+        /// <param name="cancellationToken">A cancellation token that can be used by other objects or threads to receive notice of cancellation.</param>
+        Task<Message> SendLocationAsync(SendLocationParameters sendLocationParameters,
+            CancellationToken cancellationToken = default);
+
+        /// <summary>
+        ///     Use this method to send information about a venue.
+        /// </summary>
+        /// <param name="sendVenueParameters">Request parameters.</param>
+        /// <param name="cancellationToken">A cancellation token that can be used by other objects or threads to receive notice of cancellation.</param>
+        Task<Message> SendVenueAsync(SendVenueParameters sendVenueParameters,
+            CancellationToken cancellationToken = default);
+
+        /// <summary>
+        ///     Use this method to send phone contacts.
+        /// </summary>
+        /// <param name="sendContactParameters">Request parameters.</param>
+        /// <param name="cancellationToken">A cancellation token that can be used by other objects or threads to receive notice of cancellation.</param>
+        Task<Message> SendContactAsync(SendContactParameters sendContactParameters,
+            CancellationToken cancellationToken = default);
+
+        /// <summary>
+        ///     Use this method to send a native poll. A native poll can't be sent to a private chat. On success, the sent
+        ///     <see cref="Message" /> is returned.
+        /// </summary>
+        /// <param name="sendPollParameters">Request parameters.</param>
+        /// <param name="cancellationToken">A cancellation token that can be used by other objects or threads to receive notice of cancellation.</param>
+        Task<Message> SendPollAsync(SendPollParameters sendPollParameters,
+            CancellationToken cancellationToken = default);
+
+        /// <summary>
+        ///     Use this request to send a dice, which will have a random value from 1 to 6. On success, the sent
+        ///     <see cref="Message" /> is returned
+        /// </summary>
+        /// <param name="sendDiceParameters">Request parameters.</param>
+        /// <param name="cancellationToken">A cancellation token that can be used by other objects or threads to receive notice of cancellation.</param>
+        Task<Message> SendDiceAsync(SendDiceParameters sendDiceParameters,
+            CancellationToken cancellationToken = default);
+
+        /// <summary>
+        ///     Use this method when you need to tell the user that something is happening on the bot's side. The status is set for
+        ///     5 seconds or less (when a message arrives from your bot, Telegram clients clear its typing status).
+        /// </summary>
+        /// <param name="sendChatActionParameters">Request parameters.</param>
+        /// <param name="cancellationToken">A cancellation token that can be used by other objects or threads to receive notice of cancellation.</param>
+        Task SendChatActionAsync(SendChatActionParameters sendChatActionParameters,
+            CancellationToken cancellationToken = default);
+
+        /// <summary>
+        ///     Use this method to get a list of profile pictures for a user. Returns a UserProfilePhotos object.
+        /// </summary>
+        /// <param name="getUserProfilePhotosParameters">Request parameters.</param>
+        /// <param name="cancellationToken">A cancellation token that can be used by other objects or threads to receive notice of cancellation.</param>
+        Task<UserProfilePhotos> GetUserProfilePhotosAsync(GetUserProfilePhotosParameters getUserProfilePhotosParameters,
+            CancellationToken cancellationToken = default);
+
+        /// <summary>
+        ///     Use this method to get information about a file. For the moment, bots can download files of up to 20MB in size.
+        /// </summary>
+        /// <param name="getFileParameters">Request parameters.</param>
+        /// <param name="cancellationToken">A cancellation token that can be used by other objects or threads to receive notice of cancellation.</param>
+        Task<File> GetFileAsync(GetFileParameters getFileParameters, CancellationToken cancellationToken = default);
+
+        /// <summary>
+        ///     Use this method to download a file.
+        /// </summary>
+        /// <param name="downloadFileParameters">Request parameters.</param>
+        /// <param name="cancellationToken">A cancellation token that can be used by other objects or threads to receive notice of cancellation.</param>
+        Task<Stream> DownloadFileAsync(DownloadFileParameters downloadFileParameters,
+            CancellationToken cancellationToken = default);
+
+        /// <summary>
+        ///     Use this method to download a file.
+        /// </summary>
+        /// <param name="downloadFileExtendedParameters">Request parameters.</param>
+        /// <param name="cancellationToken">A cancellation token that can be used by other objects or threads to receive notice of cancellation.</param>
+        Task DownloadFileAsync(DownloadFileExtendedParameters downloadFileExtendedParameters,
+            CancellationToken cancellationToken = default);
+
+        /// <summary>
+        ///     Use this method to get basic info about a file and download it.
+        /// </summary>
+        /// <param name="getInfoAndDownloadFileParameters">Request parameters.</param>
+        /// <param name="cancellationToken">A cancellation token that can be used by other objects or threads to receive notice of cancellation.</param>
+        Task<File> GetInfoAndDownloadFileAsync(GetInfoAndDownloadFileParameters getInfoAndDownloadFileParameters,
+            CancellationToken cancellationToken = default);
+
+        /// <summary>
+        ///     Use this method to kick a user from a group or a supergroup. In the case of supergroups, the user will not be able
+        ///     to return to the group on their own using invite links, etc., unless unbanned first. The bot must be an
+        ///     administrator in the group for this to work.
+        /// </summary>
+        /// <param name="kickChatMemberParameters">Request parameters.</param>
+        /// <param name="cancellationToken">A cancellation token that can be used by other objects or threads to receive notice of cancellation.</param>
+        Task KickChatMemberAsync(KickChatMemberParameters kickChatMemberParameters,
+            CancellationToken cancellationToken = default);
+
+        /// <summary>
+        ///     Use this method for your bot to leave a group, supergroup or channel.
+        /// </summary>
+        /// <param name="leaveChatParameters">Request parameters.</param>
+        /// <param name="cancellationToken">A cancellation token that can be used by other objects or threads to receive notice of cancellation.</param>
+        Task LeaveChatAsync(LeaveChatParameters leaveChatParameters, CancellationToken cancellationToken = default);
+
+        /// <summary>
+        ///     Use this method to unban a previously kicked user in a supergroup. The user will not return to the group
+        ///     automatically, but will be able to join via link, etc. The bot must be an administrator in the group for this to
+        ///     work.
+        /// </summary>
+        /// <param name="unbanChatMemberParameters">Request parameters.</param>
+        /// <param name="cancellationToken">A cancellation token that can be used by other objects or threads to receive notice of cancellation.</param>
+        Task UnbanChatMemberAsync(UnbanChatMemberParameters unbanChatMemberParameters,
+            CancellationToken cancellationToken = default);
+
+        /// <summary>
+        ///     Use this method to get up to date information about the chat (current name of the user for one-on-one
+        ///     conversations, current username of a user, group or channel, etc.).
+        /// </summary>
+        /// <param name="getChatParameters">Request parameters.</param>
+        /// <param name="cancellationToken">A cancellation token that can be used by other objects or threads to receive notice of cancellation.</param>
+        Task<Chat> GetChatAsync(GetChatParameters getChatParameters, CancellationToken cancellationToken = default);
+
+        /// <summary>
+        ///     Use this method to get a list of administrators in a chat.
+        /// </summary>
+        /// <param name="getChatAdministratorsParameters">Request parameters.</param>
+        /// <param name="cancellationToken">A cancellation token that can be used by other objects or threads to receive notice of cancellation.</param>
+        Task<ChatMember[]> GetChatAdministratorsAsync(GetChatAdministratorsParameters getChatAdministratorsParameters,
+            CancellationToken cancellationToken = default);
+
+        /// <summary>
+        ///     Use this method to get the number of members in a chat.
+        /// </summary>
+        /// <param name="getChatMembersCountParameters">Request parameters.</param>
+        /// <param name="cancellationToken">A cancellation token that can be used by other objects or threads to receive notice of cancellation.</param>
+        Task<int> GetChatMembersCountAsync(GetChatMembersCountParameters getChatMembersCountParameters,
+            CancellationToken cancellationToken = default);
+
+        /// <summary>
+        ///     Use this method to get information about a member of a chat.
+        /// </summary>
+        /// <param name="getChatMemberParameters">Request parameters.</param>
+        /// <param name="cancellationToken">A cancellation token that can be used by other objects or threads to receive notice of cancellation.</param>
+        Task<ChatMember> GetChatMemberAsync(GetChatMemberParameters getChatMemberParameters,
+            CancellationToken cancellationToken = default);
+
+        /// <summary>
+        ///     Use this method to send answers to callback queries sent from inline keyboards. The answer will be displayed to the
+        ///     user as a notification at the top of the chat screen or as an alert.
+        /// </summary>
+        /// <param name="answerCallbackQueryParameters">Request parameters.</param>
+        /// <param name="cancellationToken">A cancellation token that can be used by other objects or threads to receive notice of cancellation.</param>
+        Task AnswerCallbackQueryAsync(AnswerCallbackQueryParameters answerCallbackQueryParameters,
+            CancellationToken cancellationToken = default);
+
+        /// <summary>
+        ///     Use this method to restrict a user in a supergroup. The bot must be an administrator in the supergroup for this to
+        ///     work and must have the appropriate admin rights.
+        /// </summary>
+        /// <param name="restrictChatMemberParameters">Request parameters.</param>
+        /// <param name="cancellationToken">A cancellation token that can be used by other objects or threads to receive notice of cancellation.</param>
+        Task RestrictChatMemberAsync(RestrictChatMemberParameters restrictChatMemberParameters,
+            CancellationToken cancellationToken = default);
+
+        /// <summary>
+        ///     Use this method to promote or demote a user in a supergroup or a channel. The bot must be an administrator in the
+        ///     chat for this to work and must have the appropriate admin rights.
+        /// </summary>
+        /// <param name="promoteChatMemberParameters">Request parameters.</param>
+        /// <param name="cancellationToken">A cancellation token that can be used by other objects or threads to receive notice of cancellation.</param>
+        Task PromoteChatMemberAsync(PromoteChatMemberParameters promoteChatMemberParameters,
+            CancellationToken cancellationToken = default);
+
+        /// <summary>
+        ///     <inheritdoc cref="Telegram.Bot.Requests.SetChatAdministratorCustomTitleRequest" />
+        /// </summary>
+        /// <param name="setChatAdministratorCustomTitleParameters">Request parameters.</param>
+        /// <param name="cancellationToken">A cancellation token that can be used by other objects or threads to receive notice of cancellation.</param>
+        Task SetChatAdministratorCustomTitleAsync(
+            SetChatAdministratorCustomTitleParameters setChatAdministratorCustomTitleParameters,
+            CancellationToken cancellationToken = default);
+
+        /// <summary>
+        ///     Use this method to set default chat permissions for all members. The bot must be an administrator in the group or a
+        ///     supergroup for this to work and must have the can_restrict_members admin rights. Returns True on success.
+        /// </summary>
+        /// <param name="setChatPermissionsParameters">Request parameters.</param>
+        /// <param name="cancellationToken">A cancellation token that can be used by other objects or threads to receive notice of cancellation.</param>
+        Task SetChatPermissionsAsync(SetChatPermissionsParameters setChatPermissionsParameters,
+            CancellationToken cancellationToken = default);
+
+        /// <summary>
+        ///     Use this method to change the list of the bot's commands. Returns True on success.
+        /// </summary>
+        /// <param name="setMyCommandsParameters">Request parameters.</param>
+        /// <param name="cancellationToken">A cancellation token that can be used by other objects or threads to receive notice of cancellation.</param>
+        Task SetMyCommandsAsync(SetMyCommandsParameters setMyCommandsParameters,
+            CancellationToken cancellationToken = default);
+
+        /// <summary>
+        ///     Use this method to edit text messages sent by the bot or via the bot (for inline bots).
+        /// </summary>
+        /// <param name="editMessageTextParameters">Request parameters.</param>
+        /// <param name="cancellationToken">A cancellation token that can be used by other objects or threads to receive notice of cancellation.</param>
+        Task<Message> EditMessageTextAsync(EditMessageTextParameters editMessageTextParameters,
+            CancellationToken cancellationToken = default);
+
+        /// <summary>
+        ///     Use this method to edit text messages sent by the bot or via the bot (for inline bots).
+        /// </summary>
+        /// <param name="editMessageTextInlineParameters">Request parameters.</param>
+        /// <param name="cancellationToken">A cancellation token that can be used by other objects or threads to receive notice of cancellation.</param>
+        Task EditMessageTextAsync(EditMessageTextInlineParameters editMessageTextInlineParameters,
+            CancellationToken cancellationToken = default);
+
+        /// <summary>
+        ///     Use this method to stop updating a live location message sent via the bot (for inline bots) before live_period
+        ///     expires.
+        /// </summary>
+        /// <param name="stopMessageLiveLocationParameters">Request parameters.</param>
+        /// <param name="cancellationToken">A cancellation token that can be used by other objects or threads to receive notice of cancellation.</param>
+        Task<Message> StopMessageLiveLocationAsync(StopMessageLiveLocationParameters stopMessageLiveLocationParameters,
+            CancellationToken cancellationToken = default);
+
+        /// <summary>
+        ///     Use this method to stop updating a live location message sent via the bot (for inline bots) before live_period
+        ///     expires.
+        /// </summary>
+        /// <param name="stopMessageLiveLocationInlineParameters">Request parameters.</param>
+        /// <param name="cancellationToken">A cancellation token that can be used by other objects or threads to receive notice of cancellation.</param>
+        Task StopMessageLiveLocationAsync(
+            StopMessageLiveLocationInlineParameters stopMessageLiveLocationInlineParameters,
+            CancellationToken cancellationToken = default);
+
+        /// <summary>
+        ///     Use this method to edit captions of messages sent by the bot or via the bot (for inline bots).
+        /// </summary>
+        /// <param name="editMessageCaptionParameters">Request parameters.</param>
+        /// <param name="cancellationToken">A cancellation token that can be used by other objects or threads to receive notice of cancellation.</param>
+        Task<Message> EditMessageCaptionAsync(EditMessageCaptionParameters editMessageCaptionParameters,
+            CancellationToken cancellationToken = default);
+
+        /// <summary>
+        ///     Use this method to edit captions of messages sent by the bot or via the bot (for inline bots).
+        /// </summary>
+        /// <param name="editMessageCaptionInlineParameters">Request parameters.</param>
+        /// <param name="cancellationToken">A cancellation token that can be used by other objects or threads to receive notice of cancellation.</param>
+        Task EditMessageCaptionAsync(EditMessageCaptionInlineParameters editMessageCaptionInlineParameters,
+            CancellationToken cancellationToken = default);
+
+        /// <summary>
+        ///     Use this method to edit audio, document, photo, or video inline messages.
+        /// </summary>
+        /// <param name="editMessageMediaParameters">Request parameters.</param>
+        /// <param name="cancellationToken">A cancellation token that can be used by other objects or threads to receive notice of cancellation.</param>
+        Task<Message> EditMessageMediaAsync(EditMessageMediaParameters editMessageMediaParameters,
+            CancellationToken cancellationToken = default);
+
+        /// <summary>
+        ///     Use this method to edit audio, document, photo, or video inline messages.
+        /// </summary>
+        /// <param name="editMessageMediaInlineParameters">Request parameters.</param>
+        /// <param name="cancellationToken">A cancellation token that can be used by other objects or threads to receive notice of cancellation.</param>
+        Task EditMessageMediaAsync(EditMessageMediaInlineParameters editMessageMediaInlineParameters,
+            CancellationToken cancellationToken = default);
+
+        /// <summary>
+        ///     Use this method to edit only the reply markup of messages sent by the bot or via the bot (for inline bots).
+        /// </summary>
+        /// <param name="editMessageReplyMarkupParameters">Request parameters.</param>
+        /// <param name="cancellationToken">A cancellation token that can be used by other objects or threads to receive notice of cancellation.</param>
+        Task<Message> EditMessageReplyMarkupAsync(EditMessageReplyMarkupParameters editMessageReplyMarkupParameters,
+            CancellationToken cancellationToken = default);
+
+        /// <summary>
+        ///     Use this method to edit only the reply markup of messages sent by the bot or via the bot (for inline bots).
+        /// </summary>
+        /// <param name="editMessageReplyMarkupInlineParameters">Request parameters.</param>
+        /// <param name="cancellationToken">A cancellation token that can be used by other objects or threads to receive notice of cancellation.</param>
+        Task EditMessageReplyMarkupAsync(EditMessageReplyMarkupInlineParameters editMessageReplyMarkupInlineParameters,
+            CancellationToken cancellationToken = default);
+
+        /// <summary>
+        ///     Use this method to edit live location messages sent via the bot (for inline bots).
+        /// </summary>
+        /// <param name="editMessageLiveLocationParameters">Request parameters.</param>
+        /// <param name="cancellationToken">A cancellation token that can be used by other objects or threads to receive notice of cancellation.</param>
+        Task<Message> EditMessageLiveLocationAsync(EditMessageLiveLocationParameters editMessageLiveLocationParameters,
+            CancellationToken cancellationToken = default);
+
+        /// <summary>
+        ///     Use this method to edit live location messages sent via the bot (for inline bots).
+        /// </summary>
+        /// <param name="editMessageLiveLocationInlineParameters">Request parameters.</param>
+        /// <param name="cancellationToken">A cancellation token that can be used by other objects or threads to receive notice of cancellation.</param>
+        Task EditMessageLiveLocationAsync(
+            EditMessageLiveLocationInlineParameters editMessageLiveLocationInlineParameters,
+            CancellationToken cancellationToken = default);
+
+        /// <summary>
+        ///     Use this method to send a native poll. A native poll can't be sent to a private chat. On success, the sent
+        ///     <see cref="Message" /> is returned.
+        /// </summary>
+        /// <param name="stopPollParameters">Request parameters.</param>
+        /// <param name="cancellationToken">A cancellation token that can be used by other objects or threads to receive notice of cancellation.</param>
+        Task<Poll> StopPollAsync(StopPollParameters stopPollParameters, CancellationToken cancellationToken = default);
+
+        /// <summary>
+        ///     Use this method to delete a message. A message can only be deleted if it was sent less than 48 hours ago. Any such
+        ///     recently sent outgoing message may be deleted. Additionally, if the bot is an administrator in a group chat, it can
+        ///     delete any message. If the bot is an administrator in a supergroup, it can delete messages from any other user and
+        ///     service messages about people joining or leaving the group (other types of service messages may only be removed by
+        ///     the group creator). In channels, bots can only remove their own messages.
+        /// </summary>
+        /// <param name="deleteMessageParameters">Request parameters.</param>
+        /// <param name="cancellationToken">A cancellation token that can be used by other objects or threads to receive notice of cancellation.</param>
+        Task DeleteMessageAsync(DeleteMessageParameters deleteMessageParameters,
+            CancellationToken cancellationToken = default);
+
+        /// <summary>
+        ///     Use this method to send answers to an inline query.
+        /// </summary>
+        /// <param name="answerInlineQueryParameters">Request parameters.</param>
+        /// <param name="cancellationToken">A cancellation token that can be used by other objects or threads to receive notice of cancellation.</param>
+        Task AnswerInlineQueryAsync(AnswerInlineQueryParameters answerInlineQueryParameters,
+            CancellationToken cancellationToken = default);
+
+        /// <summary>
+        ///     Use this method to send invoices.
+        /// </summary>
+        /// <param name="sendInvoiceParameters">Request parameters.</param>
+        /// <param name="cancellationToken">A cancellation token that can be used by other objects or threads to receive notice of cancellation.</param>
+        Task<Message> SendInvoiceAsync(SendInvoiceParameters sendInvoiceParameters,
+            CancellationToken cancellationToken = default);
+
+        /// <summary>
+        ///     Use this method to reply to shipping queries with failure and error message. If you sent an invoice requesting a
+        ///     shipping address and the parameter is_flexible was specified, the Bot API will send an Update with a shipping_query
+        ///     field to the bot.
+        /// </summary>
+        /// <param name="answerShippingQueryParameters">Request parameters.</param>
+        /// <param name="cancellationToken">A cancellation token that can be used by other objects or threads to receive notice of cancellation.</param>
+        Task AnswerShippingQueryAsync(AnswerShippingQueryParameters answerShippingQueryParameters,
+            CancellationToken cancellationToken = default);
+
+        /// <summary>
+        ///     Use this method to reply to shipping queries with failure and error message. If you sent an invoice requesting a
+        ///     shipping address and the parameter is_flexible was specified, the Bot API will send an Update with a shipping_query
+        ///     field to the bot.
+        /// </summary>
+        /// <param name="answerShippingQueryExtendedParameters">Request parameters.</param>
+        /// <param name="cancellationToken">A cancellation token that can be used by other objects or threads to receive notice of cancellation.</param>
+        Task AnswerShippingQueryAsync(AnswerShippingQueryExtendedParameters answerShippingQueryExtendedParameters,
+            CancellationToken cancellationToken = default);
+
+        /// <summary>
+        ///     Respond to a pre-checkout query with failure and error message
+        /// </summary>
+        /// <param name="answerPreCheckoutQueryParameters">Request parameters.</param>
+        /// <param name="cancellationToken">A cancellation token that can be used by other objects or threads to receive notice of cancellation.</param>
+        Task AnswerPreCheckoutQueryAsync(AnswerPreCheckoutQueryParameters answerPreCheckoutQueryParameters,
+            CancellationToken cancellationToken = default);
+
+        /// <summary>
+        ///     Respond to a pre-checkout query with failure and error message
+        /// </summary>
+        /// <param name="answerPreCheckoutQueryExtendedParameters">Request parameters.</param>
+        /// <param name="cancellationToken">A cancellation token that can be used by other objects or threads to receive notice of cancellation.</param>
+        Task AnswerPreCheckoutQueryAsync(
+            AnswerPreCheckoutQueryExtendedParameters answerPreCheckoutQueryExtendedParameters,
+            CancellationToken cancellationToken = default);
+
+        /// <summary>
+        ///     Use this method to send a game.
+        /// </summary>
+        /// <param name="sendGameParameters">Request parameters.</param>
+        /// <param name="cancellationToken">A cancellation token that can be used by other objects or threads to receive notice of cancellation.</param>
+        Task<Message> SendGameAsync(SendGameParameters sendGameParameters,
+            CancellationToken cancellationToken = default);
+
+        /// <summary>
+        ///     Use this method to set the score of the specified user in a game.
+        /// </summary>
+        /// <param name="setGameScoreParameters">Request parameters.</param>
+        /// <param name="cancellationToken">A cancellation token that can be used by other objects or threads to receive notice of cancellation.</param>
+        Task<Message> SetGameScoreAsync(SetGameScoreParameters setGameScoreParameters,
+            CancellationToken cancellationToken = default);
+
+        /// <summary>
+        ///     Use this method to set the score of the specified user in a game.
+        /// </summary>
+        /// <param name="setGameScoreInlineParameters">Request parameters.</param>
+        /// <param name="cancellationToken">A cancellation token that can be used by other objects or threads to receive notice of cancellation.</param>
+        Task SetGameScoreAsync(SetGameScoreInlineParameters setGameScoreInlineParameters,
+            CancellationToken cancellationToken = default);
+
+        /// <summary>
+        ///     Use this method to get data for high score tables.
+        /// </summary>
+        /// <param name="getGameHighScoresParameters">Request parameters.</param>
+        /// <param name="cancellationToken">A cancellation token that can be used by other objects or threads to receive notice of cancellation.</param>
+        Task<GameHighScore[]> GetGameHighScoresAsync(GetGameHighScoresParameters getGameHighScoresParameters,
+            CancellationToken cancellationToken = default);
+
+        /// <summary>
+        ///     Use this method to get data for high score tables.
+        /// </summary>
+        /// <param name="getGameHighScoresInlineParameters">Request parameters.</param>
+        /// <param name="cancellationToken">A cancellation token that can be used by other objects or threads to receive notice of cancellation.</param>
+        Task<GameHighScore[]> GetGameHighScoresAsync(
+            GetGameHighScoresInlineParameters getGameHighScoresInlineParameters,
+            CancellationToken cancellationToken = default);
+
+        /// <summary>
+        ///     Use this method to get a sticker set.
+        /// </summary>
+        /// <param name="getStickerSetParameters">Request parameters.</param>
+        /// <param name="cancellationToken">A cancellation token that can be used by other objects or threads to receive notice of cancellation.</param>
+        Task<StickerSet> GetStickerSetAsync(GetStickerSetParameters getStickerSetParameters,
+            CancellationToken cancellationToken = default);
+
+        /// <summary>
+        ///     Use this method to upload a .png file with a sticker for later use in createNewStickerSet and addStickerToSet
+        ///     methods (can be used multiple times).
+        /// </summary>
+        /// <param name="uploadStickerFileParameters">Request parameters.</param>
+        /// <param name="cancellationToken">A cancellation token that can be used by other objects or threads to receive notice of cancellation.</param>
+        Task<File> UploadStickerFileAsync(UploadStickerFileParameters uploadStickerFileParameters,
+            CancellationToken cancellationToken = default);
+
+        /// <summary>
+        ///     Use this method to create new sticker set owned by a user. The bot will be able to edit the created sticker set.
+        /// </summary>
+        /// <param name="createNewStickerSetParameters">Request parameters.</param>
+        /// <param name="cancellationToken">A cancellation token that can be used by other objects or threads to receive notice of cancellation.</param>
+        Task CreateNewStickerSetAsync(CreateNewStickerSetParameters createNewStickerSetParameters,
+            CancellationToken cancellationToken = default);
+
+        /// <summary>
+        ///     Use this method to add a new sticker to a set created by the bot.
+        /// </summary>
+        /// <param name="addStickerToSetParameters">Request parameters.</param>
+        /// <param name="cancellationToken">A cancellation token that can be used by other objects or threads to receive notice of cancellation.</param>
+        Task AddStickerToSetAsync(AddStickerToSetParameters addStickerToSetParameters,
+            CancellationToken cancellationToken = default);
+
+        /// <summary>
+        ///     Use this method to create new sticker set owned by a user. The bot will be able to edit the created sticker set.
+        /// </summary>
+        /// <param name="createNewAnimatedStickerSetParameters">Request parameters.</param>
+        /// <param name="cancellationToken">A cancellation token that can be used by other objects or threads to receive notice of cancellation.</param>
+        Task CreateNewAnimatedStickerSetAsync(
+            CreateNewAnimatedStickerSetParameters createNewAnimatedStickerSetParameters,
+            CancellationToken cancellationToken = default);
+
+        /// <summary>
+        ///     Use this method to add a new sticker to a set created by the bot.
+        /// </summary>
+        /// <param name="addAnimatedStickerToSetParameters">Request parameters.</param>
+        /// <param name="cancellationToken">A cancellation token that can be used by other objects or threads to receive notice of cancellation.</param>
+        Task AddAnimatedStickerToSetAsync(AddAnimatedStickerToSetParameters addAnimatedStickerToSetParameters,
+            CancellationToken cancellationToken = default);
+
+        /// <summary>
+        ///     Use this method to move a sticker in a set created by the bot to a specific position.
+        /// </summary>
+        /// <param name="setStickerPositionInSetParameters">Request parameters.</param>
+        /// <param name="cancellationToken">A cancellation token that can be used by other objects or threads to receive notice of cancellation.</param>
+        Task SetStickerPositionInSetAsync(SetStickerPositionInSetParameters setStickerPositionInSetParameters,
+            CancellationToken cancellationToken = default);
+
+        /// <summary>
+        ///     Use this method to delete a sticker from a set created by the bot.
+        /// </summary>
+        /// <param name="deleteStickerFromSetParameters">Request parameters.</param>
+        /// <param name="cancellationToken">A cancellation token that can be used by other objects or threads to receive notice of cancellation.</param>
+        Task DeleteStickerFromSetAsync(DeleteStickerFromSetParameters deleteStickerFromSetParameters,
+            CancellationToken cancellationToken = default);
+
+        /// <summary>
+        ///     Use this method to set the thumbnail of a sticker set. Animated thumbnails can be set for animated sticker sets
+        ///     only. Returns True on success.
+        /// </summary>
+        /// <param name="setStickerSetThumbParameters">Request parameters.</param>
+        /// <param name="cancellationToken">A cancellation token that can be used by other objects or threads to receive notice of cancellation.</param>
+        Task SetStickerSetThumbAsync(SetStickerSetThumbParameters setStickerSetThumbParameters,
+            CancellationToken cancellationToken = default);
+
+        /// <summary>
+        ///     Use this method to export an invite link to a supergroup or a channel. The bot must be an administrator in the chat
+        ///     for this to work and must have the appropriate admin rights.
+        /// </summary>
+        /// <param name="exportChatInviteLinkParameters">Request parameters.</param>
+        /// <param name="cancellationToken">A cancellation token that can be used by other objects or threads to receive notice of cancellation.</param>
+        Task<string> ExportChatInviteLinkAsync(ExportChatInviteLinkParameters exportChatInviteLinkParameters,
+            CancellationToken cancellationToken = default);
+
+        /// <summary>
+        ///     Use this method to set a new profile photo for the chat. Photos can't be changed for private chats. The bot must be
+        ///     an administrator in the chat for this to work and must have the appropriate admin rights.
+        /// </summary>
+        /// <param name="setChatPhotoParameters">Request parameters.</param>
+        /// <param name="cancellationToken">A cancellation token that can be used by other objects or threads to receive notice of cancellation.</param>
+        Task SetChatPhotoAsync(SetChatPhotoParameters setChatPhotoParameters,
+            CancellationToken cancellationToken = default);
+
+        /// <summary>
+        ///     Use this method to delete a chat photo. Photos can't be changed for private chats. The bot must be an administrator
+        ///     in the chat for this to work and must have the appropriate admin rights.
+        /// </summary>
+        /// <param name="deleteChatPhotoParameters">Request parameters.</param>
+        /// <param name="cancellationToken">A cancellation token that can be used by other objects or threads to receive notice of cancellation.</param>
+        Task DeleteChatPhotoAsync(DeleteChatPhotoParameters deleteChatPhotoParameters,
+            CancellationToken cancellationToken = default);
+
+        /// <summary>
+        ///     Use this method to change the title of a chat. Titles can't be changed for private chats. The bot must be an
+        ///     administrator in the chat for this to work and must have the appropriate admin rights.
+        /// </summary>
+        /// <param name="setChatTitleParameters">Request parameters.</param>
+        /// <param name="cancellationToken">A cancellation token that can be used by other objects or threads to receive notice of cancellation.</param>
+        Task SetChatTitleAsync(SetChatTitleParameters setChatTitleParameters,
+            CancellationToken cancellationToken = default);
+
+        /// <summary>
+        ///     Use this method to change the description of a supergroup or a channel. The bot must be an administrator in the
+        ///     chat for this to work and must have the appropriate admin rights.
+        /// </summary>
+        /// <param name="setChatDescriptionParameters">Request parameters.</param>
+        /// <param name="cancellationToken">A cancellation token that can be used by other objects or threads to receive notice of cancellation.</param>
+        Task SetChatDescriptionAsync(SetChatDescriptionParameters setChatDescriptionParameters,
+            CancellationToken cancellationToken = default);
+
+        /// <summary>
+        ///     Use this method to pin a message in a supergroup. The bot must be an administrator in the chat for this to work and
+        ///     must have the appropriate admin rights.
+        /// </summary>
+        /// <param name="pinChatMessageParameters">Request parameters.</param>
+        /// <param name="cancellationToken">A cancellation token that can be used by other objects or threads to receive notice of cancellation.</param>
+        Task PinChatMessageAsync(PinChatMessageParameters pinChatMessageParameters,
+            CancellationToken cancellationToken = default);
+
+        /// <summary>
+        ///     Use this method to unpin a message in a supergroup chat. The bot must be an administrator in the chat for this to
+        ///     work and must have the appropriate admin rights.
+        /// </summary>
+        /// <param name="unpinChatMessageParameters">Request parameters.</param>
+        /// <param name="cancellationToken">A cancellation token that can be used by other objects or threads to receive notice of cancellation.</param>
+        Task UnpinChatMessageAsync(UnpinChatMessageParameters unpinChatMessageParameters,
+            CancellationToken cancellationToken = default);
+
+        /// <summary>
+        ///     Use this method to set a new group sticker set for a supergroup.
+        /// </summary>
+        /// <param name="setChatStickerSetParameters">Request parameters.</param>
+        /// <param name="cancellationToken">A cancellation token that can be used by other objects or threads to receive notice of cancellation.</param>
+        Task SetChatStickerSetAsync(SetChatStickerSetParameters setChatStickerSetParameters,
+            CancellationToken cancellationToken = default);
+
+        /// <summary>
+        ///     Use this method to delete a group sticker set from a supergroup.
+        /// </summary>
+        /// <param name="deleteChatStickerSetParameters">Request parameters.</param>
+        /// <param name="cancellationToken">A cancellation token that can be used by other objects or threads to receive notice of cancellation.</param>
+        Task DeleteChatStickerSetAsync(DeleteChatStickerSetParameters deleteChatStickerSetParameters,
             CancellationToken cancellationToken = default);
 
         #endregion

--- a/src/Telegram.Bot/Requests/Parameters/AddAnimatedStickerToSetParameters.cs
+++ b/src/Telegram.Bot/Requests/Parameters/AddAnimatedStickerToSetParameters.cs
@@ -1,0 +1,86 @@
+using Telegram.Bot.Types;
+using Telegram.Bot.Types.InputFiles;
+
+namespace Telegram.Bot.Requests.Parameters
+{
+    /// <summary>
+    ///     Parameters for <see cref="ITelegramBotClient.AddAnimatedStickerToSetAsync" /> method.
+    /// </summary>
+    public class AddAnimatedStickerToSetParameters : ParametersBase
+    {
+        /// <summary>
+        ///     User identifier of sticker set owner
+        /// </summary>
+        public int UserId { get; set; }
+
+        /// <summary>
+        ///     Sticker set name
+        /// </summary>
+        public string Name { get; set; }
+
+        /// <summary>
+        ///     Tgs animation with the sticker
+        /// </summary>
+        public InputFileStream TgsSticker { get; set; }
+
+        /// <summary>
+        ///     One or more emoji corresponding to the sticker
+        /// </summary>
+        public string Emojis { get; set; }
+
+        /// <summary>
+        ///     Position where the mask should be placed on faces
+        /// </summary>
+        public MaskPosition MaskPosition { get; set; }
+
+        /// <summary>
+        ///     Sets <see cref="UserId" /> property.
+        /// </summary>
+        /// <param name="userId">User identifier of sticker set owner</param>
+        public AddAnimatedStickerToSetParameters WithUserId(int userId)
+        {
+            UserId = userId;
+            return this;
+        }
+
+        /// <summary>
+        ///     Sets <see cref="Name" /> property.
+        /// </summary>
+        /// <param name="name">Sticker set name</param>
+        public AddAnimatedStickerToSetParameters WithName(string name)
+        {
+            Name = name;
+            return this;
+        }
+
+        /// <summary>
+        ///     Sets <see cref="TgsSticker" /> property.
+        /// </summary>
+        /// <param name="tgsSticker">Tgs animation with the sticker</param>
+        public AddAnimatedStickerToSetParameters WithTgsSticker(InputFileStream tgsSticker)
+        {
+            TgsSticker = tgsSticker;
+            return this;
+        }
+
+        /// <summary>
+        ///     Sets <see cref="Emojis" /> property.
+        /// </summary>
+        /// <param name="emojis">One or more emoji corresponding to the sticker</param>
+        public AddAnimatedStickerToSetParameters WithEmojis(string emojis)
+        {
+            Emojis = emojis;
+            return this;
+        }
+
+        /// <summary>
+        ///     Sets <see cref="MaskPosition" /> property.
+        /// </summary>
+        /// <param name="maskPosition">Position where the mask should be placed on faces</param>
+        public AddAnimatedStickerToSetParameters WithMaskPosition(MaskPosition maskPosition)
+        {
+            MaskPosition = maskPosition;
+            return this;
+        }
+    }
+}

--- a/src/Telegram.Bot/Requests/Parameters/AddStickerToSetParameters.cs
+++ b/src/Telegram.Bot/Requests/Parameters/AddStickerToSetParameters.cs
@@ -1,0 +1,90 @@
+using Telegram.Bot.Types;
+using Telegram.Bot.Types.InputFiles;
+
+namespace Telegram.Bot.Requests.Parameters
+{
+    /// <summary>
+    ///     Parameters for <see cref="ITelegramBotClient.AddStickerToSetAsync" /> method.
+    /// </summary>
+    public class AddStickerToSetParameters : ParametersBase
+    {
+        /// <summary>
+        ///     User identifier of sticker set owner
+        /// </summary>
+        public int UserId { get; set; }
+
+        /// <summary>
+        ///     Sticker set name
+        /// </summary>
+        public string Name { get; set; }
+
+        /// <summary>
+        ///     Png image with the sticker, must be up to 512 kilobytes in size, dimensions must not exceed 512px, and either width
+        ///     or height must be exactly 512px.
+        /// </summary>
+        public InputOnlineFile PngSticker { get; set; }
+
+        /// <summary>
+        ///     One or more emoji corresponding to the sticker
+        /// </summary>
+        public string Emojis { get; set; }
+
+        /// <summary>
+        ///     Position where the mask should be placed on faces
+        /// </summary>
+        public MaskPosition MaskPosition { get; set; }
+
+        /// <summary>
+        ///     Sets <see cref="UserId" /> property.
+        /// </summary>
+        /// <param name="userId">User identifier of sticker set owner</param>
+        public AddStickerToSetParameters WithUserId(int userId)
+        {
+            UserId = userId;
+            return this;
+        }
+
+        /// <summary>
+        ///     Sets <see cref="Name" /> property.
+        /// </summary>
+        /// <param name="name">Sticker set name</param>
+        public AddStickerToSetParameters WithName(string name)
+        {
+            Name = name;
+            return this;
+        }
+
+        /// <summary>
+        ///     Sets <see cref="PngSticker" /> property.
+        /// </summary>
+        /// <param name="pngSticker">
+        ///     Png image with the sticker, must be up to 512 kilobytes in size, dimensions must not exceed
+        ///     512px, and either width or height must be exactly 512px.
+        /// </param>
+        public AddStickerToSetParameters WithPngSticker(InputOnlineFile pngSticker)
+        {
+            PngSticker = pngSticker;
+            return this;
+        }
+
+        /// <summary>
+        ///     Sets <see cref="Emojis" /> property.
+        /// </summary>
+        /// <param name="emojis">One or more emoji corresponding to the sticker</param>
+        public AddStickerToSetParameters WithEmojis(string emojis)
+        {
+            Emojis = emojis;
+            return this;
+        }
+
+        /// <summary>
+        ///     Sets <see cref="MaskPosition" /> property.
+        /// </summary>
+        /// <param name="maskPosition">Position where the mask should be placed on faces</param>
+        public AddStickerToSetParameters WithMaskPosition(MaskPosition maskPosition)
+        {
+            MaskPosition = maskPosition;
+            return this;
+        }
+    }
+}

--- a/src/Telegram.Bot/Requests/Parameters/AnswerCallbackQueryParameters.cs
+++ b/src/Telegram.Bot/Requests/Parameters/AnswerCallbackQueryParameters.cs
@@ -1,0 +1,99 @@
+namespace Telegram.Bot.Requests.Parameters
+{
+    /// <summary>
+    ///     Parameters for <see cref="ITelegramBotClient.AnswerCallbackQueryAsync" /> method.
+    /// </summary>
+    public class AnswerCallbackQueryParameters : ParametersBase
+    {
+        /// <summary>
+        ///     Unique identifier for the query to be answered
+        /// </summary>
+        public string CallbackQueryId { get; set; }
+
+        /// <summary>
+        ///     Text of the notification. If not specified, nothing will be shown to the user
+        /// </summary>
+        public string Text { get; set; }
+
+        /// <summary>
+        ///     If true, an alert will be shown by the client instead of a notification at the top of the chat screen. Defaults to
+        ///     false.
+        /// </summary>
+        public bool ShowAlert { get; set; }
+
+        /// <summary>
+        ///     URL that will be opened by the user's client. If you have created a Game and accepted the conditions via
+        ///     @Botfather, specify the URL that opens your game — note that this will only work if the query comes from a
+        ///     callback_game button.
+        ///     Otherwise, you may use links like telegram.me/your_bot? start = XXXX that open your bot with a parameter.
+        /// </summary>
+        public string Url { get; set; }
+
+        /// <summary>
+        ///     The maximum amount of time in seconds that the result of the callback query may be cached client-side. Telegram
+        ///     apps will support caching starting in version 3.14.
+        /// </summary>
+        public int CacheTime { get; set; }
+
+        /// <summary>
+        ///     Sets <see cref="CallbackQueryId" /> property.
+        /// </summary>
+        /// <param name="callbackQueryId">Unique identifier for the query to be answered</param>
+        public AnswerCallbackQueryParameters WithCallbackQueryId(string callbackQueryId)
+        {
+            CallbackQueryId = callbackQueryId;
+            return this;
+        }
+
+        /// <summary>
+        ///     Sets <see cref="Text" /> property.
+        /// </summary>
+        /// <param name="text">Text of the notification. If not specified, nothing will be shown to the user</param>
+        public AnswerCallbackQueryParameters WithText(string text)
+        {
+            Text = text;
+            return this;
+        }
+
+        /// <summary>
+        ///     Sets <see cref="ShowAlert" /> property.
+        /// </summary>
+        /// <param name="showAlert">
+        ///     If true, an alert will be shown by the client instead of a notification at the top of the chat
+        ///     screen. Defaults to false.
+        /// </param>
+        public AnswerCallbackQueryParameters WithShowAlert(bool showAlert)
+        {
+            ShowAlert = showAlert;
+            return this;
+        }
+
+        /// <summary>
+        ///     Sets <see cref="Url" /> property.
+        /// </summary>
+        /// <param name="url">
+        ///     URL that will be opened by the user's client. If you have created a Game and accepted the conditions via
+        ///     @Botfather, specify the URL that opens your game — note that this will only work if the query comes from a
+        ///     callback_game button.
+        ///     Otherwise, you may use links like telegram.me/your_bot? start = XXXX that open your bot with a parameter.
+        /// </param>
+        public AnswerCallbackQueryParameters WithUrl(string url)
+        {
+            Url = url;
+            return this;
+        }
+
+        /// <summary>
+        ///     Sets <see cref="CacheTime" /> property.
+        /// </summary>
+        /// <param name="cacheTime">
+        ///     The maximum amount of time in seconds that the result of the callback query may be cached
+        ///     client-side. Telegram apps will support caching starting in version 3.14.
+        /// </param>
+        public AnswerCallbackQueryParameters WithCacheTime(int cacheTime)
+        {
+            CacheTime = cacheTime;
+            return this;
+        }
+    }
+}

--- a/src/Telegram.Bot/Requests/Parameters/AnswerInlineQueryParameters.cs
+++ b/src/Telegram.Bot/Requests/Parameters/AnswerInlineQueryParameters.cs
@@ -1,0 +1,128 @@
+using System.Collections.Generic;
+using Telegram.Bot.Types.InlineQueryResults;
+
+namespace Telegram.Bot.Requests.Parameters
+{
+    /// <summary>
+    ///     Parameters for <see cref="ITelegramBotClient.AnswerInlineQueryAsync" /> method.
+    /// </summary>
+    public class AnswerInlineQueryParameters : ParametersBase
+    {
+        /// <summary>
+        ///     Unique identifier for answered query
+        /// </summary>
+        public string InlineQueryId { get; set; }
+
+        /// <summary>
+        ///     A array of results for the inline query
+        /// </summary>
+        public IEnumerable<InlineQueryResultBase> Results { get; set; }
+
+        /// <summary>
+        ///     The maximum amount of time in seconds the result of the inline query may be cached on the server
+        /// </summary>
+        public int? CacheTime { get; set; }
+
+        /// <summary>
+        ///     Pass
+        /// </summary>
+        public bool IsPersonal { get; set; }
+
+        /// <summary>
+        ///     Pass the offset that a client should send in the next query with the same text to receive more results. Pass an
+        ///     empty string if there are no more results or if you don't support pagination. Offset length can't exceed 64 bytes.
+        /// </summary>
+        public string NextOffset { get; set; }
+
+        /// <summary>
+        ///     If passed, clients will display a button with specified text that switches the user to a private chat with the bot
+        ///     and sends the bot a start message with the parameter switch_pm_parameter
+        /// </summary>
+        public string SwitchPmText { get; set; }
+
+        /// <summary>
+        ///     Parameter for the start message sent to the bot when user presses the switch button
+        /// </summary>
+        public string SwitchPmParameter { get; set; }
+
+        /// <summary>
+        ///     Sets <see cref="InlineQueryId" /> property.
+        /// </summary>
+        /// <param name="inlineQueryId">Unique identifier for answered query</param>
+        public AnswerInlineQueryParameters WithInlineQueryId(string inlineQueryId)
+        {
+            InlineQueryId = inlineQueryId;
+            return this;
+        }
+
+        /// <summary>
+        ///     Sets <see cref="Results" /> property.
+        /// </summary>
+        /// <param name="results">A array of results for the inline query</param>
+        public AnswerInlineQueryParameters WithResults(IEnumerable<InlineQueryResultBase> results)
+        {
+            Results = results;
+            return this;
+        }
+
+        /// <summary>
+        ///     Sets <see cref="CacheTime" /> property.
+        /// </summary>
+        /// <param name="cacheTime">
+        ///     The maximum amount of time in seconds the result of the inline query may be cached on the
+        ///     server
+        /// </param>
+        public AnswerInlineQueryParameters WithCacheTime(int? cacheTime)
+        {
+            CacheTime = cacheTime;
+            return this;
+        }
+
+        /// <summary>
+        ///     Sets <see cref="IsPersonal" /> property.
+        /// </summary>
+        /// <param name="isPersonal">Pass </param>
+        public AnswerInlineQueryParameters WithIsPersonal(bool isPersonal)
+        {
+            IsPersonal = isPersonal;
+            return this;
+        }
+
+        /// <summary>
+        ///     Sets <see cref="NextOffset" /> property.
+        /// </summary>
+        /// <param name="nextOffset">
+        ///     Pass the offset that a client should send in the next query with the same text to receive more
+        ///     results. Pass an empty string if there are no more results or if you don't support pagination. Offset length can't
+        ///     exceed 64 bytes.
+        /// </param>
+        public AnswerInlineQueryParameters WithNextOffset(string nextOffset)
+        {
+            NextOffset = nextOffset;
+            return this;
+        }
+
+        /// <summary>
+        ///     Sets <see cref="SwitchPmText" /> property.
+        /// </summary>
+        /// <param name="switchPmText">
+        ///     If passed, clients will display a button with specified text that switches the user to a
+        ///     private chat with the bot and sends the bot a start message with the parameter switch_pm_parameter
+        /// </param>
+        public AnswerInlineQueryParameters WithSwitchPmText(string switchPmText)
+        {
+            SwitchPmText = switchPmText;
+            return this;
+        }
+
+        /// <summary>
+        ///     Sets <see cref="SwitchPmParameter" /> property.
+        /// </summary>
+        /// <param name="switchPmParameter">Parameter for the start message sent to the bot when user presses the switch button</param>
+        public AnswerInlineQueryParameters WithSwitchPmParameter(string switchPmParameter)
+        {
+            SwitchPmParameter = switchPmParameter;
+            return this;
+        }
+    }
+}

--- a/src/Telegram.Bot/Requests/Parameters/AnswerPreCheckoutQueryExtendedParameters.cs
+++ b/src/Telegram.Bot/Requests/Parameters/AnswerPreCheckoutQueryExtendedParameters.cs
@@ -1,0 +1,42 @@
+namespace Telegram.Bot.Requests.Parameters
+{
+    /// <summary>
+    ///     Parameters for <see cref="ITelegramBotClient.AnswerPreCheckoutQueryAsync" /> method.
+    /// </summary>
+    public class AnswerPreCheckoutQueryExtendedParameters : ParametersBase
+    {
+        /// <summary>
+        ///     Unique identifier for the query to be answered
+        /// </summary>
+        public string PreCheckoutQueryId { get; set; }
+
+        /// <summary>
+        ///     Required if OK is False. Error message in human readable form that explains the reason for failure to proceed with
+        ///     the checkout
+        /// </summary>
+        public string ErrorMessage { get; set; }
+
+        /// <summary>
+        ///     Sets <see cref="PreCheckoutQueryId" /> property.
+        /// </summary>
+        /// <param name="preCheckoutQueryId">Unique identifier for the query to be answered</param>
+        public AnswerPreCheckoutQueryExtendedParameters WithPreCheckoutQueryId(string preCheckoutQueryId)
+        {
+            PreCheckoutQueryId = preCheckoutQueryId;
+            return this;
+        }
+
+        /// <summary>
+        ///     Sets <see cref="ErrorMessage" /> property.
+        /// </summary>
+        /// <param name="errorMessage">
+        ///     Required if OK is False. Error message in human readable form that explains the reason for
+        ///     failure to proceed with the checkout
+        /// </param>
+        public AnswerPreCheckoutQueryExtendedParameters WithErrorMessage(string errorMessage)
+        {
+            ErrorMessage = errorMessage;
+            return this;
+        }
+    }
+}

--- a/src/Telegram.Bot/Requests/Parameters/AnswerPreCheckoutQueryParameters.cs
+++ b/src/Telegram.Bot/Requests/Parameters/AnswerPreCheckoutQueryParameters.cs
@@ -1,0 +1,23 @@
+namespace Telegram.Bot.Requests.Parameters
+{
+    /// <summary>
+    ///     Parameters for <see cref="ITelegramBotClient.AnswerPreCheckoutQueryAsync" /> method.
+    /// </summary>
+    public class AnswerPreCheckoutQueryParameters : ParametersBase
+    {
+        /// <summary>
+        ///     Unique identifier for the query to be answered
+        /// </summary>
+        public string PreCheckoutQueryId { get; set; }
+
+        /// <summary>
+        ///     Sets <see cref="PreCheckoutQueryId" /> property.
+        /// </summary>
+        /// <param name="preCheckoutQueryId">Unique identifier for the query to be answered</param>
+        public AnswerPreCheckoutQueryParameters WithPreCheckoutQueryId(string preCheckoutQueryId)
+        {
+            PreCheckoutQueryId = preCheckoutQueryId;
+            return this;
+        }
+    }
+}

--- a/src/Telegram.Bot/Requests/Parameters/AnswerShippingQueryExtendedParameters.cs
+++ b/src/Telegram.Bot/Requests/Parameters/AnswerShippingQueryExtendedParameters.cs
@@ -1,0 +1,42 @@
+namespace Telegram.Bot.Requests.Parameters
+{
+    /// <summary>
+    ///     Parameters for <see cref="ITelegramBotClient.AnswerShippingQueryAsync" /> method.
+    /// </summary>
+    public class AnswerShippingQueryExtendedParameters : ParametersBase
+    {
+        /// <summary>
+        ///     Unique identifier for the query to be answered
+        /// </summary>
+        public string ShippingQueryId { get; set; }
+
+        /// <summary>
+        ///     Required if OK is False. Error message in human readable form that explains why it is impossible to complete the
+        ///     order
+        /// </summary>
+        public string ErrorMessage { get; set; }
+
+        /// <summary>
+        ///     Sets <see cref="ShippingQueryId" /> property.
+        /// </summary>
+        /// <param name="shippingQueryId">Unique identifier for the query to be answered</param>
+        public AnswerShippingQueryExtendedParameters WithShippingQueryId(string shippingQueryId)
+        {
+            ShippingQueryId = shippingQueryId;
+            return this;
+        }
+
+        /// <summary>
+        ///     Sets <see cref="ErrorMessage" /> property.
+        /// </summary>
+        /// <param name="errorMessage">
+        ///     Required if OK is False. Error message in human readable form that explains why it is
+        ///     impossible to complete the order
+        /// </param>
+        public AnswerShippingQueryExtendedParameters WithErrorMessage(string errorMessage)
+        {
+            ErrorMessage = errorMessage;
+            return this;
+        }
+    }
+}

--- a/src/Telegram.Bot/Requests/Parameters/AnswerShippingQueryParameters.cs
+++ b/src/Telegram.Bot/Requests/Parameters/AnswerShippingQueryParameters.cs
@@ -1,0 +1,39 @@
+using System.Collections.Generic;
+using Telegram.Bot.Types.Payments;
+
+namespace Telegram.Bot.Requests.Parameters
+{
+    /// <summary>
+    ///     Parameters for <see cref="ITelegramBotClient.AnswerShippingQueryAsync" /> method.
+    /// </summary>
+    public class AnswerShippingQueryParameters : ParametersBase
+    {
+        /// <summary>
+        ///     Unique identifier for the query to be answered
+        /// </summary>
+        public string ShippingQueryId { get; set; }
+
+        /// <summary>
+        /// </summary>
+        public IEnumerable<ShippingOption> ShippingOptions { get; set; }
+
+        /// <summary>
+        ///     Sets <see cref="ShippingQueryId" /> property.
+        /// </summary>
+        /// <param name="shippingQueryId">Unique identifier for the query to be answered</param>
+        public AnswerShippingQueryParameters WithShippingQueryId(string shippingQueryId)
+        {
+            ShippingQueryId = shippingQueryId;
+            return this;
+        }
+
+        /// <summary>
+        ///     Sets <see cref="ShippingOptions" /> property.
+        /// </summary>
+        public AnswerShippingQueryParameters WithShippingOptions(IEnumerable<ShippingOption> shippingOptions)
+        {
+            ShippingOptions = shippingOptions;
+            return this;
+        }
+    }
+}

--- a/src/Telegram.Bot/Requests/Parameters/CreateNewAnimatedStickerSetParameters.cs
+++ b/src/Telegram.Bot/Requests/Parameters/CreateNewAnimatedStickerSetParameters.cs
@@ -1,0 +1,122 @@
+using Telegram.Bot.Types;
+using Telegram.Bot.Types.InputFiles;
+
+namespace Telegram.Bot.Requests.Parameters
+{
+    /// <summary>
+    ///     Parameters for <see cref="ITelegramBotClient.CreateNewAnimatedStickerSetAsync" /> method.
+    /// </summary>
+    public class CreateNewAnimatedStickerSetParameters : ParametersBase
+    {
+        /// <summary>
+        ///     User identifier of created sticker set owner
+        /// </summary>
+        public int UserId { get; set; }
+
+        /// <summary>
+        ///     Short name of sticker set, to be used in t.me/addstickers/ URLs (e.g., animals). Can contain only English letters,
+        ///     digits and underscores. Must begin with a letter, can't contain consecutive underscores and must end in “_by_&lt;
+        ///     bot_username&gt;”. &lt;bot_username&gt; is case insensitive. 1-64 characters.
+        /// </summary>
+        public string Name { get; set; }
+
+        /// <summary>
+        ///     Sticker set title, 1-64 characters
+        /// </summary>
+        public string Title { get; set; }
+
+        /// <summary>
+        ///     Tgs animation with the sticker
+        /// </summary>
+        public InputFileStream TgsSticker { get; set; }
+
+        /// <summary>
+        ///     One or more emoji corresponding to the sticker
+        /// </summary>
+        public string Emojis { get; set; }
+
+        /// <summary>
+        ///     Pass True, if a set of mask stickers should be created
+        /// </summary>
+        public bool IsMasks { get; set; }
+
+        /// <summary>
+        ///     Position where the mask should be placed on faces
+        /// </summary>
+        public MaskPosition MaskPosition { get; set; }
+
+        /// <summary>
+        ///     Sets <see cref="UserId" /> property.
+        /// </summary>
+        /// <param name="userId">User identifier of created sticker set owner</param>
+        public CreateNewAnimatedStickerSetParameters WithUserId(int userId)
+        {
+            UserId = userId;
+            return this;
+        }
+
+        /// <summary>
+        ///     Sets <see cref="Name" /> property.
+        /// </summary>
+        /// <param name="name">
+        ///     Short name of sticker set, to be used in t.me/addstickers/ URLs (e.g., animals). Can contain only
+        ///     English letters, digits and underscores. Must begin with a letter, can't contain consecutive underscores and must
+        ///     end in “_by_&lt;bot_username&gt;”. &lt;bot_username&gt; is case insensitive. 1-64 characters.
+        /// </param>
+        public CreateNewAnimatedStickerSetParameters WithName(string name)
+        {
+            Name = name;
+            return this;
+        }
+
+        /// <summary>
+        ///     Sets <see cref="Title" /> property.
+        /// </summary>
+        /// <param name="title">Sticker set title, 1-64 characters</param>
+        public CreateNewAnimatedStickerSetParameters WithTitle(string title)
+        {
+            Title = title;
+            return this;
+        }
+
+        /// <summary>
+        ///     Sets <see cref="TgsSticker" /> property.
+        /// </summary>
+        /// <param name="tgsSticker">Tgs animation with the sticker</param>
+        public CreateNewAnimatedStickerSetParameters WithTgsSticker(InputFileStream tgsSticker)
+        {
+            TgsSticker = tgsSticker;
+            return this;
+        }
+
+        /// <summary>
+        ///     Sets <see cref="Emojis" /> property.
+        /// </summary>
+        /// <param name="emojis">One or more emoji corresponding to the sticker</param>
+        public CreateNewAnimatedStickerSetParameters WithEmojis(string emojis)
+        {
+            Emojis = emojis;
+            return this;
+        }
+
+        /// <summary>
+        ///     Sets <see cref="IsMasks" /> property.
+        /// </summary>
+        /// <param name="isMasks">Pass True, if a set of mask stickers should be created</param>
+        public CreateNewAnimatedStickerSetParameters WithIsMasks(bool isMasks)
+        {
+            IsMasks = isMasks;
+            return this;
+        }
+
+        /// <summary>
+        ///     Sets <see cref="MaskPosition" /> property.
+        /// </summary>
+        /// <param name="maskPosition">Position where the mask should be placed on faces</param>
+        public CreateNewAnimatedStickerSetParameters WithMaskPosition(MaskPosition maskPosition)
+        {
+            MaskPosition = maskPosition;
+            return this;
+        }
+    }
+}

--- a/src/Telegram.Bot/Requests/Parameters/CreateNewStickerSetParameters.cs
+++ b/src/Telegram.Bot/Requests/Parameters/CreateNewStickerSetParameters.cs
@@ -1,0 +1,126 @@
+using Telegram.Bot.Types;
+using Telegram.Bot.Types.InputFiles;
+
+namespace Telegram.Bot.Requests.Parameters
+{
+    /// <summary>
+    ///     Parameters for <see cref="ITelegramBotClient.CreateNewStickerSetAsync" /> method.
+    /// </summary>
+    public class CreateNewStickerSetParameters : ParametersBase
+    {
+        /// <summary>
+        ///     User identifier of created sticker set owner
+        /// </summary>
+        public int UserId { get; set; }
+
+        /// <summary>
+        ///     Short name of sticker set, to be used in t.me/addstickers/ URLs (e.g., animals). Can contain only English letters,
+        ///     digits and underscores. Must begin with a letter, can't contain consecutive underscores and must end in “_by_&lt;
+        ///     bot_username&gt;”. &lt;bot_username&gt; is case insensitive. 1-64 characters.
+        /// </summary>
+        public string Name { get; set; }
+
+        /// <summary>
+        ///     Sticker set title, 1-64 characters
+        /// </summary>
+        public string Title { get; set; }
+
+        /// <summary>
+        ///     Png image with the sticker, must be up to 512 kilobytes in size, dimensions must not exceed 512px, and either width
+        ///     or height must be exactly 512px.
+        /// </summary>
+        public InputOnlineFile PngSticker { get; set; }
+
+        /// <summary>
+        ///     One or more emoji corresponding to the sticker
+        /// </summary>
+        public string Emojis { get; set; }
+
+        /// <summary>
+        ///     Pass True, if a set of mask stickers should be created
+        /// </summary>
+        public bool IsMasks { get; set; }
+
+        /// <summary>
+        ///     Position where the mask should be placed on faces
+        /// </summary>
+        public MaskPosition MaskPosition { get; set; }
+
+        /// <summary>
+        ///     Sets <see cref="UserId" /> property.
+        /// </summary>
+        /// <param name="userId">User identifier of created sticker set owner</param>
+        public CreateNewStickerSetParameters WithUserId(int userId)
+        {
+            UserId = userId;
+            return this;
+        }
+
+        /// <summary>
+        ///     Sets <see cref="Name" /> property.
+        /// </summary>
+        /// <param name="name">
+        ///     Short name of sticker set, to be used in t.me/addstickers/ URLs (e.g., animals). Can contain only
+        ///     English letters, digits and underscores. Must begin with a letter, can't contain consecutive underscores and must
+        ///     end in “_by_&lt;bot_username&gt;”. &lt;bot_username&gt; is case insensitive. 1-64 characters.
+        /// </param>
+        public CreateNewStickerSetParameters WithName(string name)
+        {
+            Name = name;
+            return this;
+        }
+
+        /// <summary>
+        ///     Sets <see cref="Title" /> property.
+        /// </summary>
+        /// <param name="title">Sticker set title, 1-64 characters</param>
+        public CreateNewStickerSetParameters WithTitle(string title)
+        {
+            Title = title;
+            return this;
+        }
+
+        /// <summary>
+        ///     Sets <see cref="PngSticker" /> property.
+        /// </summary>
+        /// <param name="pngSticker">
+        ///     Png image with the sticker, must be up to 512 kilobytes in size, dimensions must not exceed
+        ///     512px, and either width or height must be exactly 512px.
+        /// </param>
+        public CreateNewStickerSetParameters WithPngSticker(InputOnlineFile pngSticker)
+        {
+            PngSticker = pngSticker;
+            return this;
+        }
+
+        /// <summary>
+        ///     Sets <see cref="Emojis" /> property.
+        /// </summary>
+        /// <param name="emojis">One or more emoji corresponding to the sticker</param>
+        public CreateNewStickerSetParameters WithEmojis(string emojis)
+        {
+            Emojis = emojis;
+            return this;
+        }
+
+        /// <summary>
+        ///     Sets <see cref="IsMasks" /> property.
+        /// </summary>
+        /// <param name="isMasks">Pass True, if a set of mask stickers should be created</param>
+        public CreateNewStickerSetParameters WithIsMasks(bool isMasks)
+        {
+            IsMasks = isMasks;
+            return this;
+        }
+
+        /// <summary>
+        ///     Sets <see cref="MaskPosition" /> property.
+        /// </summary>
+        /// <param name="maskPosition">Position where the mask should be placed on faces</param>
+        public CreateNewStickerSetParameters WithMaskPosition(MaskPosition maskPosition)
+        {
+            MaskPosition = maskPosition;
+            return this;
+        }
+    }
+}

--- a/src/Telegram.Bot/Requests/Parameters/DeleteChatPhotoParameters.cs
+++ b/src/Telegram.Bot/Requests/Parameters/DeleteChatPhotoParameters.cs
@@ -1,0 +1,25 @@
+using Telegram.Bot.Types;
+
+namespace Telegram.Bot.Requests.Parameters
+{
+    /// <summary>
+    ///     Parameters for <see cref="ITelegramBotClient.DeleteChatPhotoAsync" /> method.
+    /// </summary>
+    public class DeleteChatPhotoParameters : ParametersBase
+    {
+        /// <summary>
+        ///     Unique identifier for the target chat or username of the target channel
+        /// </summary>
+        public ChatId ChatId { get; set; }
+
+        /// <summary>
+        ///     Sets <see cref="ChatId" /> property.
+        /// </summary>
+        /// <param name="chatId">Unique identifier for the target chat or username of the target channel</param>
+        public DeleteChatPhotoParameters WithChatId(ChatId chatId)
+        {
+            ChatId = chatId;
+            return this;
+        }
+    }
+}

--- a/src/Telegram.Bot/Requests/Parameters/DeleteChatStickerSetParameters.cs
+++ b/src/Telegram.Bot/Requests/Parameters/DeleteChatStickerSetParameters.cs
@@ -1,0 +1,28 @@
+using Telegram.Bot.Types;
+
+namespace Telegram.Bot.Requests.Parameters
+{
+    /// <summary>
+    ///     Parameters for <see cref="ITelegramBotClient.DeleteChatStickerSetAsync" /> method.
+    /// </summary>
+    public class DeleteChatStickerSetParameters : ParametersBase
+    {
+        /// <summary>
+        ///     Unique identifier for the target chat or username of the target supergroup (in the format @supergroupusername)
+        /// </summary>
+        public ChatId ChatId { get; set; }
+
+        /// <summary>
+        ///     Sets <see cref="ChatId" /> property.
+        /// </summary>
+        /// <param name="chatId">
+        ///     Unique identifier for the target chat or username of the target supergroup (in the format
+        ///     @supergroupusername)
+        /// </param>
+        public DeleteChatStickerSetParameters WithChatId(ChatId chatId)
+        {
+            ChatId = chatId;
+            return this;
+        }
+    }
+}

--- a/src/Telegram.Bot/Requests/Parameters/DeleteMessageParameters.cs
+++ b/src/Telegram.Bot/Requests/Parameters/DeleteMessageParameters.cs
@@ -1,0 +1,39 @@
+using Telegram.Bot.Types;
+
+namespace Telegram.Bot.Requests.Parameters
+{
+    /// <summary>
+    ///     Parameters for <see cref="ITelegramBotClient.DeleteMessageAsync" /> method.
+    /// </summary>
+    public class DeleteMessageParameters : ParametersBase
+    {
+        /// <summary>
+        /// </summary>
+        public ChatId ChatId { get; set; }
+
+        /// <summary>
+        ///     Unique identifier of the message to delete
+        /// </summary>
+        public int MessageId { get; set; }
+
+        /// <summary>
+        ///     Sets <see cref="ChatId" /> property.
+        /// </summary>
+        /// <param name="chatId"></param>
+        public DeleteMessageParameters WithChatId(ChatId chatId)
+        {
+            ChatId = chatId;
+            return this;
+        }
+
+        /// <summary>
+        ///     Sets <see cref="MessageId" /> property.
+        /// </summary>
+        /// <param name="messageId">Unique identifier of the message to delete</param>
+        public DeleteMessageParameters WithMessageId(int messageId)
+        {
+            MessageId = messageId;
+            return this;
+        }
+    }
+}

--- a/src/Telegram.Bot/Requests/Parameters/DeleteStickerFromSetParameters.cs
+++ b/src/Telegram.Bot/Requests/Parameters/DeleteStickerFromSetParameters.cs
@@ -1,0 +1,23 @@
+namespace Telegram.Bot.Requests.Parameters
+{
+    /// <summary>
+    ///     Parameters for <see cref="ITelegramBotClient.DeleteStickerFromSetAsync" /> method.
+    /// </summary>
+    public class DeleteStickerFromSetParameters : ParametersBase
+    {
+        /// <summary>
+        ///     File identifier of the sticker
+        /// </summary>
+        public string Sticker { get; set; }
+
+        /// <summary>
+        ///     Sets <see cref="Sticker" /> property.
+        /// </summary>
+        /// <param name="sticker">File identifier of the sticker</param>
+        public DeleteStickerFromSetParameters WithSticker(string sticker)
+        {
+            Sticker = sticker;
+            return this;
+        }
+    }
+}

--- a/src/Telegram.Bot/Requests/Parameters/DownloadFileExtendedParameters.cs
+++ b/src/Telegram.Bot/Requests/Parameters/DownloadFileExtendedParameters.cs
@@ -1,0 +1,40 @@
+using System.IO;
+
+namespace Telegram.Bot.Requests.Parameters
+{
+    /// <summary>
+    ///     Parameters for <see cref="ITelegramBotClient.DownloadFileAsync" /> method.
+    /// </summary>
+    public class DownloadFileExtendedParameters : ParametersBase
+    {
+        /// <summary>
+        ///     Path to file on server
+        /// </summary>
+        public string FilePath { get; set; }
+
+        /// <summary>
+        ///     Destination stream to write file to
+        /// </summary>
+        public Stream Destination { get; set; }
+
+        /// <summary>
+        ///     Sets <see cref="FilePath" /> property.
+        /// </summary>
+        /// <param name="filePath">Path to file on server</param>
+        public DownloadFileExtendedParameters WithFilePath(string filePath)
+        {
+            FilePath = filePath;
+            return this;
+        }
+
+        /// <summary>
+        ///     Sets <see cref="Destination" /> property.
+        /// </summary>
+        /// <param name="destination">Destination stream to write file to</param>
+        public DownloadFileExtendedParameters WithDestination(Stream destination)
+        {
+            Destination = destination;
+            return this;
+        }
+    }
+}

--- a/src/Telegram.Bot/Requests/Parameters/DownloadFileParameters.cs
+++ b/src/Telegram.Bot/Requests/Parameters/DownloadFileParameters.cs
@@ -1,0 +1,23 @@
+namespace Telegram.Bot.Requests.Parameters
+{
+    /// <summary>
+    ///     Parameters for <see cref="ITelegramBotClient.DownloadFileAsync" /> method.
+    /// </summary>
+    public class DownloadFileParameters : ParametersBase
+    {
+        /// <summary>
+        ///     Path to file on server
+        /// </summary>
+        public string FilePath { get; set; }
+
+        /// <summary>
+        ///     Sets <see cref="FilePath" /> property.
+        /// </summary>
+        /// <param name="filePath">Path to file on server</param>
+        public DownloadFileParameters WithFilePath(string filePath)
+        {
+            FilePath = filePath;
+            return this;
+        }
+    }
+}

--- a/src/Telegram.Bot/Requests/Parameters/EditMessageCaptionInlineParameters.cs
+++ b/src/Telegram.Bot/Requests/Parameters/EditMessageCaptionInlineParameters.cs
@@ -1,0 +1,75 @@
+using Telegram.Bot.Types.Enums;
+using Telegram.Bot.Types.ReplyMarkups;
+
+namespace Telegram.Bot.Requests.Parameters
+{
+    /// <summary>
+    ///     Parameters for <see cref="ITelegramBotClient.EditMessageCaptionAsync" /> method.
+    /// </summary>
+    public class EditMessageCaptionInlineParameters : ParametersBase
+    {
+        /// <summary>
+        ///     Unique identifier of the sent message
+        /// </summary>
+        public string InlineMessageId { get; set; }
+
+        /// <summary>
+        ///     New caption of the message
+        /// </summary>
+        public string Caption { get; set; }
+
+        /// <summary>
+        ///     A JSON-serialized object for an inline keyboard.
+        /// </summary>
+        public InlineKeyboardMarkup ReplyMarkup { get; set; }
+
+        /// <summary>
+        ///     Send Markdown or HTML, if you want Telegram apps to show bold, italic, fixed-width text or inline URLs in the media
+        ///     caption.
+        /// </summary>
+        public ParseMode ParseMode { get; set; }
+
+        /// <summary>
+        ///     Sets <see cref="InlineMessageId" /> property.
+        /// </summary>
+        /// <param name="inlineMessageId">Unique identifier of the sent message</param>
+        public EditMessageCaptionInlineParameters WithInlineMessageId(string inlineMessageId)
+        {
+            InlineMessageId = inlineMessageId;
+            return this;
+        }
+
+        /// <summary>
+        ///     Sets <see cref="Caption" /> property.
+        /// </summary>
+        /// <param name="caption">New caption of the message</param>
+        public EditMessageCaptionInlineParameters WithCaption(string caption)
+        {
+            Caption = caption;
+            return this;
+        }
+
+        /// <summary>
+        ///     Sets <see cref="ReplyMarkup" /> property.
+        /// </summary>
+        /// <param name="replyMarkup">A JSON-serialized object for an inline keyboard.</param>
+        public EditMessageCaptionInlineParameters WithReplyMarkup(InlineKeyboardMarkup replyMarkup)
+        {
+            ReplyMarkup = replyMarkup;
+            return this;
+        }
+
+        /// <summary>
+        ///     Sets <see cref="ParseMode" /> property.
+        /// </summary>
+        /// <param name="parseMode">
+        ///     Send Markdown or HTML, if you want Telegram apps to show bold, italic, fixed-width text or
+        ///     inline URLs in the media caption.
+        /// </param>
+        public EditMessageCaptionInlineParameters WithParseMode(ParseMode parseMode)
+        {
+            ParseMode = parseMode;
+            return this;
+        }
+    }
+}

--- a/src/Telegram.Bot/Requests/Parameters/EditMessageCaptionParameters.cs
+++ b/src/Telegram.Bot/Requests/Parameters/EditMessageCaptionParameters.cs
@@ -1,0 +1,87 @@
+using Telegram.Bot.Types;
+using Telegram.Bot.Types.Enums;
+using Telegram.Bot.Types.ReplyMarkups;
+
+namespace Telegram.Bot.Requests.Parameters
+{
+    /// <summary>
+    ///     Parameters for <see cref="ITelegramBotClient.EditMessageCaptionAsync" /> method.
+    /// </summary>
+    public class EditMessageCaptionParameters : ParametersBase
+    {
+        /// <summary>
+        /// </summary>
+        public ChatId ChatId { get; set; }
+
+        /// <summary>
+        /// </summary>
+        public int MessageId { get; set; }
+
+        /// <summary>
+        ///     New caption of the message
+        /// </summary>
+        public string Caption { get; set; }
+
+        /// <summary>
+        ///     A JSON-serialized object for an inline keyboard.
+        /// </summary>
+        public InlineKeyboardMarkup ReplyMarkup { get; set; }
+
+        /// <summary>
+        ///     Send Markdown or HTML, if you want Telegram apps to show bold, italic, fixed-width text or inline URLs in the media
+        ///     caption.
+        /// </summary>
+        public ParseMode ParseMode { get; set; }
+
+        /// <summary>
+        ///     Sets <see cref="ChatId" /> property.
+        /// </summary>
+        public EditMessageCaptionParameters WithChatId(ChatId chatId)
+        {
+            ChatId = chatId;
+            return this;
+        }
+
+        /// <summary>
+        ///     Sets <see cref="MessageId" /> property.
+        /// </summary>
+        public EditMessageCaptionParameters WithMessageId(int messageId)
+        {
+            MessageId = messageId;
+            return this;
+        }
+
+        /// <summary>
+        ///     Sets <see cref="Caption" /> property.
+        /// </summary>
+        /// <param name="caption">New caption of the message</param>
+        public EditMessageCaptionParameters WithCaption(string caption)
+        {
+            Caption = caption;
+            return this;
+        }
+
+        /// <summary>
+        ///     Sets <see cref="ReplyMarkup" /> property.
+        /// </summary>
+        /// <param name="replyMarkup">A JSON-serialized object for an inline keyboard.</param>
+        public EditMessageCaptionParameters WithReplyMarkup(InlineKeyboardMarkup replyMarkup)
+        {
+            ReplyMarkup = replyMarkup;
+            return this;
+        }
+
+        /// <summary>
+        ///     Sets <see cref="ParseMode" /> property.
+        /// </summary>
+        /// <param name="parseMode">
+        ///     Send Markdown or HTML, if you want Telegram apps to show bold, italic, fixed-width text or
+        ///     inline URLs in the media caption.
+        /// </param>
+        public EditMessageCaptionParameters WithParseMode(ParseMode parseMode)
+        {
+            ParseMode = parseMode;
+            return this;
+        }
+    }
+}

--- a/src/Telegram.Bot/Requests/Parameters/EditMessageLiveLocationInlineParameters.cs
+++ b/src/Telegram.Bot/Requests/Parameters/EditMessageLiveLocationInlineParameters.cs
@@ -1,0 +1,70 @@
+using Telegram.Bot.Types.ReplyMarkups;
+
+namespace Telegram.Bot.Requests.Parameters
+{
+    /// <summary>
+    ///     Parameters for <see cref="ITelegramBotClient.EditMessageLiveLocationAsync" /> method.
+    /// </summary>
+    public class EditMessageLiveLocationInlineParameters : ParametersBase
+    {
+        /// <summary>
+        ///     Unique identifier of the sent message
+        /// </summary>
+        public string InlineMessageId { get; set; }
+
+        /// <summary>
+        ///     Latitude of location
+        /// </summary>
+        public float Latitude { get; set; }
+
+        /// <summary>
+        ///     Longitude of location
+        /// </summary>
+        public float Longitude { get; set; }
+
+        /// <summary>
+        ///     A JSON-serialized object for an inline keyboard.
+        /// </summary>
+        public InlineKeyboardMarkup ReplyMarkup { get; set; }
+
+        /// <summary>
+        ///     Sets <see cref="InlineMessageId" /> property.
+        /// </summary>
+        /// <param name="inlineMessageId">Unique identifier of the sent message</param>
+        public EditMessageLiveLocationInlineParameters WithInlineMessageId(string inlineMessageId)
+        {
+            InlineMessageId = inlineMessageId;
+            return this;
+        }
+
+        /// <summary>
+        ///     Sets <see cref="Latitude" /> property.
+        /// </summary>
+        /// <param name="latitude">Latitude of location</param>
+        public EditMessageLiveLocationInlineParameters WithLatitude(float latitude)
+        {
+            Latitude = latitude;
+            return this;
+        }
+
+        /// <summary>
+        ///     Sets <see cref="Longitude" /> property.
+        /// </summary>
+        /// <param name="longitude">Longitude of location</param>
+        public EditMessageLiveLocationInlineParameters WithLongitude(float longitude)
+        {
+            Longitude = longitude;
+            return this;
+        }
+
+        /// <summary>
+        ///     Sets <see cref="ReplyMarkup" /> property.
+        /// </summary>
+        /// <param name="replyMarkup">A JSON-serialized object for an inline keyboard.</param>
+        public EditMessageLiveLocationInlineParameters WithReplyMarkup(InlineKeyboardMarkup replyMarkup)
+        {
+            ReplyMarkup = replyMarkup;
+            return this;
+        }
+    }
+}

--- a/src/Telegram.Bot/Requests/Parameters/EditMessageLiveLocationParameters.cs
+++ b/src/Telegram.Bot/Requests/Parameters/EditMessageLiveLocationParameters.cs
@@ -1,0 +1,82 @@
+using Telegram.Bot.Types;
+using Telegram.Bot.Types.ReplyMarkups;
+
+namespace Telegram.Bot.Requests.Parameters
+{
+    /// <summary>
+    ///     Parameters for <see cref="ITelegramBotClient.EditMessageLiveLocationAsync" /> method.
+    /// </summary>
+    public class EditMessageLiveLocationParameters : ParametersBase
+    {
+        /// <summary>
+        /// </summary>
+        public ChatId ChatId { get; set; }
+
+        /// <summary>
+        /// </summary>
+        public int MessageId { get; set; }
+
+        /// <summary>
+        ///     Latitude of location
+        /// </summary>
+        public float Latitude { get; set; }
+
+        /// <summary>
+        ///     Longitude of location
+        /// </summary>
+        public float Longitude { get; set; }
+
+        /// <summary>
+        ///     A JSON-serialized object for an inline keyboard.
+        /// </summary>
+        public InlineKeyboardMarkup ReplyMarkup { get; set; }
+
+        /// <summary>
+        ///     Sets <see cref="ChatId" /> property.
+        /// </summary>
+        public EditMessageLiveLocationParameters WithChatId(ChatId chatId)
+        {
+            ChatId = chatId;
+            return this;
+        }
+
+        /// <summary>
+        ///     Sets <see cref="MessageId" /> property.
+        /// </summary>
+        public EditMessageLiveLocationParameters WithMessageId(int messageId)
+        {
+            MessageId = messageId;
+            return this;
+        }
+
+        /// <summary>
+        ///     Sets <see cref="Latitude" /> property.
+        /// </summary>
+        /// <param name="latitude">Latitude of location</param>
+        public EditMessageLiveLocationParameters WithLatitude(float latitude)
+        {
+            Latitude = latitude;
+            return this;
+        }
+
+        /// <summary>
+        ///     Sets <see cref="Longitude" /> property.
+        /// </summary>
+        /// <param name="longitude">Longitude of location</param>
+        public EditMessageLiveLocationParameters WithLongitude(float longitude)
+        {
+            Longitude = longitude;
+            return this;
+        }
+
+        /// <summary>
+        ///     Sets <see cref="ReplyMarkup" /> property.
+        /// </summary>
+        /// <param name="replyMarkup">A JSON-serialized object for an inline keyboard.</param>
+        public EditMessageLiveLocationParameters WithReplyMarkup(InlineKeyboardMarkup replyMarkup)
+        {
+            ReplyMarkup = replyMarkup;
+            return this;
+        }
+    }
+}

--- a/src/Telegram.Bot/Requests/Parameters/EditMessageMediaInlineParameters.cs
+++ b/src/Telegram.Bot/Requests/Parameters/EditMessageMediaInlineParameters.cs
@@ -1,0 +1,56 @@
+using Telegram.Bot.Types;
+using Telegram.Bot.Types.ReplyMarkups;
+
+namespace Telegram.Bot.Requests.Parameters
+{
+    /// <summary>
+    ///     Parameters for <see cref="ITelegramBotClient.EditMessageMediaAsync" /> method.
+    /// </summary>
+    public class EditMessageMediaInlineParameters : ParametersBase
+    {
+        /// <summary>
+        ///     Unique identifier of the sent message
+        /// </summary>
+        public string InlineMessageId { get; set; }
+
+        /// <summary>
+        ///     A JSON-serialized object for a new media content of the message
+        /// </summary>
+        public InputMediaBase Media { get; set; }
+
+        /// <summary>
+        ///     A JSON-serialized object for an inline keyboard.
+        /// </summary>
+        public InlineKeyboardMarkup ReplyMarkup { get; set; }
+
+        /// <summary>
+        ///     Sets <see cref="InlineMessageId" /> property.
+        /// </summary>
+        /// <param name="inlineMessageId">Unique identifier of the sent message</param>
+        public EditMessageMediaInlineParameters WithInlineMessageId(string inlineMessageId)
+        {
+            InlineMessageId = inlineMessageId;
+            return this;
+        }
+
+        /// <summary>
+        ///     Sets <see cref="Media" /> property.
+        /// </summary>
+        /// <param name="media">A JSON-serialized object for a new media content of the message</param>
+        public EditMessageMediaInlineParameters WithMedia(InputMediaBase media)
+        {
+            Media = media;
+            return this;
+        }
+
+        /// <summary>
+        ///     Sets <see cref="ReplyMarkup" /> property.
+        /// </summary>
+        /// <param name="replyMarkup">A JSON-serialized object for an inline keyboard.</param>
+        public EditMessageMediaInlineParameters WithReplyMarkup(InlineKeyboardMarkup replyMarkup)
+        {
+            ReplyMarkup = replyMarkup;
+            return this;
+        }
+    }
+}

--- a/src/Telegram.Bot/Requests/Parameters/EditMessageMediaParameters.cs
+++ b/src/Telegram.Bot/Requests/Parameters/EditMessageMediaParameters.cs
@@ -1,0 +1,67 @@
+using Telegram.Bot.Types;
+using Telegram.Bot.Types.ReplyMarkups;
+
+namespace Telegram.Bot.Requests.Parameters
+{
+    /// <summary>
+    ///     Parameters for <see cref="ITelegramBotClient.EditMessageMediaAsync" /> method.
+    /// </summary>
+    public class EditMessageMediaParameters : ParametersBase
+    {
+        /// <summary>
+        /// </summary>
+        public ChatId ChatId { get; set; }
+
+        /// <summary>
+        /// </summary>
+        public int MessageId { get; set; }
+
+        /// <summary>
+        ///     A JSON-serialized object for a new media content of the message
+        /// </summary>
+        public InputMediaBase Media { get; set; }
+
+        /// <summary>
+        ///     A JSON-serialized object for an inline keyboard.
+        /// </summary>
+        public InlineKeyboardMarkup ReplyMarkup { get; set; }
+
+        /// <summary>
+        ///     Sets <see cref="ChatId" /> property.
+        /// </summary>
+        public EditMessageMediaParameters WithChatId(ChatId chatId)
+        {
+            ChatId = chatId;
+            return this;
+        }
+
+        /// <summary>
+        ///     Sets <see cref="MessageId" /> property.
+        /// </summary>
+        public EditMessageMediaParameters WithMessageId(int messageId)
+        {
+            MessageId = messageId;
+            return this;
+        }
+
+        /// <summary>
+        ///     Sets <see cref="Media" /> property.
+        /// </summary>
+        /// <param name="media">A JSON-serialized object for a new media content of the message</param>
+        public EditMessageMediaParameters WithMedia(InputMediaBase media)
+        {
+            Media = media;
+            return this;
+        }
+
+        /// <summary>
+        ///     Sets <see cref="ReplyMarkup" /> property.
+        /// </summary>
+        /// <param name="replyMarkup">A JSON-serialized object for an inline keyboard.</param>
+        public EditMessageMediaParameters WithReplyMarkup(InlineKeyboardMarkup replyMarkup)
+        {
+            ReplyMarkup = replyMarkup;
+            return this;
+        }
+    }
+}

--- a/src/Telegram.Bot/Requests/Parameters/EditMessageReplyMarkupInlineParameters.cs
+++ b/src/Telegram.Bot/Requests/Parameters/EditMessageReplyMarkupInlineParameters.cs
@@ -1,0 +1,40 @@
+using Telegram.Bot.Types.ReplyMarkups;
+
+namespace Telegram.Bot.Requests.Parameters
+{
+    /// <summary>
+    ///     Parameters for <see cref="ITelegramBotClient.EditMessageReplyMarkupAsync" /> method.
+    /// </summary>
+    public class EditMessageReplyMarkupInlineParameters : ParametersBase
+    {
+        /// <summary>
+        ///     Unique identifier of the sent message
+        /// </summary>
+        public string InlineMessageId { get; set; }
+
+        /// <summary>
+        ///     A JSON-serialized object for an inline keyboard.
+        /// </summary>
+        public InlineKeyboardMarkup ReplyMarkup { get; set; }
+
+        /// <summary>
+        ///     Sets <see cref="InlineMessageId" /> property.
+        /// </summary>
+        /// <param name="inlineMessageId">Unique identifier of the sent message</param>
+        public EditMessageReplyMarkupInlineParameters WithInlineMessageId(string inlineMessageId)
+        {
+            InlineMessageId = inlineMessageId;
+            return this;
+        }
+
+        /// <summary>
+        ///     Sets <see cref="ReplyMarkup" /> property.
+        /// </summary>
+        /// <param name="replyMarkup">A JSON-serialized object for an inline keyboard.</param>
+        public EditMessageReplyMarkupInlineParameters WithReplyMarkup(InlineKeyboardMarkup replyMarkup)
+        {
+            ReplyMarkup = replyMarkup;
+            return this;
+        }
+    }
+}

--- a/src/Telegram.Bot/Requests/Parameters/EditMessageReplyMarkupParameters.cs
+++ b/src/Telegram.Bot/Requests/Parameters/EditMessageReplyMarkupParameters.cs
@@ -1,0 +1,52 @@
+using Telegram.Bot.Types;
+using Telegram.Bot.Types.ReplyMarkups;
+
+namespace Telegram.Bot.Requests.Parameters
+{
+    /// <summary>
+    ///     Parameters for <see cref="ITelegramBotClient.EditMessageReplyMarkupAsync" /> method.
+    /// </summary>
+    public class EditMessageReplyMarkupParameters : ParametersBase
+    {
+        /// <summary>
+        /// </summary>
+        public ChatId ChatId { get; set; }
+
+        /// <summary>
+        /// </summary>
+        public int MessageId { get; set; }
+
+        /// <summary>
+        ///     A JSON-serialized object for an inline keyboard.
+        /// </summary>
+        public InlineKeyboardMarkup ReplyMarkup { get; set; }
+
+        /// <summary>
+        ///     Sets <see cref="ChatId" /> property.
+        /// </summary>
+        public EditMessageReplyMarkupParameters WithChatId(ChatId chatId)
+        {
+            ChatId = chatId;
+            return this;
+        }
+
+        /// <summary>
+        ///     Sets <see cref="MessageId" /> property.
+        /// </summary>
+        public EditMessageReplyMarkupParameters WithMessageId(int messageId)
+        {
+            MessageId = messageId;
+            return this;
+        }
+
+        /// <summary>
+        ///     Sets <see cref="ReplyMarkup" /> property.
+        /// </summary>
+        /// <param name="replyMarkup">A JSON-serialized object for an inline keyboard.</param>
+        public EditMessageReplyMarkupParameters WithReplyMarkup(InlineKeyboardMarkup replyMarkup)
+        {
+            ReplyMarkup = replyMarkup;
+            return this;
+        }
+    }
+}

--- a/src/Telegram.Bot/Requests/Parameters/EditMessageTextInlineParameters.cs
+++ b/src/Telegram.Bot/Requests/Parameters/EditMessageTextInlineParameters.cs
@@ -1,0 +1,90 @@
+using Telegram.Bot.Types.Enums;
+using Telegram.Bot.Types.ReplyMarkups;
+
+namespace Telegram.Bot.Requests.Parameters
+{
+    /// <summary>
+    ///     Parameters for <see cref="ITelegramBotClient.EditMessageTextAsync" /> method.
+    /// </summary>
+    public class EditMessageTextInlineParameters : ParametersBase
+    {
+        /// <summary>
+        ///     Identifier of the inline message
+        /// </summary>
+        public string InlineMessageId { get; set; }
+
+        /// <summary>
+        ///     New text of the message
+        /// </summary>
+        public string Text { get; set; }
+
+        /// <summary>
+        ///     Send Markdown or HTML, if you want Telegram apps to show bold, italic, fixed-width text or inline URLs in your
+        ///     bot's message.
+        /// </summary>
+        public ParseMode ParseMode { get; set; }
+
+        /// <summary>
+        ///     Disables link previews for links in this message
+        /// </summary>
+        public bool DisableWebPagePreview { get; set; }
+
+        /// <summary>
+        ///     A JSON-serialized object for an inline keyboard.
+        /// </summary>
+        public InlineKeyboardMarkup ReplyMarkup { get; set; }
+
+        /// <summary>
+        ///     Sets <see cref="InlineMessageId" /> property.
+        /// </summary>
+        /// <param name="inlineMessageId">Identifier of the inline message</param>
+        public EditMessageTextInlineParameters WithInlineMessageId(string inlineMessageId)
+        {
+            InlineMessageId = inlineMessageId;
+            return this;
+        }
+
+        /// <summary>
+        ///     Sets <see cref="Text" /> property.
+        /// </summary>
+        /// <param name="text">New text of the message</param>
+        public EditMessageTextInlineParameters WithText(string text)
+        {
+            Text = text;
+            return this;
+        }
+
+        /// <summary>
+        ///     Sets <see cref="ParseMode" /> property.
+        /// </summary>
+        /// <param name="parseMode">
+        ///     Send Markdown or HTML, if you want Telegram apps to show bold, italic, fixed-width text or
+        ///     inline URLs in your bot's message.
+        /// </param>
+        public EditMessageTextInlineParameters WithParseMode(ParseMode parseMode)
+        {
+            ParseMode = parseMode;
+            return this;
+        }
+
+        /// <summary>
+        ///     Sets <see cref="DisableWebPagePreview" /> property.
+        /// </summary>
+        /// <param name="disableWebPagePreview">Disables link previews for links in this message</param>
+        public EditMessageTextInlineParameters WithDisableWebPagePreview(bool disableWebPagePreview)
+        {
+            DisableWebPagePreview = disableWebPagePreview;
+            return this;
+        }
+
+        /// <summary>
+        ///     Sets <see cref="ReplyMarkup" /> property.
+        /// </summary>
+        /// <param name="replyMarkup">A JSON-serialized object for an inline keyboard.</param>
+        public EditMessageTextInlineParameters WithReplyMarkup(InlineKeyboardMarkup replyMarkup)
+        {
+            ReplyMarkup = replyMarkup;
+            return this;
+        }
+    }
+}

--- a/src/Telegram.Bot/Requests/Parameters/EditMessageTextParameters.cs
+++ b/src/Telegram.Bot/Requests/Parameters/EditMessageTextParameters.cs
@@ -1,0 +1,102 @@
+using Telegram.Bot.Types;
+using Telegram.Bot.Types.Enums;
+using Telegram.Bot.Types.ReplyMarkups;
+
+namespace Telegram.Bot.Requests.Parameters
+{
+    /// <summary>
+    ///     Parameters for <see cref="ITelegramBotClient.EditMessageTextAsync" /> method.
+    /// </summary>
+    public class EditMessageTextParameters : ParametersBase
+    {
+        /// <summary>
+        /// </summary>
+        public ChatId ChatId { get; set; }
+
+        /// <summary>
+        /// </summary>
+        public int MessageId { get; set; }
+
+        /// <summary>
+        ///     New text of the message
+        /// </summary>
+        public string Text { get; set; }
+
+        /// <summary>
+        ///     Send Markdown or HTML, if you want Telegram apps to show bold, italic, fixed-width text or inline URLs in your
+        ///     bot's message.
+        /// </summary>
+        public ParseMode ParseMode { get; set; }
+
+        /// <summary>
+        ///     Disables link previews for links in this message
+        /// </summary>
+        public bool DisableWebPagePreview { get; set; }
+
+        /// <summary>
+        ///     A JSON-serialized object for an inline keyboard.
+        /// </summary>
+        public InlineKeyboardMarkup ReplyMarkup { get; set; }
+
+        /// <summary>
+        ///     Sets <see cref="ChatId" /> property.
+        /// </summary>
+        public EditMessageTextParameters WithChatId(ChatId chatId)
+        {
+            ChatId = chatId;
+            return this;
+        }
+
+        /// <summary>
+        ///     Sets <see cref="MessageId" /> property.
+        /// </summary>
+        public EditMessageTextParameters WithMessageId(int messageId)
+        {
+            MessageId = messageId;
+            return this;
+        }
+
+        /// <summary>
+        ///     Sets <see cref="Text" /> property.
+        /// </summary>
+        /// <param name="text">New text of the message</param>
+        public EditMessageTextParameters WithText(string text)
+        {
+            Text = text;
+            return this;
+        }
+
+        /// <summary>
+        ///     Sets <see cref="ParseMode" /> property.
+        /// </summary>
+        /// <param name="parseMode">
+        ///     Send Markdown or HTML, if you want Telegram apps to show bold, italic, fixed-width text or
+        ///     inline URLs in your bot's message.
+        /// </param>
+        public EditMessageTextParameters WithParseMode(ParseMode parseMode)
+        {
+            ParseMode = parseMode;
+            return this;
+        }
+
+        /// <summary>
+        ///     Sets <see cref="DisableWebPagePreview" /> property.
+        /// </summary>
+        /// <param name="disableWebPagePreview">Disables link previews for links in this message</param>
+        public EditMessageTextParameters WithDisableWebPagePreview(bool disableWebPagePreview)
+        {
+            DisableWebPagePreview = disableWebPagePreview;
+            return this;
+        }
+
+        /// <summary>
+        ///     Sets <see cref="ReplyMarkup" /> property.
+        /// </summary>
+        /// <param name="replyMarkup">A JSON-serialized object for an inline keyboard.</param>
+        public EditMessageTextParameters WithReplyMarkup(InlineKeyboardMarkup replyMarkup)
+        {
+            ReplyMarkup = replyMarkup;
+            return this;
+        }
+    }
+}

--- a/src/Telegram.Bot/Requests/Parameters/ExportChatInviteLinkParameters.cs
+++ b/src/Telegram.Bot/Requests/Parameters/ExportChatInviteLinkParameters.cs
@@ -1,0 +1,25 @@
+using Telegram.Bot.Types;
+
+namespace Telegram.Bot.Requests.Parameters
+{
+    /// <summary>
+    ///     Parameters for <see cref="ITelegramBotClient.ExportChatInviteLinkAsync" /> method.
+    /// </summary>
+    public class ExportChatInviteLinkParameters : ParametersBase
+    {
+        /// <summary>
+        ///     Unique identifier for the target chat or username of the target channel
+        /// </summary>
+        public ChatId ChatId { get; set; }
+
+        /// <summary>
+        ///     Sets <see cref="ChatId" /> property.
+        /// </summary>
+        /// <param name="chatId">Unique identifier for the target chat or username of the target channel</param>
+        public ExportChatInviteLinkParameters WithChatId(ChatId chatId)
+        {
+            ChatId = chatId;
+            return this;
+        }
+    }
+}

--- a/src/Telegram.Bot/Requests/Parameters/ForwardMessageParameters.cs
+++ b/src/Telegram.Bot/Requests/Parameters/ForwardMessageParameters.cs
@@ -1,0 +1,72 @@
+using Telegram.Bot.Types;
+
+namespace Telegram.Bot.Requests.Parameters
+{
+    /// <summary>
+    ///     Parameters for <see cref="ITelegramBotClient.ForwardMessageAsync" /> method.
+    /// </summary>
+    public class ForwardMessageParameters : ParametersBase
+    {
+        /// <summary>
+        /// </summary>
+        public ChatId ChatId { get; set; }
+
+        /// <summary>
+        /// </summary>
+        public ChatId FromChatId { get; set; }
+
+        /// <summary>
+        ///     Unique message identifier
+        /// </summary>
+        public int MessageId { get; set; }
+
+        /// <summary>
+        ///     Sends the message silently. iOS users will not receive a notification, Android users will receive a notification
+        ///     with no sound.
+        /// </summary>
+        public bool DisableNotification { get; set; }
+
+        /// <summary>
+        ///     Sets <see cref="ChatId" /> property.
+        /// </summary>
+        /// <param name="chatId"></param>
+        public ForwardMessageParameters WithChatId(ChatId chatId)
+        {
+            ChatId = chatId;
+            return this;
+        }
+
+        /// <summary>
+        ///     Sets <see cref="FromChatId" /> property.
+        /// </summary>
+        /// <param name="fromChatId"></param>
+        public ForwardMessageParameters WithFromChatId(ChatId fromChatId)
+        {
+            FromChatId = fromChatId;
+            return this;
+        }
+
+        /// <summary>
+        ///     Sets <see cref="MessageId" /> property.
+        /// </summary>
+        /// <param name="messageId">Unique message identifier</param>
+        public ForwardMessageParameters WithMessageId(int messageId)
+        {
+            MessageId = messageId;
+            return this;
+        }
+
+        /// <summary>
+        ///     Sets <see cref="DisableNotification" /> property.
+        /// </summary>
+        /// <param name="disableNotification">
+        ///     Sends the message silently. iOS users will not receive a notification, Android users
+        ///     will receive a notification with no sound.
+        /// </param>
+        public ForwardMessageParameters WithDisableNotification(bool disableNotification)
+        {
+            DisableNotification = disableNotification;
+            return this;
+        }
+    }
+}

--- a/src/Telegram.Bot/Requests/Parameters/GetChatAdministratorsParameters.cs
+++ b/src/Telegram.Bot/Requests/Parameters/GetChatAdministratorsParameters.cs
@@ -1,0 +1,24 @@
+using Telegram.Bot.Types;
+
+namespace Telegram.Bot.Requests.Parameters
+{
+    /// <summary>
+    ///     Parameters for <see cref="ITelegramBotClient.GetChatAdministratorsAsync" /> method.
+    /// </summary>
+    public class GetChatAdministratorsParameters : ParametersBase
+    {
+        /// <summary>
+        /// </summary>
+        public ChatId ChatId { get; set; }
+
+        /// <summary>
+        ///     Sets <see cref="ChatId" /> property.
+        /// </summary>
+        /// <param name="chatId"></param>
+        public GetChatAdministratorsParameters WithChatId(ChatId chatId)
+        {
+            ChatId = chatId;
+            return this;
+        }
+    }
+}

--- a/src/Telegram.Bot/Requests/Parameters/GetChatMemberParameters.cs
+++ b/src/Telegram.Bot/Requests/Parameters/GetChatMemberParameters.cs
@@ -1,0 +1,39 @@
+using Telegram.Bot.Types;
+
+namespace Telegram.Bot.Requests.Parameters
+{
+    /// <summary>
+    ///     Parameters for <see cref="ITelegramBotClient.GetChatMemberAsync" /> method.
+    /// </summary>
+    public class GetChatMemberParameters : ParametersBase
+    {
+        /// <summary>
+        /// </summary>
+        public ChatId ChatId { get; set; }
+
+        /// <summary>
+        ///     Unique identifier of the target user
+        /// </summary>
+        public int UserId { get; set; }
+
+        /// <summary>
+        ///     Sets <see cref="ChatId" /> property.
+        /// </summary>
+        /// <param name="chatId"></param>
+        public GetChatMemberParameters WithChatId(ChatId chatId)
+        {
+            ChatId = chatId;
+            return this;
+        }
+
+        /// <summary>
+        ///     Sets <see cref="UserId" /> property.
+        /// </summary>
+        /// <param name="userId">Unique identifier of the target user</param>
+        public GetChatMemberParameters WithUserId(int userId)
+        {
+            UserId = userId;
+            return this;
+        }
+    }
+}

--- a/src/Telegram.Bot/Requests/Parameters/GetChatMembersCountParameters.cs
+++ b/src/Telegram.Bot/Requests/Parameters/GetChatMembersCountParameters.cs
@@ -1,0 +1,24 @@
+using Telegram.Bot.Types;
+
+namespace Telegram.Bot.Requests.Parameters
+{
+    /// <summary>
+    ///     Parameters for <see cref="ITelegramBotClient.GetChatMembersCountAsync" /> method.
+    /// </summary>
+    public class GetChatMembersCountParameters : ParametersBase
+    {
+        /// <summary>
+        /// </summary>
+        public ChatId ChatId { get; set; }
+
+        /// <summary>
+        ///     Sets <see cref="ChatId" /> property.
+        /// </summary>
+        /// <param name="chatId"></param>
+        public GetChatMembersCountParameters WithChatId(ChatId chatId)
+        {
+            ChatId = chatId;
+            return this;
+        }
+    }
+}

--- a/src/Telegram.Bot/Requests/Parameters/GetChatParameters.cs
+++ b/src/Telegram.Bot/Requests/Parameters/GetChatParameters.cs
@@ -1,0 +1,24 @@
+using Telegram.Bot.Types;
+
+namespace Telegram.Bot.Requests.Parameters
+{
+    /// <summary>
+    ///     Parameters for <see cref="ITelegramBotClient.GetChatAsync" /> method.
+    /// </summary>
+    public class GetChatParameters : ParametersBase
+    {
+        /// <summary>
+        /// </summary>
+        public ChatId ChatId { get; set; }
+
+        /// <summary>
+        ///     Sets <see cref="ChatId" /> property.
+        /// </summary>
+        /// <param name="chatId"></param>
+        public GetChatParameters WithChatId(ChatId chatId)
+        {
+            ChatId = chatId;
+            return this;
+        }
+    }
+}

--- a/src/Telegram.Bot/Requests/Parameters/GetFileParameters.cs
+++ b/src/Telegram.Bot/Requests/Parameters/GetFileParameters.cs
@@ -1,0 +1,23 @@
+namespace Telegram.Bot.Requests.Parameters
+{
+    /// <summary>
+    ///     Parameters for <see cref="ITelegramBotClient.GetFileAsync" /> method.
+    /// </summary>
+    public class GetFileParameters : ParametersBase
+    {
+        /// <summary>
+        ///     File identifier
+        /// </summary>
+        public string FileId { get; set; }
+
+        /// <summary>
+        ///     Sets <see cref="FileId" /> property.
+        /// </summary>
+        /// <param name="fileId">File identifier</param>
+        public GetFileParameters WithFileId(string fileId)
+        {
+            FileId = fileId;
+            return this;
+        }
+    }
+}

--- a/src/Telegram.Bot/Requests/Parameters/GetGameHighScoresInlineParameters.cs
+++ b/src/Telegram.Bot/Requests/Parameters/GetGameHighScoresInlineParameters.cs
@@ -1,0 +1,38 @@
+namespace Telegram.Bot.Requests.Parameters
+{
+    /// <summary>
+    ///     Parameters for <see cref="ITelegramBotClient.GetGameHighScoresAsync" /> method.
+    /// </summary>
+    public class GetGameHighScoresInlineParameters : ParametersBase
+    {
+        /// <summary>
+        ///     Unique identifier of the target user.
+        /// </summary>
+        public int UserId { get; set; }
+
+        /// <summary>
+        ///     Unique identifier of the inline message.
+        /// </summary>
+        public string InlineMessageId { get; set; }
+
+        /// <summary>
+        ///     Sets <see cref="UserId" /> property.
+        /// </summary>
+        /// <param name="userId">Unique identifier of the target user.</param>
+        public GetGameHighScoresInlineParameters WithUserId(int userId)
+        {
+            UserId = userId;
+            return this;
+        }
+
+        /// <summary>
+        ///     Sets <see cref="InlineMessageId" /> property.
+        /// </summary>
+        /// <param name="inlineMessageId">Unique identifier of the inline message.</param>
+        public GetGameHighScoresInlineParameters WithInlineMessageId(string inlineMessageId)
+        {
+            InlineMessageId = inlineMessageId;
+            return this;
+        }
+    }
+}

--- a/src/Telegram.Bot/Requests/Parameters/GetGameHighScoresParameters.cs
+++ b/src/Telegram.Bot/Requests/Parameters/GetGameHighScoresParameters.cs
@@ -1,0 +1,49 @@
+namespace Telegram.Bot.Requests.Parameters
+{
+    /// <summary>
+    ///     Parameters for <see cref="ITelegramBotClient.GetGameHighScoresAsync" /> method.
+    /// </summary>
+    public class GetGameHighScoresParameters : ParametersBase
+    {
+        /// <summary>
+        ///     Unique identifier of the target user.
+        /// </summary>
+        public int UserId { get; set; }
+
+        /// <summary>
+        /// </summary>
+        public long ChatId { get; set; }
+
+        /// <summary>
+        /// </summary>
+        public int MessageId { get; set; }
+
+        /// <summary>
+        ///     Sets <see cref="UserId" /> property.
+        /// </summary>
+        /// <param name="userId">Unique identifier of the target user.</param>
+        public GetGameHighScoresParameters WithUserId(int userId)
+        {
+            UserId = userId;
+            return this;
+        }
+
+        /// <summary>
+        ///     Sets <see cref="ChatId" /> property.
+        /// </summary>
+        public GetGameHighScoresParameters WithChatId(long chatId)
+        {
+            ChatId = chatId;
+            return this;
+        }
+
+        /// <summary>
+        ///     Sets <see cref="MessageId" /> property.
+        /// </summary>
+        public GetGameHighScoresParameters WithMessageId(int messageId)
+        {
+            MessageId = messageId;
+            return this;
+        }
+    }
+}

--- a/src/Telegram.Bot/Requests/Parameters/GetInfoAndDownloadFileParameters.cs
+++ b/src/Telegram.Bot/Requests/Parameters/GetInfoAndDownloadFileParameters.cs
@@ -1,0 +1,40 @@
+using System.IO;
+
+namespace Telegram.Bot.Requests.Parameters
+{
+    /// <summary>
+    ///     Parameters for <see cref="ITelegramBotClient.GetInfoAndDownloadFileAsync" /> method.
+    /// </summary>
+    public class GetInfoAndDownloadFileParameters : ParametersBase
+    {
+        /// <summary>
+        ///     File identifier to get info about
+        /// </summary>
+        public string FileId { get; set; }
+
+        /// <summary>
+        ///     Destination stream to write file to
+        /// </summary>
+        public Stream Destination { get; set; }
+
+        /// <summary>
+        ///     Sets <see cref="FileId" /> property.
+        /// </summary>
+        /// <param name="fileId">File identifier to get info about</param>
+        public GetInfoAndDownloadFileParameters WithFileId(string fileId)
+        {
+            FileId = fileId;
+            return this;
+        }
+
+        /// <summary>
+        ///     Sets <see cref="Destination" /> property.
+        /// </summary>
+        /// <param name="destination">Destination stream to write file to</param>
+        public GetInfoAndDownloadFileParameters WithDestination(Stream destination)
+        {
+            Destination = destination;
+            return this;
+        }
+    }
+}

--- a/src/Telegram.Bot/Requests/Parameters/GetStickerSetParameters.cs
+++ b/src/Telegram.Bot/Requests/Parameters/GetStickerSetParameters.cs
@@ -1,0 +1,23 @@
+namespace Telegram.Bot.Requests.Parameters
+{
+    /// <summary>
+    ///     Parameters for <see cref="ITelegramBotClient.GetStickerSetAsync" /> method.
+    /// </summary>
+    public class GetStickerSetParameters : ParametersBase
+    {
+        /// <summary>
+        ///     Short name of the sticker set that is used in t.me/addstickers/ URLs (e.g., animals)
+        /// </summary>
+        public string Name { get; set; }
+
+        /// <summary>
+        ///     Sets <see cref="Name" /> property.
+        /// </summary>
+        /// <param name="name">Short name of the sticker set that is used in t.me/addstickers/ URLs (e.g., animals)</param>
+        public GetStickerSetParameters WithName(string name)
+        {
+            Name = name;
+            return this;
+        }
+    }
+}

--- a/src/Telegram.Bot/Requests/Parameters/GetUpdatesParameters.cs
+++ b/src/Telegram.Bot/Requests/Parameters/GetUpdatesParameters.cs
@@ -1,0 +1,81 @@
+using System.Collections.Generic;
+using Telegram.Bot.Types.Enums;
+
+namespace Telegram.Bot.Requests.Parameters
+{
+    /// <summary>
+    ///     Parameters for <see cref="ITelegramBotClient.GetUpdatesAsync" /> method.
+    /// </summary>
+    public class GetUpdatesParameters : ParametersBase
+    {
+        /// <summary>
+        ///     Identifier of the first
+        /// </summary>
+        public int Offset { get; set; }
+
+        /// <summary>
+        ///     Limits the number of updates to be retrieved. Values between 1-100 are accepted.
+        /// </summary>
+        public int Limit { get; set; }
+
+        /// <summary>
+        ///     Timeout in seconds for long polling. Defaults to 0, i.e. usual short polling. Should be positive, short polling
+        ///     should be used for testing purposes only.
+        /// </summary>
+        public int Timeout { get; set; }
+
+        /// <summary>
+        ///     List the
+        /// </summary>
+        public IEnumerable<UpdateType> AllowedUpdates { get; set; }
+
+        /// <summary>
+        ///     Sets <see cref="Offset" /> property.
+        /// </summary>
+        /// <param name="offset">
+        ///     Identifier of the first
+        /// </param>
+        public GetUpdatesParameters WithOffset(int offset)
+        {
+            Offset = offset;
+            return this;
+        }
+
+        /// <summary>
+        ///     Sets <see cref="Limit" /> property.
+        /// </summary>
+        /// <param name="limit">
+        ///     Limits the number of updates to be retrieved. Values between 1-100 are accepted.
+        /// </param>
+        public GetUpdatesParameters WithLimit(int limit)
+        {
+            Limit = limit;
+            return this;
+        }
+
+        /// <summary>
+        ///     Sets <see cref="Timeout" /> property.
+        /// </summary>
+        /// <param name="timeout">
+        ///     Timeout in seconds for long polling. Defaults to 0, i.e. usual short polling. Should be positive, short polling
+        ///     should be used for testing purposes only.
+        /// </param>
+        public GetUpdatesParameters WithTimeout(int timeout)
+        {
+            Timeout = timeout;
+            return this;
+        }
+
+        /// <summary>
+        ///     Sets <see cref="AllowedUpdates" /> property.
+        /// </summary>
+        /// <param name="allowedUpdates">
+        ///     List the
+        /// </param>
+        public GetUpdatesParameters WithAllowedUpdates(IEnumerable<UpdateType> allowedUpdates)
+        {
+            AllowedUpdates = allowedUpdates;
+            return this;
+        }
+    }
+}

--- a/src/Telegram.Bot/Requests/Parameters/GetUserProfilePhotosParameters.cs
+++ b/src/Telegram.Bot/Requests/Parameters/GetUserProfilePhotosParameters.cs
@@ -1,0 +1,53 @@
+namespace Telegram.Bot.Requests.Parameters
+{
+    /// <summary>
+    ///     Parameters for <see cref="ITelegramBotClient.GetUserProfilePhotosAsync" /> method.
+    /// </summary>
+    public class GetUserProfilePhotosParameters : ParametersBase
+    {
+        /// <summary>
+        ///     Unique identifier of the target user
+        /// </summary>
+        public int UserId { get; set; }
+
+        /// <summary>
+        ///     Sequential number of the first photo to be returned. By default, all photos are returned.
+        /// </summary>
+        public int Offset { get; set; }
+
+        /// <summary>
+        ///     Limits the number of photos to be retrieved. Values between 1-100 are accepted. Defaults to 100.
+        /// </summary>
+        public int Limit { get; set; }
+
+        /// <summary>
+        ///     Sets <see cref="UserId" /> property.
+        /// </summary>
+        /// <param name="userId">Unique identifier of the target user</param>
+        public GetUserProfilePhotosParameters WithUserId(int userId)
+        {
+            UserId = userId;
+            return this;
+        }
+
+        /// <summary>
+        ///     Sets <see cref="Offset" /> property.
+        /// </summary>
+        /// <param name="offset">Sequential number of the first photo to be returned. By default, all photos are returned.</param>
+        public GetUserProfilePhotosParameters WithOffset(int offset)
+        {
+            Offset = offset;
+            return this;
+        }
+
+        /// <summary>
+        ///     Sets <see cref="Limit" /> property.
+        /// </summary>
+        /// <param name="limit">Limits the number of photos to be retrieved. Values between 1-100 are accepted. Defaults to 100.</param>
+        public GetUserProfilePhotosParameters WithLimit(int limit)
+        {
+            Limit = limit;
+            return this;
+        }
+    }
+}

--- a/src/Telegram.Bot/Requests/Parameters/KickChatMemberParameters.cs
+++ b/src/Telegram.Bot/Requests/Parameters/KickChatMemberParameters.cs
@@ -1,0 +1,54 @@
+using System;
+using Telegram.Bot.Types;
+
+namespace Telegram.Bot.Requests.Parameters
+{
+    /// <summary>
+    ///     Parameters for <see cref="ITelegramBotClient.KickChatMemberAsync" /> method.
+    /// </summary>
+    public class KickChatMemberParameters : ParametersBase
+    {
+        /// <summary>
+        /// </summary>
+        public ChatId ChatId { get; set; }
+
+        /// <summary>
+        ///     Unique identifier of the target user
+        /// </summary>
+        public int UserId { get; set; }
+
+        /// <summary>
+        /// </summary>
+        public DateTime UntilDate { get; set; }
+
+        /// <summary>
+        ///     Sets <see cref="ChatId" /> property.
+        /// </summary>
+        /// <param name="chatId"></param>
+        public KickChatMemberParameters WithChatId(ChatId chatId)
+        {
+            ChatId = chatId;
+            return this;
+        }
+
+        /// <summary>
+        ///     Sets <see cref="UserId" /> property.
+        /// </summary>
+        /// <param name="userId">Unique identifier of the target user</param>
+        public KickChatMemberParameters WithUserId(int userId)
+        {
+            UserId = userId;
+            return this;
+        }
+
+        /// <summary>
+        ///     Sets <see cref="UntilDate" /> property.
+        /// </summary>
+        /// <param name="untilDate"></param>
+        public KickChatMemberParameters WithUntilDate(DateTime untilDate)
+        {
+            UntilDate = untilDate;
+            return this;
+        }
+    }
+}

--- a/src/Telegram.Bot/Requests/Parameters/LeaveChatParameters.cs
+++ b/src/Telegram.Bot/Requests/Parameters/LeaveChatParameters.cs
@@ -1,0 +1,24 @@
+using Telegram.Bot.Types;
+
+namespace Telegram.Bot.Requests.Parameters
+{
+    /// <summary>
+    ///     Parameters for <see cref="ITelegramBotClient.LeaveChatAsync" /> method.
+    /// </summary>
+    public class LeaveChatParameters : ParametersBase
+    {
+        /// <summary>
+        /// </summary>
+        public ChatId ChatId { get; set; }
+
+        /// <summary>
+        ///     Sets <see cref="ChatId" /> property.
+        /// </summary>
+        /// <param name="chatId"></param>
+        public LeaveChatParameters WithChatId(ChatId chatId)
+        {
+            ChatId = chatId;
+            return this;
+        }
+    }
+}

--- a/src/Telegram.Bot/Requests/Parameters/MakeRequestParameters.cs
+++ b/src/Telegram.Bot/Requests/Parameters/MakeRequestParameters.cs
@@ -1,0 +1,25 @@
+using Telegram.Bot.Requests.Abstractions;
+
+namespace Telegram.Bot.Requests.Parameters
+{
+    /// <summary>
+    ///     Parameters for <see cref="ITelegramBotClient.MakeRequestAsync" /> method.
+    /// </summary>
+    public class MakeRequestParameters<TResponse> : ParametersBase
+    {
+        /// <summary>
+        ///     API request object
+        /// </summary>
+        public IRequest<TResponse> Request { get; set; }
+
+        /// <summary>
+        ///     Sets <see cref="Request" /> property.
+        /// </summary>
+        /// <param name="request">API request object</param>
+        public MakeRequestParameters<TResponse> WithRequest(IRequest<TResponse> request)
+        {
+            Request = request;
+            return this;
+        }
+    }
+}

--- a/src/Telegram.Bot/Requests/Parameters/ParametersBase.cs
+++ b/src/Telegram.Bot/Requests/Parameters/ParametersBase.cs
@@ -1,0 +1,9 @@
+﻿namespace Telegram.Bot.Requests.Parameters
+{
+    /// <summary>
+    ///     Base class for all parameter classes.
+    /// </summary>
+    public class ParametersBase
+    {
+    }
+}

--- a/src/Telegram.Bot/Requests/Parameters/PinChatMessageParameters.cs
+++ b/src/Telegram.Bot/Requests/Parameters/PinChatMessageParameters.cs
@@ -1,0 +1,58 @@
+using Telegram.Bot.Types;
+
+namespace Telegram.Bot.Requests.Parameters
+{
+    /// <summary>
+    ///     Parameters for <see cref="ITelegramBotClient.PinChatMessageAsync" /> method.
+    /// </summary>
+    public class PinChatMessageParameters : ParametersBase
+    {
+        /// <summary>
+        ///     Unique identifier for the target chat or username of the target supergroup
+        /// </summary>
+        public ChatId ChatId { get; set; }
+
+        /// <summary>
+        ///     Identifier of a message to pin
+        /// </summary>
+        public int MessageId { get; set; }
+
+        /// <summary>
+        ///     Pass True, if it is not necessary to send a notification to all group members about the new pinned message
+        /// </summary>
+        public bool DisableNotification { get; set; }
+
+        /// <summary>
+        ///     Sets <see cref="ChatId" /> property.
+        /// </summary>
+        /// <param name="chatId">Unique identifier for the target chat or username of the target supergroup</param>
+        public PinChatMessageParameters WithChatId(ChatId chatId)
+        {
+            ChatId = chatId;
+            return this;
+        }
+
+        /// <summary>
+        ///     Sets <see cref="MessageId" /> property.
+        /// </summary>
+        /// <param name="messageId">Identifier of a message to pin</param>
+        public PinChatMessageParameters WithMessageId(int messageId)
+        {
+            MessageId = messageId;
+            return this;
+        }
+
+        /// <summary>
+        ///     Sets <see cref="DisableNotification" /> property.
+        /// </summary>
+        /// <param name="disableNotification">
+        ///     Pass True, if it is not necessary to send a notification to all group members about
+        ///     the new pinned message
+        /// </param>
+        public PinChatMessageParameters WithDisableNotification(bool disableNotification)
+        {
+            DisableNotification = disableNotification;
+            return this;
+        }
+    }
+}

--- a/src/Telegram.Bot/Requests/Parameters/PromoteChatMemberParameters.cs
+++ b/src/Telegram.Bot/Requests/Parameters/PromoteChatMemberParameters.cs
@@ -1,0 +1,165 @@
+using Telegram.Bot.Types;
+
+namespace Telegram.Bot.Requests.Parameters
+{
+    /// <summary>
+    ///     Parameters for <see cref="ITelegramBotClient.PromoteChatMemberAsync" /> method.
+    /// </summary>
+    public class PromoteChatMemberParameters : ParametersBase
+    {
+        /// <summary>
+        ///     Unique identifier for the target chat or username of the target channel
+        /// </summary>
+        public ChatId ChatId { get; set; }
+
+        /// <summary>
+        ///     Unique identifier of the target user
+        /// </summary>
+        public int UserId { get; set; }
+
+        /// <summary>
+        ///     Pass True, if the administrator can change chat title, photo and other settings
+        /// </summary>
+        public bool? CanChangeInfo { get; set; }
+
+        /// <summary>
+        ///     Pass True, if the administrator can create channel posts, channels only
+        /// </summary>
+        public bool? CanPostMessages { get; set; }
+
+        /// <summary>
+        ///     Pass True, if the administrator can edit messages of other users, channels only
+        /// </summary>
+        public bool? CanEditMessages { get; set; }
+
+        /// <summary>
+        ///     Pass True, if the administrator can delete messages of other users
+        /// </summary>
+        public bool? CanDeleteMessages { get; set; }
+
+        /// <summary>
+        ///     Pass True, if the administrator can invite new users to the chat
+        /// </summary>
+        public bool? CanInviteUsers { get; set; }
+
+        /// <summary>
+        ///     Pass True, if the administrator can restrict, ban or unban chat members
+        /// </summary>
+        public bool? CanRestrictMembers { get; set; }
+
+        /// <summary>
+        ///     Pass True, if the administrator can pin messages, supergroups only
+        /// </summary>
+        public bool? CanPinMessages { get; set; }
+
+        /// <summary>
+        ///     Pass True, if the administrator can add new administrators with a subset of his own privileges or demote
+        ///     administrators that he has promoted, directly or indirectly (promoted by administrators that were appointed by him)
+        /// </summary>
+        public bool? CanPromoteMembers { get; set; }
+
+        /// <summary>
+        ///     Sets <see cref="ChatId" /> property.
+        /// </summary>
+        /// <param name="chatId">Unique identifier for the target chat or username of the target channel</param>
+        public PromoteChatMemberParameters WithChatId(ChatId chatId)
+        {
+            ChatId = chatId;
+            return this;
+        }
+
+        /// <summary>
+        ///     Sets <see cref="UserId" /> property.
+        /// </summary>
+        /// <param name="userId">Unique identifier of the target user</param>
+        public PromoteChatMemberParameters WithUserId(int userId)
+        {
+            UserId = userId;
+            return this;
+        }
+
+        /// <summary>
+        ///     Sets <see cref="CanChangeInfo" /> property.
+        /// </summary>
+        /// <param name="canChangeInfo">Pass True, if the administrator can change chat title, photo and other settings</param>
+        public PromoteChatMemberParameters WithCanChangeInfo(bool? canChangeInfo)
+        {
+            CanChangeInfo = canChangeInfo;
+            return this;
+        }
+
+        /// <summary>
+        ///     Sets <see cref="CanPostMessages" /> property.
+        /// </summary>
+        /// <param name="canPostMessages">Pass True, if the administrator can create channel posts, channels only</param>
+        public PromoteChatMemberParameters WithCanPostMessages(bool? canPostMessages)
+        {
+            CanPostMessages = canPostMessages;
+            return this;
+        }
+
+        /// <summary>
+        ///     Sets <see cref="CanEditMessages" /> property.
+        /// </summary>
+        /// <param name="canEditMessages">Pass True, if the administrator can edit messages of other users, channels only</param>
+        public PromoteChatMemberParameters WithCanEditMessages(bool? canEditMessages)
+        {
+            CanEditMessages = canEditMessages;
+            return this;
+        }
+
+        /// <summary>
+        ///     Sets <see cref="CanDeleteMessages" /> property.
+        /// </summary>
+        /// <param name="canDeleteMessages">Pass True, if the administrator can delete messages of other users</param>
+        public PromoteChatMemberParameters WithCanDeleteMessages(bool? canDeleteMessages)
+        {
+            CanDeleteMessages = canDeleteMessages;
+            return this;
+        }
+
+        /// <summary>
+        ///     Sets <see cref="CanInviteUsers" /> property.
+        /// </summary>
+        /// <param name="canInviteUsers">Pass True, if the administrator can invite new users to the chat</param>
+        public PromoteChatMemberParameters WithCanInviteUsers(bool? canInviteUsers)
+        {
+            CanInviteUsers = canInviteUsers;
+            return this;
+        }
+
+        /// <summary>
+        ///     Sets <see cref="CanRestrictMembers" /> property.
+        /// </summary>
+        /// <param name="canRestrictMembers">Pass True, if the administrator can restrict, ban or unban chat members</param>
+        public PromoteChatMemberParameters WithCanRestrictMembers(bool? canRestrictMembers)
+        {
+            CanRestrictMembers = canRestrictMembers;
+            return this;
+        }
+
+        /// <summary>
+        ///     Sets <see cref="CanPinMessages" /> property.
+        /// </summary>
+        /// <param name="canPinMessages">Pass True, if the administrator can pin messages, supergroups only</param>
+        public PromoteChatMemberParameters WithCanPinMessages(bool? canPinMessages)
+        {
+            CanPinMessages = canPinMessages;
+            return this;
+        }
+
+        /// <summary>
+        ///     Sets <see cref="CanPromoteMembers" /> property.
+        /// </summary>
+        /// <param name="canPromoteMembers">
+        ///     Pass True, if the administrator can add new administrators with a subset of his own
+        ///     privileges or demote administrators that he has promoted, directly or indirectly (promoted by administrators that
+        ///     were appointed by him)
+        /// </param>
+        public PromoteChatMemberParameters WithCanPromoteMembers(bool? canPromoteMembers)
+        {
+            CanPromoteMembers = canPromoteMembers;
+            return this;
+        }
+    }
+}

--- a/src/Telegram.Bot/Requests/Parameters/RestrictChatMemberParameters.cs
+++ b/src/Telegram.Bot/Requests/Parameters/RestrictChatMemberParameters.cs
@@ -1,0 +1,70 @@
+using System;
+using Telegram.Bot.Types;
+
+namespace Telegram.Bot.Requests.Parameters
+{
+    /// <summary>
+    ///     Parameters for <see cref="ITelegramBotClient.RestrictChatMemberAsync" /> method.
+    /// </summary>
+    public class RestrictChatMemberParameters : ParametersBase
+    {
+        /// <summary>
+        ///     Unique identifier for the target chat or username of the target supergroup
+        /// </summary>
+        public ChatId ChatId { get; set; }
+
+        /// <summary>
+        ///     Unique identifier of the target user
+        /// </summary>
+        public int UserId { get; set; }
+
+        /// <summary>
+        ///     New user permissions
+        /// </summary>
+        public ChatPermissions Permissions { get; set; }
+
+        /// <summary>
+        /// </summary>
+        public DateTime UntilDate { get; set; }
+
+        /// <summary>
+        ///     Sets <see cref="ChatId" /> property.
+        /// </summary>
+        /// <param name="chatId">Unique identifier for the target chat or username of the target supergroup</param>
+        public RestrictChatMemberParameters WithChatId(ChatId chatId)
+        {
+            ChatId = chatId;
+            return this;
+        }
+
+        /// <summary>
+        ///     Sets <see cref="UserId" /> property.
+        /// </summary>
+        /// <param name="userId">Unique identifier of the target user</param>
+        public RestrictChatMemberParameters WithUserId(int userId)
+        {
+            UserId = userId;
+            return this;
+        }
+
+        /// <summary>
+        ///     Sets <see cref="Permissions" /> property.
+        /// </summary>
+        /// <param name="permissions">New user permissions</param>
+        public RestrictChatMemberParameters WithPermissions(ChatPermissions permissions)
+        {
+            Permissions = permissions;
+            return this;
+        }
+
+        /// <summary>
+        ///     Sets <see cref="UntilDate" /> property.
+        /// </summary>
+        /// <param name="untilDate"></param>
+        public RestrictChatMemberParameters WithUntilDate(DateTime untilDate)
+        {
+            UntilDate = untilDate;
+            return this;
+        }
+    }
+}

--- a/src/Telegram.Bot/Requests/Parameters/SendAnimationParameters.cs
+++ b/src/Telegram.Bot/Requests/Parameters/SendAnimationParameters.cs
@@ -1,0 +1,195 @@
+using Telegram.Bot.Types;
+using Telegram.Bot.Types.Enums;
+using Telegram.Bot.Types.InputFiles;
+using Telegram.Bot.Types.ReplyMarkups;
+
+namespace Telegram.Bot.Requests.Parameters
+{
+    /// <summary>
+    ///     Parameters for <see cref="ITelegramBotClient.SendAnimationAsync" /> method.
+    /// </summary>
+    public class SendAnimationParameters : ParametersBase
+    {
+        /// <summary>
+        /// </summary>
+        public ChatId ChatId { get; set; }
+
+        /// <summary>
+        ///     Animation to send
+        /// </summary>
+        public InputOnlineFile Animation { get; set; }
+
+        /// <summary>
+        ///     Duration of sent animation in seconds
+        /// </summary>
+        public int Duration { get; set; }
+
+        /// <summary>
+        ///     Animation width
+        /// </summary>
+        public int Width { get; set; }
+
+        /// <summary>
+        ///     Animation height
+        /// </summary>
+        public int Height { get; set; }
+
+        /// <summary>
+        ///     Thumbnail of the file sent. The thumbnail should be in JPEG format and less than 200 kB
+        ///     in size. A thumbnail's width and height should not exceed 90. Thumbnails can't be reused and can be only
+        ///     uploaded as a new file.
+        /// </summary>
+        public InputMedia Thumb { get; set; }
+
+        /// <summary>
+        ///     Animation caption
+        /// </summary>
+        public string Caption { get; set; }
+
+        /// <summary>
+        ///     Change, if you want Telegram apps to show bold, italic, fixed-width text or inline
+        ///     URLs in your bot's message.
+        /// </summary>
+        public ParseMode ParseMode { get; set; }
+
+        /// <summary>
+        ///     Sends the message silently. iOS users will not receive a notification,
+        ///     Android users will receive a notification with no sound.
+        /// </summary>
+        public bool DisableNotification { get; set; }
+
+        /// <summary>
+        ///     If the message is a reply, ID of the original message
+        /// </summary>
+        public int ReplyToMessageId { get; set; }
+
+        /// <summary>
+        ///     Additional interface options. A JSON-serialized object for a custom reply keyboard,
+        ///     instructions to hide keyboard or to force a reply from the user.
+        /// </summary>
+        public IReplyMarkup ReplyMarkup { get; set; }
+
+        /// <summary>
+        ///     Sets <see cref="ChatId" /> property.
+        /// </summary>
+        /// <param name="chatId"></param>
+        public SendAnimationParameters WithChatId(ChatId chatId)
+        {
+            ChatId = chatId;
+            return this;
+        }
+
+        /// <summary>
+        ///     Sets <see cref="Animation" /> property.
+        /// </summary>
+        /// <param name="animation">Animation to send</param>
+        public SendAnimationParameters WithAnimation(InputOnlineFile animation)
+        {
+            Animation = animation;
+            return this;
+        }
+
+        /// <summary>
+        ///     Sets <see cref="Duration" /> property.
+        /// </summary>
+        /// <param name="duration">Duration of sent animation in seconds</param>
+        public SendAnimationParameters WithDuration(int duration)
+        {
+            Duration = duration;
+            return this;
+        }
+
+        /// <summary>
+        ///     Sets <see cref="Width" /> property.
+        /// </summary>
+        /// <param name="width">Animation width</param>
+        public SendAnimationParameters WithWidth(int width)
+        {
+            Width = width;
+            return this;
+        }
+
+        /// <summary>
+        ///     Sets <see cref="Height" /> property.
+        /// </summary>
+        /// <param name="height">Animation height</param>
+        public SendAnimationParameters WithHeight(int height)
+        {
+            Height = height;
+            return this;
+        }
+
+        /// <summary>
+        ///     Sets <see cref="Thumb" /> property.
+        /// </summary>
+        /// <param name="thumb">
+        ///     Thumbnail of the file sent. The thumbnail should be in JPEG format and less than 200 kB
+        ///     in size. A thumbnail's width and height should not exceed 90. Thumbnails can't be reused and can be only
+        ///     uploaded as a new file.
+        /// </param>
+        public SendAnimationParameters WithThumb(InputMedia thumb)
+        {
+            Thumb = thumb;
+            return this;
+        }
+
+        /// <summary>
+        ///     Sets <see cref="Caption" /> property.
+        /// </summary>
+        /// <param name="caption">Animation caption</param>
+        public SendAnimationParameters WithCaption(string caption)
+        {
+            Caption = caption;
+            return this;
+        }
+
+        /// <summary>
+        ///     Sets <see cref="ParseMode" /> property.
+        /// </summary>
+        /// <param name="parseMode">
+        ///     Change, if you want Telegram apps to show bold, italic, fixed-width text or inline
+        ///     URLs in your bot's message.
+        /// </param>
+        public SendAnimationParameters WithParseMode(ParseMode parseMode)
+        {
+            ParseMode = parseMode;
+            return this;
+        }
+
+        /// <summary>
+        ///     Sets <see cref="DisableNotification" /> property.
+        /// </summary>
+        /// <param name="disableNotification">
+        ///     Sends the message silently. iOS users will not receive a notification,
+        ///     Android users will receive a notification with no sound.
+        /// </param>
+        public SendAnimationParameters WithDisableNotification(bool disableNotification)
+        {
+            DisableNotification = disableNotification;
+            return this;
+        }
+
+        /// <summary>
+        ///     Sets <see cref="ReplyToMessageId" /> property.
+        /// </summary>
+        /// <param name="replyToMessageId">If the message is a reply, ID of the original message</param>
+        public SendAnimationParameters WithReplyToMessageId(int replyToMessageId)
+        {
+            ReplyToMessageId = replyToMessageId;
+            return this;
+        }
+
+        /// <summary>
+        ///     Sets <see cref="ReplyMarkup" /> property.
+        /// </summary>
+        /// <param name="replyMarkup">
+        ///     Additional interface options. A JSON-serialized object for a custom reply keyboard,
+        ///     instructions to hide keyboard or to force a reply from the user.
+        /// </param>
+        public SendAnimationParameters WithReplyMarkup(IReplyMarkup replyMarkup)
+        {
+            ReplyMarkup = replyMarkup;
+            return this;
+        }
+    }
+}

--- a/src/Telegram.Bot/Requests/Parameters/SendAudioParameters.cs
+++ b/src/Telegram.Bot/Requests/Parameters/SendAudioParameters.cs
@@ -1,0 +1,195 @@
+using Telegram.Bot.Types;
+using Telegram.Bot.Types.Enums;
+using Telegram.Bot.Types.InputFiles;
+using Telegram.Bot.Types.ReplyMarkups;
+
+namespace Telegram.Bot.Requests.Parameters
+{
+    /// <summary>
+    ///     Parameters for <see cref="ITelegramBotClient.SendAudioAsync" /> method.
+    /// </summary>
+    public class SendAudioParameters : ParametersBase
+    {
+        /// <summary>
+        /// </summary>
+        public ChatId ChatId { get; set; }
+
+        /// <summary>
+        ///     Audio file to send.
+        /// </summary>
+        public InputOnlineFile Audio { get; set; }
+
+        /// <summary>
+        ///     Audio caption, 0-1024 characters
+        /// </summary>
+        public string Caption { get; set; }
+
+        /// <summary>
+        ///     Change, if you want Telegram apps to show bold, italic, fixed-width text or inline
+        ///     URLs in your bot's message.
+        /// </summary>
+        public ParseMode ParseMode { get; set; }
+
+        /// <summary>
+        ///     Duration of the audio in seconds
+        /// </summary>
+        public int Duration { get; set; }
+
+        /// <summary>
+        ///     Performer
+        /// </summary>
+        public string Performer { get; set; }
+
+        /// <summary>
+        ///     Track name
+        /// </summary>
+        public string Title { get; set; }
+
+        /// <summary>
+        ///     Sends the message silently. iOS users will not receive a notification,
+        ///     Android users will receive a notification with no sound.
+        /// </summary>
+        public bool DisableNotification { get; set; }
+
+        /// <summary>
+        ///     If the message is a reply, ID of the original message
+        /// </summary>
+        public int ReplyToMessageId { get; set; }
+
+        /// <summary>
+        ///     Additional interface options. A JSON-serialized object for a custom reply keyboard,
+        ///     instructions to hide keyboard or to force a reply from the user.
+        /// </summary>
+        public IReplyMarkup ReplyMarkup { get; set; }
+
+        /// <summary>
+        ///     Thumbnail of the file sent. The thumbnail should be in JPEG format and less than 200 kB
+        ///     in size. A thumbnail's width and height should not exceed 90. Thumbnails can't be reused and can be only
+        ///     uploaded as a new file.
+        /// </summary>
+        public InputMedia Thumb { get; set; }
+
+        /// <summary>
+        ///     Sets <see cref="ChatId" /> property.
+        /// </summary>
+        /// <param name="chatId"></param>
+        public SendAudioParameters WithChatId(ChatId chatId)
+        {
+            ChatId = chatId;
+            return this;
+        }
+
+        /// <summary>
+        ///     Sets <see cref="Audio" /> property.
+        /// </summary>
+        /// <param name="audio">Audio file to send.</param>
+        public SendAudioParameters WithAudio(InputOnlineFile audio)
+        {
+            Audio = audio;
+            return this;
+        }
+
+        /// <summary>
+        ///     Sets <see cref="Caption" /> property.
+        /// </summary>
+        /// <param name="caption">Audio caption, 0-1024 characters</param>
+        public SendAudioParameters WithCaption(string caption)
+        {
+            Caption = caption;
+            return this;
+        }
+
+        /// <summary>
+        ///     Sets <see cref="ParseMode" /> property.
+        /// </summary>
+        /// <param name="parseMode">
+        ///     Change, if you want Telegram apps to show bold, italic, fixed-width text or inline
+        ///     URLs in your bot's message.
+        /// </param>
+        public SendAudioParameters WithParseMode(ParseMode parseMode)
+        {
+            ParseMode = parseMode;
+            return this;
+        }
+
+        /// <summary>
+        ///     Sets <see cref="Duration" /> property.
+        /// </summary>
+        /// <param name="duration">Duration of the audio in seconds</param>
+        public SendAudioParameters WithDuration(int duration)
+        {
+            Duration = duration;
+            return this;
+        }
+
+        /// <summary>
+        ///     Sets <see cref="Performer" /> property.
+        /// </summary>
+        /// <param name="performer">Performer</param>
+        public SendAudioParameters WithPerformer(string performer)
+        {
+            Performer = performer;
+            return this;
+        }
+
+        /// <summary>
+        ///     Sets <see cref="Title" /> property.
+        /// </summary>
+        /// <param name="title">Track name</param>
+        public SendAudioParameters WithTitle(string title)
+        {
+            Title = title;
+            return this;
+        }
+
+        /// <summary>
+        ///     Sets <see cref="DisableNotification" /> property.
+        /// </summary>
+        /// <param name="disableNotification">
+        ///     Sends the message silently. iOS users will not receive a notification,
+        ///     Android users will receive a notification with no sound.
+        /// </param>
+        public SendAudioParameters WithDisableNotification(bool disableNotification)
+        {
+            DisableNotification = disableNotification;
+            return this;
+        }
+
+        /// <summary>
+        ///     Sets <see cref="ReplyToMessageId" /> property.
+        /// </summary>
+        /// <param name="replyToMessageId">If the message is a reply, ID of the original message</param>
+        public SendAudioParameters WithReplyToMessageId(int replyToMessageId)
+        {
+            ReplyToMessageId = replyToMessageId;
+            return this;
+        }
+
+        /// <summary>
+        ///     Sets <see cref="ReplyMarkup" /> property.
+        /// </summary>
+        /// <param name="replyMarkup">
+        ///     Additional interface options. A JSON-serialized object for a custom reply keyboard,
+        ///     instructions to hide keyboard or to force a reply from the user.
+        /// </param>
+        public SendAudioParameters WithReplyMarkup(IReplyMarkup replyMarkup)
+        {
+            ReplyMarkup = replyMarkup;
+            return this;
+        }
+
+        /// <summary>
+        ///     Sets <see cref="Thumb" /> property.
+        /// </summary>
+        /// <param name="thumb">
+        ///     Thumbnail of the file sent. The thumbnail should be in JPEG format and less than 200 kB
+        ///     in size. A thumbnail's width and height should not exceed 90. Thumbnails can't be reused and can be only
+        ///     uploaded as a new file.
+        /// </param>
+        public SendAudioParameters WithThumb(InputMedia thumb)
+        {
+            Thumb = thumb;
+            return this;
+        }
+    }
+}

--- a/src/Telegram.Bot/Requests/Parameters/SendChatActionParameters.cs
+++ b/src/Telegram.Bot/Requests/Parameters/SendChatActionParameters.cs
@@ -1,0 +1,40 @@
+using Telegram.Bot.Types;
+using Telegram.Bot.Types.Enums;
+
+namespace Telegram.Bot.Requests.Parameters
+{
+    /// <summary>
+    ///     Parameters for <see cref="ITelegramBotClient.SendChatActionAsync" /> method.
+    /// </summary>
+    public class SendChatActionParameters : ParametersBase
+    {
+        /// <summary>
+        /// </summary>
+        public ChatId ChatId { get; set; }
+
+        /// <summary>
+        ///     Type of action to broadcast. Choose one, depending on what the user is about to receive.
+        /// </summary>
+        public ChatAction ChatAction { get; set; }
+
+        /// <summary>
+        ///     Sets <see cref="ChatId" /> property.
+        /// </summary>
+        /// <param name="chatId"></param>
+        public SendChatActionParameters WithChatId(ChatId chatId)
+        {
+            ChatId = chatId;
+            return this;
+        }
+
+        /// <summary>
+        ///     Sets <see cref="ChatAction" /> property.
+        /// </summary>
+        /// <param name="chatAction">Type of action to broadcast. Choose one, depending on what the user is about to receive.</param>
+        public SendChatActionParameters WithChatAction(ChatAction chatAction)
+        {
+            ChatAction = chatAction;
+            return this;
+        }
+    }
+}

--- a/src/Telegram.Bot/Requests/Parameters/SendContactParameters.cs
+++ b/src/Telegram.Bot/Requests/Parameters/SendContactParameters.cs
@@ -1,0 +1,138 @@
+using Telegram.Bot.Types;
+using Telegram.Bot.Types.ReplyMarkups;
+
+namespace Telegram.Bot.Requests.Parameters
+{
+    /// <summary>
+    ///     Parameters for <see cref="ITelegramBotClient.SendContactAsync" /> method.
+    /// </summary>
+    public class SendContactParameters : ParametersBase
+    {
+        /// <summary>
+        /// </summary>
+        public ChatId ChatId { get; set; }
+
+        /// <summary>
+        ///     Contact's phone number
+        /// </summary>
+        public string PhoneNumber { get; set; }
+
+        /// <summary>
+        ///     Contact's first name
+        /// </summary>
+        public string FirstName { get; set; }
+
+        /// <summary>
+        ///     Contact's last name
+        /// </summary>
+        public string LastName { get; set; }
+
+        /// <summary>
+        ///     Sends the message silently. iOS users will not receive a notification, Android users will receive a notification
+        ///     with no sound.
+        /// </summary>
+        public bool DisableNotification { get; set; }
+
+        /// <summary>
+        ///     If the message is a reply, ID of the original message
+        /// </summary>
+        public int ReplyToMessageId { get; set; }
+
+        /// <summary>
+        ///     Additional interface options. A JSON-serialized object for an inline keyboard, custom reply keyboard, instructions
+        ///     to hide keyboard or to force a reply from the user.
+        /// </summary>
+        public IReplyMarkup ReplyMarkup { get; set; }
+
+        /// <summary>
+        ///     Additional data about the contact in the form of a vCard, 0-2048 bytes
+        /// </summary>
+        public string VCard { get; set; }
+
+        /// <summary>
+        ///     Sets <see cref="ChatId" /> property.
+        /// </summary>
+        /// <param name="chatId"></param>
+        public SendContactParameters WithChatId(ChatId chatId)
+        {
+            ChatId = chatId;
+            return this;
+        }
+
+        /// <summary>
+        ///     Sets <see cref="PhoneNumber" /> property.
+        /// </summary>
+        /// <param name="phoneNumber">Contact's phone number</param>
+        public SendContactParameters WithPhoneNumber(string phoneNumber)
+        {
+            PhoneNumber = phoneNumber;
+            return this;
+        }
+
+        /// <summary>
+        ///     Sets <see cref="FirstName" /> property.
+        /// </summary>
+        /// <param name="firstName">Contact's first name</param>
+        public SendContactParameters WithFirstName(string firstName)
+        {
+            FirstName = firstName;
+            return this;
+        }
+
+        /// <summary>
+        ///     Sets <see cref="LastName" /> property.
+        /// </summary>
+        /// <param name="lastName">Contact's last name</param>
+        public SendContactParameters WithLastName(string lastName)
+        {
+            LastName = lastName;
+            return this;
+        }
+
+        /// <summary>
+        ///     Sets <see cref="DisableNotification" /> property.
+        /// </summary>
+        /// <param name="disableNotification">
+        ///     Sends the message silently. iOS users will not receive a notification, Android users
+        ///     will receive a notification with no sound.
+        /// </param>
+        public SendContactParameters WithDisableNotification(bool disableNotification)
+        {
+            DisableNotification = disableNotification;
+            return this;
+        }
+
+        /// <summary>
+        ///     Sets <see cref="ReplyToMessageId" /> property.
+        /// </summary>
+        /// <param name="replyToMessageId">If the message is a reply, ID of the original message</param>
+        public SendContactParameters WithReplyToMessageId(int replyToMessageId)
+        {
+            ReplyToMessageId = replyToMessageId;
+            return this;
+        }
+
+        /// <summary>
+        ///     Sets <see cref="ReplyMarkup" /> property.
+        /// </summary>
+        /// <param name="replyMarkup">
+        ///     Additional interface options. A JSON-serialized object for an inline keyboard, custom reply
+        ///     keyboard, instructions to hide keyboard or to force a reply from the user.
+        /// </param>
+        public SendContactParameters WithReplyMarkup(IReplyMarkup replyMarkup)
+        {
+            ReplyMarkup = replyMarkup;
+            return this;
+        }
+
+        /// <summary>
+        ///     Sets <see cref="VCard" /> property.
+        /// </summary>
+        /// <param name="vCard">Additional data about the contact in the form of a vCard, 0-2048 bytes</param>
+        public SendContactParameters WithVCard(string vCard)
+        {
+            VCard = vCard;
+            return this;
+        }
+    }
+}

--- a/src/Telegram.Bot/Requests/Parameters/SendDiceParameters.cs
+++ b/src/Telegram.Bot/Requests/Parameters/SendDiceParameters.cs
@@ -1,0 +1,95 @@
+using Telegram.Bot.Types;
+using Telegram.Bot.Types.Enums;
+using Telegram.Bot.Types.ReplyMarkups;
+
+namespace Telegram.Bot.Requests.Parameters
+{
+    /// <summary>
+    ///     Parameters for <see cref="ITelegramBotClient.SendDiceAsync" /> method.
+    /// </summary>
+    public class SendDiceParameters : ParametersBase
+    {
+        /// <summary>
+        ///     Unique identifier for the target chat or username of the target channel
+        /// </summary>
+        public ChatId ChatId { get; set; }
+
+        /// <summary>
+        ///     Sends the message silently. iOS users will not receive a notification, Android users will receive a notification
+        ///     with no sound.
+        /// </summary>
+        public bool DisableNotification { get; set; }
+
+        /// <summary>
+        ///     If the message is a reply, ID of the original message
+        /// </summary>
+        public int ReplyToMessageId { get; set; }
+
+        /// <summary>
+        ///     Additional interface options. A JSON-serialized object for an inline keyboard, custom reply keyboard, instructions
+        ///     to hide keyboard or to force a reply from the user.
+        /// </summary>
+        public IReplyMarkup ReplyMarkup { get; set; }
+
+        /// <summary>
+        ///     Emoji on which the dice throw animation is based
+        /// </summary>
+        public Emoji? Emoji { get; set; }
+
+        /// <summary>
+        ///     Sets <see cref="ChatId" /> property.
+        /// </summary>
+        /// <param name="chatId">Unique identifier for the target chat or username of the target channel</param>
+        public SendDiceParameters WithChatId(ChatId chatId)
+        {
+            ChatId = chatId;
+            return this;
+        }
+
+        /// <summary>
+        ///     Sets <see cref="DisableNotification" /> property.
+        /// </summary>
+        /// <param name="disableNotification">
+        ///     Sends the message silently. iOS users will not receive a notification, Android users
+        ///     will receive a notification with no sound.
+        /// </param>
+        public SendDiceParameters WithDisableNotification(bool disableNotification)
+        {
+            DisableNotification = disableNotification;
+            return this;
+        }
+
+        /// <summary>
+        ///     Sets <see cref="ReplyToMessageId" /> property.
+        /// </summary>
+        /// <param name="replyToMessageId">If the message is a reply, ID of the original message</param>
+        public SendDiceParameters WithReplyToMessageId(int replyToMessageId)
+        {
+            ReplyToMessageId = replyToMessageId;
+            return this;
+        }
+
+        /// <summary>
+        ///     Sets <see cref="ReplyMarkup" /> property.
+        /// </summary>
+        /// <param name="replyMarkup">
+        ///     Additional interface options. A JSON-serialized object for an inline keyboard, custom reply
+        ///     keyboard, instructions to hide keyboard or to force a reply from the user.
+        /// </param>
+        public SendDiceParameters WithReplyMarkup(IReplyMarkup replyMarkup)
+        {
+            ReplyMarkup = replyMarkup;
+            return this;
+        }
+
+        /// <summary>
+        ///     Sets <see cref="Emoji" /> property.
+        /// </summary>
+        /// <param name="emoji">Emoji on which the dice throw animation is based</param>
+        public SendDiceParameters WithEmoji(Emoji? emoji)
+        {
+            Emoji = emoji;
+            return this;
+        }
+    }
+}

--- a/src/Telegram.Bot/Requests/Parameters/SendDocumentParameters.cs
+++ b/src/Telegram.Bot/Requests/Parameters/SendDocumentParameters.cs
@@ -1,0 +1,150 @@
+using Telegram.Bot.Types;
+using Telegram.Bot.Types.Enums;
+using Telegram.Bot.Types.InputFiles;
+using Telegram.Bot.Types.ReplyMarkups;
+
+namespace Telegram.Bot.Requests.Parameters
+{
+    /// <summary>
+    ///     Parameters for <see cref="ITelegramBotClient.SendDocumentAsync" /> method.
+    /// </summary>
+    public class SendDocumentParameters : ParametersBase
+    {
+        /// <summary>
+        /// </summary>
+        public ChatId ChatId { get; set; }
+
+        /// <summary>
+        ///     File to send.
+        /// </summary>
+        public InputOnlineFile Document { get; set; }
+
+        /// <summary>
+        ///     Document caption
+        /// </summary>
+        public string Caption { get; set; }
+
+        /// <summary>
+        ///     Change, if you want Telegram apps to show bold, italic, fixed-width text or inline
+        ///     URLs in your bot's message.
+        /// </summary>
+        public ParseMode ParseMode { get; set; }
+
+        /// <summary>
+        ///     Sends the message silently. iOS users will not receive a notification,
+        ///     Android users will receive a notification with no sound.
+        /// </summary>
+        public bool DisableNotification { get; set; }
+
+        /// <summary>
+        ///     If the message is a reply, ID of the original message
+        /// </summary>
+        public int ReplyToMessageId { get; set; }
+
+        /// <summary>
+        ///     Additional interface options. A JSON-serialized object for a custom reply keyboard,
+        ///     instructions to hide keyboard or to force a reply from the user.
+        /// </summary>
+        public IReplyMarkup ReplyMarkup { get; set; }
+
+        /// <summary>
+        ///     Thumbnail of the file sent. The thumbnail should be in JPEG format and less than 200 kB
+        ///     in size. A thumbnail's width and height should not exceed 90. Thumbnails can't be reused and can be only
+        ///     uploaded as a new file.
+        /// </summary>
+        public InputMedia Thumb { get; set; }
+
+        /// <summary>
+        ///     Sets <see cref="ChatId" /> property.
+        /// </summary>
+        /// <param name="chatId"></param>
+        public SendDocumentParameters WithChatId(ChatId chatId)
+        {
+            ChatId = chatId;
+            return this;
+        }
+
+        /// <summary>
+        ///     Sets <see cref="Document" /> property.
+        /// </summary>
+        /// <param name="document">File to send.</param>
+        public SendDocumentParameters WithDocument(InputOnlineFile document)
+        {
+            Document = document;
+            return this;
+        }
+
+        /// <summary>
+        ///     Sets <see cref="Caption" /> property.
+        /// </summary>
+        /// <param name="caption">Document caption</param>
+        public SendDocumentParameters WithCaption(string caption)
+        {
+            Caption = caption;
+            return this;
+        }
+
+        /// <summary>
+        ///     Sets <see cref="ParseMode" /> property.
+        /// </summary>
+        /// <param name="parseMode">
+        ///     Change, if you want Telegram apps to show bold, italic, fixed-width text or inline
+        ///     URLs in your bot's message.
+        /// </param>
+        public SendDocumentParameters WithParseMode(ParseMode parseMode)
+        {
+            ParseMode = parseMode;
+            return this;
+        }
+
+        /// <summary>
+        ///     Sets <see cref="DisableNotification" /> property.
+        /// </summary>
+        /// <param name="disableNotification">
+        ///     Sends the message silently. iOS users will not receive a notification,
+        ///     Android users will receive a notification with no sound.
+        /// </param>
+        public SendDocumentParameters WithDisableNotification(bool disableNotification)
+        {
+            DisableNotification = disableNotification;
+            return this;
+        }
+
+        /// <summary>
+        ///     Sets <see cref="ReplyToMessageId" /> property.
+        /// </summary>
+        /// <param name="replyToMessageId">If the message is a reply, ID of the original message</param>
+        public SendDocumentParameters WithReplyToMessageId(int replyToMessageId)
+        {
+            ReplyToMessageId = replyToMessageId;
+            return this;
+        }
+
+        /// <summary>
+        ///     Sets <see cref="ReplyMarkup" /> property.
+        /// </summary>
+        /// <param name="replyMarkup">
+        ///     Additional interface options. A JSON-serialized object for a custom reply keyboard,
+        ///     instructions to hide keyboard or to force a reply from the user.
+        /// </param>
+        public SendDocumentParameters WithReplyMarkup(IReplyMarkup replyMarkup)
+        {
+            ReplyMarkup = replyMarkup;
+            return this;
+        }
+
+        /// <summary>
+        ///     Sets <see cref="Thumb" /> property.
+        /// </summary>
+        /// <param name="thumb">
+        ///     Thumbnail of the file sent. The thumbnail should be in JPEG format and less than 200 kB
+        ///     in size. A thumbnail's width and height should not exceed 90. Thumbnails can't be reused and can be only
+        ///     uploaded as a new file.
+        /// </param>
+        public SendDocumentParameters WithThumb(InputMedia thumb)
+        {
+            Thumb = thumb;
+            return this;
+        }
+    }
+}

--- a/src/Telegram.Bot/Requests/Parameters/SendGameParameters.cs
+++ b/src/Telegram.Bot/Requests/Parameters/SendGameParameters.cs
@@ -1,0 +1,93 @@
+using Telegram.Bot.Types.ReplyMarkups;
+
+namespace Telegram.Bot.Requests.Parameters
+{
+    /// <summary>
+    ///     Parameters for <see cref="ITelegramBotClient.SendGameAsync" /> method.
+    /// </summary>
+    public class SendGameParameters : ParametersBase
+    {
+        /// <summary>
+        ///     Unique identifier of the target chat
+        /// </summary>
+        public long ChatId { get; set; }
+
+        /// <summary>
+        ///     Short name of the game, serves as the unique identifier for the game.
+        /// </summary>
+        public string GameShortName { get; set; }
+
+        /// <summary>
+        ///     Sends the message silently. iOS users will not receive a notification, Android users will receive a notification
+        ///     with no sound.
+        /// </summary>
+        public bool DisableNotification { get; set; }
+
+        /// <summary>
+        ///     If the message is a reply, ID of the original message
+        /// </summary>
+        public int ReplyToMessageId { get; set; }
+
+        /// <summary>
+        ///     Additional interface options. A JSON-serialized object for a custom reply keyboard, instructions to hide keyboard
+        ///     or to force a reply from the user.
+        /// </summary>
+        public InlineKeyboardMarkup ReplyMarkup { get; set; }
+
+        /// <summary>
+        ///     Sets <see cref="ChatId" /> property.
+        /// </summary>
+        /// <param name="chatId">Unique identifier of the target chat</param>
+        public SendGameParameters WithChatId(long chatId)
+        {
+            ChatId = chatId;
+            return this;
+        }
+
+        /// <summary>
+        ///     Sets <see cref="GameShortName" /> property.
+        /// </summary>
+        /// <param name="gameShortName">Short name of the game, serves as the unique identifier for the game.</param>
+        public SendGameParameters WithGameShortName(string gameShortName)
+        {
+            GameShortName = gameShortName;
+            return this;
+        }
+
+        /// <summary>
+        ///     Sets <see cref="DisableNotification" /> property.
+        /// </summary>
+        /// <param name="disableNotification">
+        ///     Sends the message silently. iOS users will not receive a notification, Android users
+        ///     will receive a notification with no sound.
+        /// </param>
+        public SendGameParameters WithDisableNotification(bool disableNotification)
+        {
+            DisableNotification = disableNotification;
+            return this;
+        }
+
+        /// <summary>
+        ///     Sets <see cref="ReplyToMessageId" /> property.
+        /// </summary>
+        /// <param name="replyToMessageId">If the message is a reply, ID of the original message</param>
+        public SendGameParameters WithReplyToMessageId(int replyToMessageId)
+        {
+            ReplyToMessageId = replyToMessageId;
+            return this;
+        }
+
+        /// <summary>
+        ///     Sets <see cref="ReplyMarkup" /> property.
+        /// </summary>
+        /// <param name="replyMarkup">
+        ///     Additional interface options. A JSON-serialized object for a custom reply keyboard,
+        ///     instructions to hide keyboard or to force a reply from the user.
+        /// </param>
+        public SendGameParameters WithReplyMarkup(InlineKeyboardMarkup replyMarkup)
+        {
+            ReplyMarkup = replyMarkup;
+            return this;
+        }
+    }
+}

--- a/src/Telegram.Bot/Requests/Parameters/SendInvoiceParameters.cs
+++ b/src/Telegram.Bot/Requests/Parameters/SendInvoiceParameters.cs
@@ -1,0 +1,381 @@
+using System.Collections.Generic;
+using Telegram.Bot.Types.Payments;
+using Telegram.Bot.Types.ReplyMarkups;
+
+namespace Telegram.Bot.Requests.Parameters
+{
+    /// <summary>
+    ///     Parameters for <see cref="ITelegramBotClient.SendInvoiceAsync" /> method.
+    /// </summary>
+    public class SendInvoiceParameters : ParametersBase
+    {
+        /// <summary>
+        ///     Unique identifier for the target private chat
+        /// </summary>
+        public int ChatId { get; set; }
+
+        /// <summary>
+        ///     Product name
+        /// </summary>
+        public string Title { get; set; }
+
+        /// <summary>
+        ///     Product description
+        /// </summary>
+        public string Description { get; set; }
+
+        /// <summary>
+        ///     Bot-defined invoice payload, 1-128 bytes. This will not be displayed to the user, use for your internal processes.
+        /// </summary>
+        public string Payload { get; set; }
+
+        /// <summary>
+        ///     Payments provider token, obtained via Botfather
+        /// </summary>
+        public string ProviderToken { get; set; }
+
+        /// <summary>
+        ///     Unique deep-linking parameter that can be used to generate this invoice when used as a start parameter
+        /// </summary>
+        public string StartParameter { get; set; }
+
+        /// <summary>
+        ///     Three-letter ISO 4217 currency code, see more on currencies
+        /// </summary>
+        public string Currency { get; set; }
+
+        /// <summary>
+        ///     Price breakdown, a list of components (e.g. product price, tax, discount, delivery cost, delivery tax, bonus, etc.)
+        /// </summary>
+        public IEnumerable<LabeledPrice> Prices { get; set; }
+
+        /// <summary>
+        ///     JSON-encoded data about the invoice, which will be shared with the payment provider. A detailed description of
+        ///     required fields should be provided by the payment provider.
+        /// </summary>
+        public string ProviderData { get; set; }
+
+        /// <summary>
+        ///     URL of the product photo for the invoice. Can be a photo of the goods or a marketing image for a service.
+        /// </summary>
+        public string PhotoUrl { get; set; }
+
+        /// <summary>
+        ///     Photo size
+        /// </summary>
+        public int PhotoSize { get; set; }
+
+        /// <summary>
+        ///     Photo width
+        /// </summary>
+        public int PhotoWidth { get; set; }
+
+        /// <summary>
+        ///     Photo height
+        /// </summary>
+        public int PhotoHeight { get; set; }
+
+        /// <summary>
+        ///     Pass True, if you require the user's full name to complete the order
+        /// </summary>
+        public bool NeedName { get; set; }
+
+        /// <summary>
+        ///     Pass True, if you require the user's phone number to complete the order
+        /// </summary>
+        public bool NeedPhoneNumber { get; set; }
+
+        /// <summary>
+        ///     Pass True, if you require the user's email to complete the order
+        /// </summary>
+        public bool NeedEmail { get; set; }
+
+        /// <summary>
+        ///     Pass True, if you require the user's shipping address to complete the order
+        /// </summary>
+        public bool NeedShippingAddress { get; set; }
+
+        /// <summary>
+        ///     Pass True, if the final price depends on the shipping method
+        /// </summary>
+        public bool IsFlexible { get; set; }
+
+        /// <summary>
+        ///     Sends the message silently. iOS users will not receive a notification, Android users will receive a notification
+        ///     with no sound.
+        /// </summary>
+        public bool DisableNotification { get; set; }
+
+        /// <summary>
+        ///     If the message is a reply, ID of the original message
+        /// </summary>
+        public int ReplyToMessageId { get; set; }
+
+        /// <summary>
+        ///     Additional interface options. A JSON-serialized object for a custom reply keyboard, instructions to hide keyboard
+        ///     or to force a reply from the user.
+        /// </summary>
+        public InlineKeyboardMarkup ReplyMarkup { get; set; }
+
+        /// <summary>
+        ///     Pass True, if user's phone number should be sent to provider
+        /// </summary>
+        public bool SendPhoneNumberToProvider { get; set; }
+
+        /// <summary>
+        ///     Pass True, if user's email address should be sent to provider
+        /// </summary>
+        public bool SendEmailToProvider { get; set; }
+
+        /// <summary>
+        ///     Sets <see cref="ChatId" /> property.
+        /// </summary>
+        /// <param name="chatId">Unique identifier for the target private chat</param>
+        public SendInvoiceParameters WithChatId(int chatId)
+        {
+            ChatId = chatId;
+            return this;
+        }
+
+        /// <summary>
+        ///     Sets <see cref="Title" /> property.
+        /// </summary>
+        /// <param name="title">Product name</param>
+        public SendInvoiceParameters WithTitle(string title)
+        {
+            Title = title;
+            return this;
+        }
+
+        /// <summary>
+        ///     Sets <see cref="Description" /> property.
+        /// </summary>
+        /// <param name="description">Product description</param>
+        public SendInvoiceParameters WithDescription(string description)
+        {
+            Description = description;
+            return this;
+        }
+
+        /// <summary>
+        ///     Sets <see cref="Payload" /> property.
+        /// </summary>
+        /// <param name="payload">
+        ///     Bot-defined invoice payload, 1-128 bytes. This will not be displayed to the user, use for your
+        ///     internal processes.
+        /// </param>
+        public SendInvoiceParameters WithPayload(string payload)
+        {
+            Payload = payload;
+            return this;
+        }
+
+        /// <summary>
+        ///     Sets <see cref="ProviderToken" /> property.
+        /// </summary>
+        /// <param name="providerToken">Payments provider token, obtained via Botfather</param>
+        public SendInvoiceParameters WithProviderToken(string providerToken)
+        {
+            ProviderToken = providerToken;
+            return this;
+        }
+
+        /// <summary>
+        ///     Sets <see cref="StartParameter" /> property.
+        /// </summary>
+        /// <param name="startParameter">
+        ///     Unique deep-linking parameter that can be used to generate this invoice when used as a
+        ///     start parameter
+        /// </param>
+        public SendInvoiceParameters WithStartParameter(string startParameter)
+        {
+            StartParameter = startParameter;
+            return this;
+        }
+
+        /// <summary>
+        ///     Sets <see cref="Currency" /> property.
+        /// </summary>
+        /// <param name="currency">Three-letter ISO 4217 currency code, see more on currencies</param>
+        public SendInvoiceParameters WithCurrency(string currency)
+        {
+            Currency = currency;
+            return this;
+        }
+
+        /// <summary>
+        ///     Sets <see cref="Prices" /> property.
+        /// </summary>
+        /// <param name="prices">
+        ///     Price breakdown, a list of components (e.g. product price, tax, discount, delivery cost, delivery
+        ///     tax, bonus, etc.)
+        /// </param>
+        public SendInvoiceParameters WithPrices(IEnumerable<LabeledPrice> prices)
+        {
+            Prices = prices;
+            return this;
+        }
+
+        /// <summary>
+        ///     Sets <see cref="ProviderData" /> property.
+        /// </summary>
+        /// <param name="providerData">
+        ///     JSON-encoded data about the invoice, which will be shared with the payment provider. A
+        ///     detailed description of required fields should be provided by the payment provider.
+        /// </param>
+        public SendInvoiceParameters WithProviderData(string providerData)
+        {
+            ProviderData = providerData;
+            return this;
+        }
+
+        /// <summary>
+        ///     Sets <see cref="PhotoUrl" /> property.
+        /// </summary>
+        /// <param name="photoUrl">
+        ///     URL of the product photo for the invoice. Can be a photo of the goods or a marketing image for a
+        ///     service.
+        /// </param>
+        public SendInvoiceParameters WithPhotoUrl(string photoUrl)
+        {
+            PhotoUrl = photoUrl;
+            return this;
+        }
+
+        /// <summary>
+        ///     Sets <see cref="PhotoSize" /> property.
+        /// </summary>
+        /// <param name="photoSize">Photo size</param>
+        public SendInvoiceParameters WithPhotoSize(int photoSize)
+        {
+            PhotoSize = photoSize;
+            return this;
+        }
+
+        /// <summary>
+        ///     Sets <see cref="PhotoWidth" /> property.
+        /// </summary>
+        /// <param name="photoWidth">Photo width</param>
+        public SendInvoiceParameters WithPhotoWidth(int photoWidth)
+        {
+            PhotoWidth = photoWidth;
+            return this;
+        }
+
+        /// <summary>
+        ///     Sets <see cref="PhotoHeight" /> property.
+        /// </summary>
+        /// <param name="photoHeight">Photo height</param>
+        public SendInvoiceParameters WithPhotoHeight(int photoHeight)
+        {
+            PhotoHeight = photoHeight;
+            return this;
+        }
+
+        /// <summary>
+        ///     Sets <see cref="NeedName" /> property.
+        /// </summary>
+        /// <param name="needName">Pass True, if you require the user's full name to complete the order</param>
+        public SendInvoiceParameters WithNeedName(bool needName)
+        {
+            NeedName = needName;
+            return this;
+        }
+
+        /// <summary>
+        ///     Sets <see cref="NeedPhoneNumber" /> property.
+        /// </summary>
+        /// <param name="needPhoneNumber">Pass True, if you require the user's phone number to complete the order</param>
+        public SendInvoiceParameters WithNeedPhoneNumber(bool needPhoneNumber)
+        {
+            NeedPhoneNumber = needPhoneNumber;
+            return this;
+        }
+
+        /// <summary>
+        ///     Sets <see cref="NeedEmail" /> property.
+        /// </summary>
+        /// <param name="needEmail">Pass True, if you require the user's email to complete the order</param>
+        public SendInvoiceParameters WithNeedEmail(bool needEmail)
+        {
+            NeedEmail = needEmail;
+            return this;
+        }
+
+        /// <summary>
+        ///     Sets <see cref="NeedShippingAddress" /> property.
+        /// </summary>
+        /// <param name="needShippingAddress">Pass True, if you require the user's shipping address to complete the order</param>
+        public SendInvoiceParameters WithNeedShippingAddress(bool needShippingAddress)
+        {
+            NeedShippingAddress = needShippingAddress;
+            return this;
+        }
+
+        /// <summary>
+        ///     Sets <see cref="IsFlexible" /> property.
+        /// </summary>
+        /// <param name="isFlexible">Pass True, if the final price depends on the shipping method</param>
+        public SendInvoiceParameters WithIsFlexible(bool isFlexible)
+        {
+            IsFlexible = isFlexible;
+            return this;
+        }
+
+        /// <summary>
+        ///     Sets <see cref="DisableNotification" /> property.
+        /// </summary>
+        /// <param name="disableNotification">
+        ///     Sends the message silently. iOS users will not receive a notification, Android users
+        ///     will receive a notification with no sound.
+        /// </param>
+        public SendInvoiceParameters WithDisableNotification(bool disableNotification)
+        {
+            DisableNotification = disableNotification;
+            return this;
+        }
+
+        /// <summary>
+        ///     Sets <see cref="ReplyToMessageId" /> property.
+        /// </summary>
+        /// <param name="replyToMessageId">If the message is a reply, ID of the original message</param>
+        public SendInvoiceParameters WithReplyToMessageId(int replyToMessageId)
+        {
+            ReplyToMessageId = replyToMessageId;
+            return this;
+        }
+
+        /// <summary>
+        ///     Sets <see cref="ReplyMarkup" /> property.
+        /// </summary>
+        /// <param name="replyMarkup">
+        ///     Additional interface options. A JSON-serialized object for a custom reply keyboard,
+        ///     instructions to hide keyboard or to force a reply from the user.
+        /// </param>
+        public SendInvoiceParameters WithReplyMarkup(InlineKeyboardMarkup replyMarkup)
+        {
+            ReplyMarkup = replyMarkup;
+            return this;
+        }
+
+        /// <summary>
+        ///     Sets <see cref="SendPhoneNumberToProvider" /> property.
+        /// </summary>
+        /// <param name="sendPhoneNumberToProvider">Pass True, if user's phone number should be sent to provider</param>
+        public SendInvoiceParameters WithSendPhoneNumberToProvider(bool sendPhoneNumberToProvider)
+        {
+            SendPhoneNumberToProvider = sendPhoneNumberToProvider;
+            return this;
+        }
+
+        /// <summary>
+        ///     Sets <see cref="SendEmailToProvider" /> property.
+        /// </summary>
+        /// <param name="sendEmailToProvider">Pass True, if user's email address should be sent to provider</param>
+        public SendInvoiceParameters WithSendEmailToProvider(bool sendEmailToProvider)
+        {
+            SendEmailToProvider = sendEmailToProvider;
+            return this;
+        }
+    }
+}

--- a/src/Telegram.Bot/Requests/Parameters/SendLocationParameters.cs
+++ b/src/Telegram.Bot/Requests/Parameters/SendLocationParameters.cs
@@ -1,0 +1,123 @@
+using Telegram.Bot.Types;
+using Telegram.Bot.Types.ReplyMarkups;
+
+namespace Telegram.Bot.Requests.Parameters
+{
+    /// <summary>
+    ///     Parameters for <see cref="ITelegramBotClient.SendLocationAsync" /> method.
+    /// </summary>
+    public class SendLocationParameters : ParametersBase
+    {
+        /// <summary>
+        /// </summary>
+        public ChatId ChatId { get; set; }
+
+        /// <summary>
+        ///     Latitude of location
+        /// </summary>
+        public float Latitude { get; set; }
+
+        /// <summary>
+        ///     Longitude of location
+        /// </summary>
+        public float Longitude { get; set; }
+
+        /// <summary>
+        ///     Period in seconds for which the location will be updated. Should be between 60 and 86400.
+        /// </summary>
+        public int LivePeriod { get; set; }
+
+        /// <summary>
+        ///     Sends the message silently. iOS users will not receive a notification, Android users will receive a notification
+        ///     with no sound.
+        /// </summary>
+        public bool DisableNotification { get; set; }
+
+        /// <summary>
+        ///     If the message is a reply, ID of the original message
+        /// </summary>
+        public int ReplyToMessageId { get; set; }
+
+        /// <summary>
+        ///     Additional interface options. A JSON-serialized object for a custom reply keyboard, instructions to hide keyboard
+        ///     or to force a reply from the user.
+        /// </summary>
+        public IReplyMarkup ReplyMarkup { get; set; }
+
+        /// <summary>
+        ///     Sets <see cref="ChatId" /> property.
+        /// </summary>
+        /// <param name="chatId"></param>
+        public SendLocationParameters WithChatId(ChatId chatId)
+        {
+            ChatId = chatId;
+            return this;
+        }
+
+        /// <summary>
+        ///     Sets <see cref="Latitude" /> property.
+        /// </summary>
+        /// <param name="latitude">Latitude of location</param>
+        public SendLocationParameters WithLatitude(float latitude)
+        {
+            Latitude = latitude;
+            return this;
+        }
+
+        /// <summary>
+        ///     Sets <see cref="Longitude" /> property.
+        /// </summary>
+        /// <param name="longitude">Longitude of location</param>
+        public SendLocationParameters WithLongitude(float longitude)
+        {
+            Longitude = longitude;
+            return this;
+        }
+
+        /// <summary>
+        ///     Sets <see cref="LivePeriod" /> property.
+        /// </summary>
+        /// <param name="livePeriod">Period in seconds for which the location will be updated. Should be between 60 and 86400.</param>
+        public SendLocationParameters WithLivePeriod(int livePeriod)
+        {
+            LivePeriod = livePeriod;
+            return this;
+        }
+
+        /// <summary>
+        ///     Sets <see cref="DisableNotification" /> property.
+        /// </summary>
+        /// <param name="disableNotification">
+        ///     Sends the message silently. iOS users will not receive a notification, Android users
+        ///     will receive a notification with no sound.
+        /// </param>
+        public SendLocationParameters WithDisableNotification(bool disableNotification)
+        {
+            DisableNotification = disableNotification;
+            return this;
+        }
+
+        /// <summary>
+        ///     Sets <see cref="ReplyToMessageId" /> property.
+        /// </summary>
+        /// <param name="replyToMessageId">If the message is a reply, ID of the original message</param>
+        public SendLocationParameters WithReplyToMessageId(int replyToMessageId)
+        {
+            ReplyToMessageId = replyToMessageId;
+            return this;
+        }
+
+        /// <summary>
+        ///     Sets <see cref="ReplyMarkup" /> property.
+        /// </summary>
+        /// <param name="replyMarkup">
+        ///     Additional interface options. A JSON-serialized object for a custom reply keyboard,
+        ///     instructions to hide keyboard or to force a reply from the user.
+        /// </param>
+        public SendLocationParameters WithReplyMarkup(IReplyMarkup replyMarkup)
+        {
+            ReplyMarkup = replyMarkup;
+            return this;
+        }
+    }
+}

--- a/src/Telegram.Bot/Requests/Parameters/SendMediaGroupExtendedParameters.cs
+++ b/src/Telegram.Bot/Requests/Parameters/SendMediaGroupExtendedParameters.cs
@@ -1,0 +1,74 @@
+using System.Collections.Generic;
+using Telegram.Bot.Types;
+
+namespace Telegram.Bot.Requests.Parameters
+{
+    /// <summary>
+    ///     Parameters for <see cref="ITelegramBotClient.SendMediaGroupAsync" /> method.
+    /// </summary>
+    public class SendMediaGroupExtendedParameters : ParametersBase
+    {
+        /// <summary>
+        ///     A JSON-serialized array describing photos and videos to be sent, must include 2–10 items
+        /// </summary>
+        public IEnumerable<IAlbumInputMedia> InputMedia { get; set; }
+
+        /// <summary>
+        ///     Unique identifier for the target chat or username of the target channel (in the format @channelusername)
+        /// </summary>
+        public ChatId ChatId { get; set; }
+
+        /// <summary>
+        ///     Sends the messages silently. Users will receive a notification with no sound.
+        /// </summary>
+        public bool DisableNotification { get; set; }
+
+        /// <summary>
+        ///     If the message is a reply, ID of the original message
+        /// </summary>
+        public int ReplyToMessageId { get; set; }
+
+        /// <summary>
+        ///     Sets <see cref="InputMedia" /> property.
+        /// </summary>
+        /// <param name="inputMedia">A JSON-serialized array describing photos and videos to be sent, must include 2–10 items</param>
+        public SendMediaGroupExtendedParameters WithInputMedia(IEnumerable<IAlbumInputMedia> inputMedia)
+        {
+            InputMedia = inputMedia;
+            return this;
+        }
+
+        /// <summary>
+        ///     Sets <see cref="ChatId" /> property.
+        /// </summary>
+        /// <param name="chatId">
+        ///     Unique identifier for the target chat or username of the target channel (in the format
+        ///     @channelusername)
+        /// </param>
+        public SendMediaGroupExtendedParameters WithChatId(ChatId chatId)
+        {
+            ChatId = chatId;
+            return this;
+        }
+
+        /// <summary>
+        ///     Sets <see cref="DisableNotification" /> property.
+        /// </summary>
+        /// <param name="disableNotification">Sends the messages silently. Users will receive a notification with no sound.</param>
+        public SendMediaGroupExtendedParameters WithDisableNotification(bool disableNotification)
+        {
+            DisableNotification = disableNotification;
+            return this;
+        }
+
+        /// <summary>
+        ///     Sets <see cref="ReplyToMessageId" /> property.
+        /// </summary>
+        /// <param name="replyToMessageId">If the message is a reply, ID of the original message</param>
+        public SendMediaGroupExtendedParameters WithReplyToMessageId(int replyToMessageId)
+        {
+            ReplyToMessageId = replyToMessageId;
+            return this;
+        }
+    }
+}

--- a/src/Telegram.Bot/Requests/Parameters/SendMediaGroupParameters.cs
+++ b/src/Telegram.Bot/Requests/Parameters/SendMediaGroupParameters.cs
@@ -1,0 +1,72 @@
+using System.Collections.Generic;
+using Telegram.Bot.Types;
+
+namespace Telegram.Bot.Requests.Parameters
+{
+    /// <summary>
+    ///     Parameters for <see cref="ITelegramBotClient.SendMediaGroupAsync" /> method.
+    /// </summary>
+    public class SendMediaGroupParameters : ParametersBase
+    {
+        /// <summary>
+        ///     Unique identifier for the target chat or username of the target channel (in the format @channelusername)
+        /// </summary>
+        public ChatId ChatId { get; set; }
+
+        /// <summary>
+        /// </summary>
+        public IEnumerable<InputMediaBase> Media { get; set; }
+
+        /// <summary>
+        ///     Sends the messages silently. Users will receive a notification with no sound.
+        /// </summary>
+        public bool DisableNotification { get; set; }
+
+        /// <summary>
+        ///     If the message is a reply, ID of the original message
+        /// </summary>
+        public int ReplyToMessageId { get; set; }
+
+        /// <summary>
+        ///     Sets <see cref="ChatId" /> property.
+        /// </summary>
+        /// <param name="chatId">
+        ///     Unique identifier for the target chat or username of the target channel (in the format
+        ///     @channelusername)
+        /// </param>
+        public SendMediaGroupParameters WithChatId(ChatId chatId)
+        {
+            ChatId = chatId;
+            return this;
+        }
+
+        /// <summary>
+        ///     Sets <see cref="Media" /> property.
+        /// </summary>
+        public SendMediaGroupParameters WithMedia(IEnumerable<InputMediaBase> media)
+        {
+            Media = media;
+            return this;
+        }
+
+        /// <summary>
+        ///     Sets <see cref="DisableNotification" /> property.
+        /// </summary>
+        /// <param name="disableNotification">Sends the messages silently. Users will receive a notification with no sound.</param>
+        public SendMediaGroupParameters WithDisableNotification(bool disableNotification)
+        {
+            DisableNotification = disableNotification;
+            return this;
+        }
+
+        /// <summary>
+        ///     Sets <see cref="ReplyToMessageId" /> property.
+        /// </summary>
+        /// <param name="replyToMessageId">If the message is a reply, ID of the original message</param>
+        public SendMediaGroupParameters WithReplyToMessageId(int replyToMessageId)
+        {
+            ReplyToMessageId = replyToMessageId;
+            return this;
+        }
+    }
+}

--- a/src/Telegram.Bot/Requests/Parameters/SendPhotoParameters.cs
+++ b/src/Telegram.Bot/Requests/Parameters/SendPhotoParameters.cs
@@ -1,0 +1,128 @@
+using Telegram.Bot.Types;
+using Telegram.Bot.Types.Enums;
+using Telegram.Bot.Types.InputFiles;
+using Telegram.Bot.Types.ReplyMarkups;
+
+namespace Telegram.Bot.Requests.Parameters
+{
+    /// <summary>
+    ///     Parameters for <see cref="ITelegramBotClient.SendPhotoAsync" /> method.
+    /// </summary>
+    public class SendPhotoParameters : ParametersBase
+    {
+        /// <summary>
+        /// </summary>
+        public ChatId ChatId { get; set; }
+
+        /// <summary>
+        ///     Photo to send.
+        /// </summary>
+        public InputOnlineFile Photo { get; set; }
+
+        /// <summary>
+        ///     Photo caption (may also be used when resending photos by file_id).
+        /// </summary>
+        public string Caption { get; set; }
+
+        /// <summary>
+        ///     Change, if you want Telegram apps to show bold, italic, fixed-width text or inline URLs in your bot's message.
+        /// </summary>
+        public ParseMode ParseMode { get; set; }
+
+        /// <summary>
+        ///     Sends the message silently. iOS users will not receive a notification, Android users will receive a notification
+        ///     with no sound.
+        /// </summary>
+        public bool DisableNotification { get; set; }
+
+        /// <summary>
+        ///     If the message is a reply, ID of the original message
+        /// </summary>
+        public int ReplyToMessageId { get; set; }
+
+        /// <summary>
+        ///     Additional interface options. A JSON-serialized object for a custom reply keyboard, instructions to hide keyboard
+        ///     or to force a reply from the user.
+        /// </summary>
+        public IReplyMarkup ReplyMarkup { get; set; }
+
+        /// <summary>
+        ///     Sets <see cref="ChatId" /> property.
+        /// </summary>
+        /// <param name="chatId"></param>
+        public SendPhotoParameters WithChatId(ChatId chatId)
+        {
+            ChatId = chatId;
+            return this;
+        }
+
+        /// <summary>
+        ///     Sets <see cref="Photo" /> property.
+        /// </summary>
+        /// <param name="photo">Photo to send.</param>
+        public SendPhotoParameters WithPhoto(InputOnlineFile photo)
+        {
+            Photo = photo;
+            return this;
+        }
+
+        /// <summary>
+        ///     Sets <see cref="Caption" /> property.
+        /// </summary>
+        /// <param name="caption">Photo caption (may also be used when resending photos by file_id).</param>
+        public SendPhotoParameters WithCaption(string caption)
+        {
+            Caption = caption;
+            return this;
+        }
+
+        /// <summary>
+        ///     Sets <see cref="ParseMode" /> property.
+        /// </summary>
+        /// <param name="parseMode">
+        ///     Change, if you want Telegram apps to show bold, italic, fixed-width text or inline URLs in your
+        ///     bot's message.
+        /// </param>
+        public SendPhotoParameters WithParseMode(ParseMode parseMode)
+        {
+            ParseMode = parseMode;
+            return this;
+        }
+
+        /// <summary>
+        ///     Sets <see cref="DisableNotification" /> property.
+        /// </summary>
+        /// <param name="disableNotification">
+        ///     Sends the message silently. iOS users will not receive a notification, Android users
+        ///     will receive a notification with no sound.
+        /// </param>
+        public SendPhotoParameters WithDisableNotification(bool disableNotification)
+        {
+            DisableNotification = disableNotification;
+            return this;
+        }
+
+        /// <summary>
+        ///     Sets <see cref="ReplyToMessageId" /> property.
+        /// </summary>
+        /// <param name="replyToMessageId">If the message is a reply, ID of the original message</param>
+        public SendPhotoParameters WithReplyToMessageId(int replyToMessageId)
+        {
+            ReplyToMessageId = replyToMessageId;
+            return this;
+        }
+
+        /// <summary>
+        ///     Sets <see cref="ReplyMarkup" /> property.
+        /// </summary>
+        /// <param name="replyMarkup">
+        ///     Additional interface options. A JSON-serialized object for a custom reply keyboard,
+        ///     instructions to hide keyboard or to force a reply from the user.
+        /// </param>
+        public SendPhotoParameters WithReplyMarkup(IReplyMarkup replyMarkup)
+        {
+            ReplyMarkup = replyMarkup;
+            return this;
+        }
+    }
+}

--- a/src/Telegram.Bot/Requests/Parameters/SendPollParameters.cs
+++ b/src/Telegram.Bot/Requests/Parameters/SendPollParameters.cs
@@ -1,0 +1,252 @@
+using System;
+using System.Collections.Generic;
+using Telegram.Bot.Types;
+using Telegram.Bot.Types.Enums;
+using Telegram.Bot.Types.ReplyMarkups;
+
+namespace Telegram.Bot.Requests.Parameters
+{
+    /// <summary>
+    ///     Parameters for <see cref="ITelegramBotClient.SendPollAsync" /> method.
+    /// </summary>
+    public class SendPollParameters : ParametersBase
+    {
+        /// <summary>
+        /// </summary>
+        public ChatId ChatId { get; set; }
+
+        /// <summary>
+        ///     Poll question, 1-255 characters
+        /// </summary>
+        public string Question { get; set; }
+
+        /// <summary>
+        ///     List of answer options, 2-10 strings 1-100 characters each
+        /// </summary>
+        public IEnumerable<string> Options { get; set; }
+
+        /// <summary>
+        ///     Sends the message silently. iOS users will not receive a notification, Android users will receive a notification
+        ///     with no sound.
+        /// </summary>
+        public bool DisableNotification { get; set; }
+
+        /// <summary>
+        ///     If the message is a reply, ID of the original message
+        /// </summary>
+        public int ReplyToMessageId { get; set; }
+
+        /// <summary>
+        ///     Additional interface options. A JSON-serialized object for an inline keyboard, custom reply keyboard, instructions
+        ///     to hide keyboard or to force a reply from the user.
+        /// </summary>
+        public IReplyMarkup ReplyMarkup { get; set; }
+
+        /// <summary>
+        ///     True, if the poll needs to be anonymous, defaults to True
+        /// </summary>
+        public bool? IsAnonymous { get; set; }
+
+        /// <summary>
+        ///     Poll type, “quiz” or “regular”, defaults to “regular”
+        /// </summary>
+        public PollType? Type { get; set; }
+
+        /// <summary>
+        ///     True, if the poll allows multiple answers, ignored for polls in quiz mode, defaults to False
+        /// </summary>
+        public bool? AllowsMultipleAnswers { get; set; }
+
+        /// <summary>
+        ///     0-based identifier of the correct answer option, required for polls in quiz mode
+        /// </summary>
+        public int? CorrectOptionId { get; set; }
+
+        /// <summary>
+        ///     Pass True, if the poll needs to be immediately closed
+        /// </summary>
+        public bool? IsClosed { get; set; }
+
+        /// <summary>
+        ///     Text that is shown when a user chooses an incorrect answer or taps on the lamp icon in a quiz-style poll
+        /// </summary>
+        public string Explanation { get; set; }
+
+        /// <summary>
+        ///     Mode for parsing entities in the explanation
+        /// </summary>
+        public ParseMode ExplanationParseMode { get; set; }
+
+        /// <summary>
+        ///     Amount of time in seconds the poll will be active after creation
+        /// </summary>
+        public int? OpenPeriod { get; set; }
+
+        /// <summary>
+        ///     Point in time when the poll will be automatically closed
+        /// </summary>
+        public DateTime? CloseDate { get; set; }
+
+        /// <summary>
+        ///     Sets <see cref="ChatId" /> property.
+        /// </summary>
+        /// <param name="chatId"></param>
+        public SendPollParameters WithChatId(ChatId chatId)
+        {
+            ChatId = chatId;
+            return this;
+        }
+
+        /// <summary>
+        ///     Sets <see cref="Question" /> property.
+        /// </summary>
+        /// <param name="question">Poll question, 1-255 characters</param>
+        public SendPollParameters WithQuestion(string question)
+        {
+            Question = question;
+            return this;
+        }
+
+        /// <summary>
+        ///     Sets <see cref="Options" /> property.
+        /// </summary>
+        /// <param name="options">List of answer options, 2-10 strings 1-100 characters each</param>
+        public SendPollParameters WithOptions(IEnumerable<string> options)
+        {
+            Options = options;
+            return this;
+        }
+
+        /// <summary>
+        ///     Sets <see cref="DisableNotification" /> property.
+        /// </summary>
+        /// <param name="disableNotification">
+        ///     Sends the message silently. iOS users will not receive a notification, Android users
+        ///     will receive a notification with no sound.
+        /// </param>
+        public SendPollParameters WithDisableNotification(bool disableNotification)
+        {
+            DisableNotification = disableNotification;
+            return this;
+        }
+
+        /// <summary>
+        ///     Sets <see cref="ReplyToMessageId" /> property.
+        /// </summary>
+        /// <param name="replyToMessageId">If the message is a reply, ID of the original message</param>
+        public SendPollParameters WithReplyToMessageId(int replyToMessageId)
+        {
+            ReplyToMessageId = replyToMessageId;
+            return this;
+        }
+
+        /// <summary>
+        ///     Sets <see cref="ReplyMarkup" /> property.
+        /// </summary>
+        /// <param name="replyMarkup">
+        ///     Additional interface options. A JSON-serialized object for an inline keyboard, custom reply
+        ///     keyboard, instructions to hide keyboard or to force a reply from the user.
+        /// </param>
+        public SendPollParameters WithReplyMarkup(IReplyMarkup replyMarkup)
+        {
+            ReplyMarkup = replyMarkup;
+            return this;
+        }
+
+        /// <summary>
+        ///     Sets <see cref="IsAnonymous" /> property.
+        /// </summary>
+        /// <param name="isAnonymous">True, if the poll needs to be anonymous, defaults to True</param>
+        public SendPollParameters WithIsAnonymous(bool? isAnonymous)
+        {
+            IsAnonymous = isAnonymous;
+            return this;
+        }
+
+        /// <summary>
+        ///     Sets <see cref="Type" /> property.
+        /// </summary>
+        /// <param name="type">Poll type, “quiz” or “regular”, defaults to “regular”</param>
+        public SendPollParameters WithType(PollType? type)
+        {
+            Type = type;
+            return this;
+        }
+
+        /// <summary>
+        ///     Sets <see cref="AllowsMultipleAnswers" /> property.
+        /// </summary>
+        /// <param name="allowsMultipleAnswers">
+        ///     True, if the poll allows multiple answers, ignored for polls in quiz mode, defaults
+        ///     to False
+        /// </param>
+        public SendPollParameters WithAllowsMultipleAnswers(bool? allowsMultipleAnswers)
+        {
+            AllowsMultipleAnswers = allowsMultipleAnswers;
+            return this;
+        }
+
+        /// <summary>
+        ///     Sets <see cref="CorrectOptionId" /> property.
+        /// </summary>
+        /// <param name="correctOptionId">0-based identifier of the correct answer option, required for polls in quiz mode</param>
+        public SendPollParameters WithCorrectOptionId(int? correctOptionId)
+        {
+            CorrectOptionId = correctOptionId;
+            return this;
+        }
+
+        /// <summary>
+        ///     Sets <see cref="IsClosed" /> property.
+        /// </summary>
+        /// <param name="isClosed">Pass True, if the poll needs to be immediately closed</param>
+        public SendPollParameters WithIsClosed(bool? isClosed)
+        {
+            IsClosed = isClosed;
+            return this;
+        }
+
+        /// <summary>
+        ///     Sets <see cref="Explanation" /> property.
+        /// </summary>
+        /// <param name="explanation">
+        ///     Text that is shown when a user chooses an incorrect answer or taps on the lamp icon in a
+        ///     quiz-style poll
+        /// </param>
+        public SendPollParameters WithExplanation(string explanation)
+        {
+            Explanation = explanation;
+            return this;
+        }
+
+        /// <summary>
+        ///     Sets <see cref="ExplanationParseMode" /> property.
+        /// </summary>
+        /// <param name="explanationParseMode">Mode for parsing entities in the explanation</param>
+        public SendPollParameters WithExplanationParseMode(ParseMode explanationParseMode)
+        {
+            ExplanationParseMode = explanationParseMode;
+            return this;
+        }
+
+        /// <summary>
+        ///     Sets <see cref="OpenPeriod" /> property.
+        /// </summary>
+        /// <param name="openPeriod">Amount of time in seconds the poll will be active after creation</param>
+        public SendPollParameters WithOpenPeriod(int? openPeriod)
+        {
+            OpenPeriod = openPeriod;
+            return this;
+        }
+
+        /// <summary>
+        ///     Sets <see cref="CloseDate" /> property.
+        /// </summary>
+        /// <param name="closeDate">Point in time when the poll will be automatically closed</param>
+        public SendPollParameters WithCloseDate(DateTime? closeDate)
+        {
+            CloseDate = closeDate;
+            return this;
+        }
+    }
+}

--- a/src/Telegram.Bot/Requests/Parameters/SendStickerParameters.cs
+++ b/src/Telegram.Bot/Requests/Parameters/SendStickerParameters.cs
@@ -1,0 +1,94 @@
+using Telegram.Bot.Types;
+using Telegram.Bot.Types.InputFiles;
+using Telegram.Bot.Types.ReplyMarkups;
+
+namespace Telegram.Bot.Requests.Parameters
+{
+    /// <summary>
+    ///     Parameters for <see cref="ITelegramBotClient.SendStickerAsync" /> method.
+    /// </summary>
+    public class SendStickerParameters : ParametersBase
+    {
+        /// <summary>
+        /// </summary>
+        public ChatId ChatId { get; set; }
+
+        /// <summary>
+        ///     Sticker to send.
+        /// </summary>
+        public InputOnlineFile Sticker { get; set; }
+
+        /// <summary>
+        ///     Sends the message silently. iOS users will not receive a notification, Android users will receive a notification
+        ///     with no sound.
+        /// </summary>
+        public bool DisableNotification { get; set; }
+
+        /// <summary>
+        ///     If the message is a reply, ID of the original message
+        /// </summary>
+        public int ReplyToMessageId { get; set; }
+
+        /// <summary>
+        ///     Additional interface options. A JSON-serialized object for a custom reply keyboard, instructions to hide keyboard
+        ///     or to force a reply from the user.
+        /// </summary>
+        public IReplyMarkup ReplyMarkup { get; set; }
+
+        /// <summary>
+        ///     Sets <see cref="ChatId" /> property.
+        /// </summary>
+        /// <param name="chatId"></param>
+        public SendStickerParameters WithChatId(ChatId chatId)
+        {
+            ChatId = chatId;
+            return this;
+        }
+
+        /// <summary>
+        ///     Sets <see cref="Sticker" /> property.
+        /// </summary>
+        /// <param name="sticker">Sticker to send.</param>
+        public SendStickerParameters WithSticker(InputOnlineFile sticker)
+        {
+            Sticker = sticker;
+            return this;
+        }
+
+        /// <summary>
+        ///     Sets <see cref="DisableNotification" /> property.
+        /// </summary>
+        /// <param name="disableNotification">
+        ///     Sends the message silently. iOS users will not receive a notification, Android users
+        ///     will receive a notification with no sound.
+        /// </param>
+        public SendStickerParameters WithDisableNotification(bool disableNotification)
+        {
+            DisableNotification = disableNotification;
+            return this;
+        }
+
+        /// <summary>
+        ///     Sets <see cref="ReplyToMessageId" /> property.
+        /// </summary>
+        /// <param name="replyToMessageId">If the message is a reply, ID of the original message</param>
+        public SendStickerParameters WithReplyToMessageId(int replyToMessageId)
+        {
+            ReplyToMessageId = replyToMessageId;
+            return this;
+        }
+
+        /// <summary>
+        ///     Sets <see cref="ReplyMarkup" /> property.
+        /// </summary>
+        /// <param name="replyMarkup">
+        ///     Additional interface options. A JSON-serialized object for a custom reply keyboard,
+        ///     instructions to hide keyboard or to force a reply from the user.
+        /// </param>
+        public SendStickerParameters WithReplyMarkup(IReplyMarkup replyMarkup)
+        {
+            ReplyMarkup = replyMarkup;
+            return this;
+        }
+    }
+}

--- a/src/Telegram.Bot/Requests/Parameters/SendTextMessageParameters.cs
+++ b/src/Telegram.Bot/Requests/Parameters/SendTextMessageParameters.cs
@@ -1,0 +1,127 @@
+using Telegram.Bot.Types;
+using Telegram.Bot.Types.Enums;
+using Telegram.Bot.Types.ReplyMarkups;
+
+namespace Telegram.Bot.Requests.Parameters
+{
+    /// <summary>
+    ///     Parameters for <see cref="ITelegramBotClient.SendTextMessageAsync" /> method.
+    /// </summary>
+    public class SendTextMessageParameters : ParametersBase
+    {
+        /// <summary>
+        /// </summary>
+        public ChatId ChatId { get; set; }
+
+        /// <summary>
+        ///     Text of the message to be sent
+        /// </summary>
+        public string Text { get; set; }
+
+        /// <summary>
+        ///     Change, if you want Telegram apps to show bold, italic, fixed-width text or inline URLs in your bot's message.
+        /// </summary>
+        public ParseMode ParseMode { get; set; }
+
+        /// <summary>
+        ///     Disables link previews for links in this message
+        /// </summary>
+        public bool DisableWebPagePreview { get; set; }
+
+        /// <summary>
+        ///     Sends the message silently. iOS users will not receive a notification, Android users will receive a notification
+        ///     with no sound.
+        /// </summary>
+        public bool DisableNotification { get; set; }
+
+        /// <summary>
+        ///     If the message is a reply, ID of the original message
+        /// </summary>
+        public int ReplyToMessageId { get; set; }
+
+        /// <summary>
+        ///     Additional interface options. A JSON-serialized object for a custom reply keyboard, instructions to hide keyboard
+        ///     or to force a reply from the user.
+        /// </summary>
+        public IReplyMarkup ReplyMarkup { get; set; }
+
+        /// <summary>
+        ///     Sets <see cref="ChatId" /> property.
+        /// </summary>
+        /// <param name="chatId"></param>
+        public SendTextMessageParameters WithChatId(ChatId chatId)
+        {
+            ChatId = chatId;
+            return this;
+        }
+
+        /// <summary>
+        ///     Sets <see cref="Text" /> property.
+        /// </summary>
+        /// <param name="text">Text of the message to be sent</param>
+        public SendTextMessageParameters WithText(string text)
+        {
+            Text = text;
+            return this;
+        }
+
+        /// <summary>
+        ///     Sets <see cref="ParseMode" /> property.
+        /// </summary>
+        /// <param name="parseMode">
+        ///     Change, if you want Telegram apps to show bold, italic, fixed-width text or inline URLs in your
+        ///     bot's message.
+        /// </param>
+        public SendTextMessageParameters WithParseMode(ParseMode parseMode)
+        {
+            ParseMode = parseMode;
+            return this;
+        }
+
+        /// <summary>
+        ///     Sets <see cref="DisableWebPagePreview" /> property.
+        /// </summary>
+        /// <param name="disableWebPagePreview">Disables link previews for links in this message</param>
+        public SendTextMessageParameters WithDisableWebPagePreview(bool disableWebPagePreview)
+        {
+            DisableWebPagePreview = disableWebPagePreview;
+            return this;
+        }
+
+        /// <summary>
+        ///     Sets <see cref="DisableNotification" /> property.
+        /// </summary>
+        /// <param name="disableNotification">
+        ///     Sends the message silently. iOS users will not receive a notification, Android users
+        ///     will receive a notification with no sound.
+        /// </param>
+        public SendTextMessageParameters WithDisableNotification(bool disableNotification)
+        {
+            DisableNotification = disableNotification;
+            return this;
+        }
+
+        /// <summary>
+        ///     Sets <see cref="ReplyToMessageId" /> property.
+        /// </summary>
+        /// <param name="replyToMessageId">If the message is a reply, ID of the original message</param>
+        public SendTextMessageParameters WithReplyToMessageId(int replyToMessageId)
+        {
+            ReplyToMessageId = replyToMessageId;
+            return this;
+        }
+
+        /// <summary>
+        ///     Sets <see cref="ReplyMarkup" /> property.
+        /// </summary>
+        /// <param name="replyMarkup">
+        ///     Additional interface options. A JSON-serialized object for a custom reply keyboard,
+        ///     instructions to hide keyboard or to force a reply from the user.
+        /// </param>
+        public SendTextMessageParameters WithReplyMarkup(IReplyMarkup replyMarkup)
+        {
+            ReplyMarkup = replyMarkup;
+            return this;
+        }
+    }
+}

--- a/src/Telegram.Bot/Requests/Parameters/SendVenueParameters.cs
+++ b/src/Telegram.Bot/Requests/Parameters/SendVenueParameters.cs
@@ -1,0 +1,172 @@
+using Telegram.Bot.Types;
+using Telegram.Bot.Types.ReplyMarkups;
+
+namespace Telegram.Bot.Requests.Parameters
+{
+    /// <summary>
+    ///     Parameters for <see cref="ITelegramBotClient.SendVenueAsync" /> method.
+    /// </summary>
+    public class SendVenueParameters : ParametersBase
+    {
+        /// <summary>
+        /// </summary>
+        public ChatId ChatId { get; set; }
+
+        /// <summary>
+        ///     Latitude of the venue
+        /// </summary>
+        public float Latitude { get; set; }
+
+        /// <summary>
+        ///     Longitude of the venue
+        /// </summary>
+        public float Longitude { get; set; }
+
+        /// <summary>
+        ///     Name of the venue
+        /// </summary>
+        public string Title { get; set; }
+
+        /// <summary>
+        ///     Address of the venue
+        /// </summary>
+        public string Address { get; set; }
+
+        /// <summary>
+        ///     Foursquare identifier of the venue
+        /// </summary>
+        public string FoursquareId { get; set; }
+
+        /// <summary>
+        ///     Sends the message silently. iOS users will not receive a notification,
+        ///     Android users will receive a notification with no sound.
+        /// </summary>
+        public bool DisableNotification { get; set; }
+
+        /// <summary>
+        ///     If the message is a reply, ID of the original message
+        /// </summary>
+        public int ReplyToMessageId { get; set; }
+
+        /// <summary>
+        ///     Additional interface options. A JSON-serialized object for a custom reply
+        ///     keyboard, instructions to hide keyboard or to force a reply from the user.
+        /// </summary>
+        public IReplyMarkup ReplyMarkup { get; set; }
+
+        /// <summary>
+        ///     Foursquare type of the venue, if known. (For example,
+        ///     "arts_entertainment/default", "arts_entertainment/aquarium" or "food/icecream".)
+        /// </summary>
+        public string FoursquareType { get; set; }
+
+        /// <summary>
+        ///     Sets <see cref="ChatId" /> property.
+        /// </summary>
+        /// <param name="chatId"></param>
+        public SendVenueParameters WithChatId(ChatId chatId)
+        {
+            ChatId = chatId;
+            return this;
+        }
+
+        /// <summary>
+        ///     Sets <see cref="Latitude" /> property.
+        /// </summary>
+        /// <param name="latitude">Latitude of the venue</param>
+        public SendVenueParameters WithLatitude(float latitude)
+        {
+            Latitude = latitude;
+            return this;
+        }
+
+        /// <summary>
+        ///     Sets <see cref="Longitude" /> property.
+        /// </summary>
+        /// <param name="longitude">Longitude of the venue</param>
+        public SendVenueParameters WithLongitude(float longitude)
+        {
+            Longitude = longitude;
+            return this;
+        }
+
+        /// <summary>
+        ///     Sets <see cref="Title" /> property.
+        /// </summary>
+        /// <param name="title">Name of the venue</param>
+        public SendVenueParameters WithTitle(string title)
+        {
+            Title = title;
+            return this;
+        }
+
+        /// <summary>
+        ///     Sets <see cref="Address" /> property.
+        /// </summary>
+        /// <param name="address">Address of the venue</param>
+        public SendVenueParameters WithAddress(string address)
+        {
+            Address = address;
+            return this;
+        }
+
+        /// <summary>
+        ///     Sets <see cref="FoursquareId" /> property.
+        /// </summary>
+        /// <param name="foursquareId">Foursquare identifier of the venue</param>
+        public SendVenueParameters WithFoursquareId(string foursquareId)
+        {
+            FoursquareId = foursquareId;
+            return this;
+        }
+
+        /// <summary>
+        ///     Sets <see cref="DisableNotification" /> property.
+        /// </summary>
+        /// <param name="disableNotification">
+        ///     Sends the message silently. iOS users will not receive a notification,
+        ///     Android users will receive a notification with no sound.
+        /// </param>
+        public SendVenueParameters WithDisableNotification(bool disableNotification)
+        {
+            DisableNotification = disableNotification;
+            return this;
+        }
+
+        /// <summary>
+        ///     Sets <see cref="ReplyToMessageId" /> property.
+        /// </summary>
+        /// <param name="replyToMessageId">If the message is a reply, ID of the original message</param>
+        public SendVenueParameters WithReplyToMessageId(int replyToMessageId)
+        {
+            ReplyToMessageId = replyToMessageId;
+            return this;
+        }
+
+        /// <summary>
+        ///     Sets <see cref="ReplyMarkup" /> property.
+        /// </summary>
+        /// <param name="replyMarkup">
+        ///     Additional interface options. A JSON-serialized object for a custom reply
+        ///     keyboard, instructions to hide keyboard or to force a reply from the user.
+        /// </param>
+        public SendVenueParameters WithReplyMarkup(IReplyMarkup replyMarkup)
+        {
+            ReplyMarkup = replyMarkup;
+            return this;
+        }
+
+        /// <summary>
+        ///     Sets <see cref="FoursquareType" /> property.
+        /// </summary>
+        /// <param name="foursquareType">
+        ///     Foursquare type of the venue, if known. (For example,
+        ///     "arts_entertainment/default", "arts_entertainment/aquarium" or "food/icecream".)
+        /// </param>
+        public SendVenueParameters WithFoursquareType(string foursquareType)
+        {
+            FoursquareType = foursquareType;
+            return this;
+        }
+    }
+}

--- a/src/Telegram.Bot/Requests/Parameters/SendVideoNoteParameters.cs
+++ b/src/Telegram.Bot/Requests/Parameters/SendVideoNoteParameters.cs
@@ -1,0 +1,145 @@
+using Telegram.Bot.Types;
+using Telegram.Bot.Types.InputFiles;
+using Telegram.Bot.Types.ReplyMarkups;
+
+namespace Telegram.Bot.Requests.Parameters
+{
+    /// <summary>
+    ///     Parameters for <see cref="ITelegramBotClient.SendVideoNoteAsync" /> method.
+    /// </summary>
+    public class SendVideoNoteParameters : ParametersBase
+    {
+        /// <summary>
+        /// </summary>
+        public ChatId ChatId { get; set; }
+
+        /// <summary>
+        ///     Video note to send.
+        /// </summary>
+        public InputTelegramFile VideoNote { get; set; }
+
+        /// <summary>
+        ///     Duration of sent video in seconds
+        /// </summary>
+        public int Duration { get; set; }
+
+        /// <summary>
+        ///     Video width and height
+        /// </summary>
+        public int Length { get; set; }
+
+        /// <summary>
+        ///     Sends the message silently. iOS users will not receive a notification,
+        ///     Android users will receive a notification with no sound.
+        /// </summary>
+        public bool DisableNotification { get; set; }
+
+        /// <summary>
+        ///     If the message is a reply, ID of the original message
+        /// </summary>
+        public int ReplyToMessageId { get; set; }
+
+        /// <summary>
+        ///     Additional interface options. A JSON-serialized object for a custom reply keyboard,
+        ///     instructions to hide keyboard or to force a reply from the user.
+        /// </summary>
+        public IReplyMarkup ReplyMarkup { get; set; }
+
+        /// <summary>
+        ///     Thumbnail of the file sent. The thumbnail should be in JPEG format and less than 200 kB
+        ///     in size. A thumbnail's width and height should not exceed 90. Thumbnails can't be reused and can be only
+        ///     uploaded as a new file.
+        /// </summary>
+        public InputMedia Thumb { get; set; }
+
+        /// <summary>
+        ///     Sets <see cref="ChatId" /> property.
+        /// </summary>
+        /// <param name="chatId"></param>
+        public SendVideoNoteParameters WithChatId(ChatId chatId)
+        {
+            ChatId = chatId;
+            return this;
+        }
+
+        /// <summary>
+        ///     Sets <see cref="VideoNote" /> property.
+        /// </summary>
+        /// <param name="videoNote">Video note to send.</param>
+        public SendVideoNoteParameters WithVideoNote(InputTelegramFile videoNote)
+        {
+            VideoNote = videoNote;
+            return this;
+        }
+
+        /// <summary>
+        ///     Sets <see cref="Duration" /> property.
+        /// </summary>
+        /// <param name="duration">Duration of sent video in seconds</param>
+        public SendVideoNoteParameters WithDuration(int duration)
+        {
+            Duration = duration;
+            return this;
+        }
+
+        /// <summary>
+        ///     Sets <see cref="Length" /> property.
+        /// </summary>
+        /// <param name="length">Video width and height</param>
+        public SendVideoNoteParameters WithLength(int length)
+        {
+            Length = length;
+            return this;
+        }
+
+        /// <summary>
+        ///     Sets <see cref="DisableNotification" /> property.
+        /// </summary>
+        /// <param name="disableNotification">
+        ///     Sends the message silently. iOS users will not receive a notification,
+        ///     Android users will receive a notification with no sound.
+        /// </param>
+        public SendVideoNoteParameters WithDisableNotification(bool disableNotification)
+        {
+            DisableNotification = disableNotification;
+            return this;
+        }
+
+        /// <summary>
+        ///     Sets <see cref="ReplyToMessageId" /> property.
+        /// </summary>
+        /// <param name="replyToMessageId">If the message is a reply, ID of the original message</param>
+        public SendVideoNoteParameters WithReplyToMessageId(int replyToMessageId)
+        {
+            ReplyToMessageId = replyToMessageId;
+            return this;
+        }
+
+        /// <summary>
+        ///     Sets <see cref="ReplyMarkup" /> property.
+        /// </summary>
+        /// <param name="replyMarkup">
+        ///     Additional interface options. A JSON-serialized object for a custom reply keyboard,
+        ///     instructions to hide keyboard or to force a reply from the user.
+        /// </param>
+        public SendVideoNoteParameters WithReplyMarkup(IReplyMarkup replyMarkup)
+        {
+            ReplyMarkup = replyMarkup;
+            return this;
+        }
+
+        /// <summary>
+        ///     Sets <see cref="Thumb" /> property.
+        /// </summary>
+        /// <param name="thumb">
+        ///     Thumbnail of the file sent. The thumbnail should be in JPEG format and less than 200 kB
+        ///     in size. A thumbnail's width and height should not exceed 90. Thumbnails can't be reused and can be only
+        ///     uploaded as a new file.
+        /// </param>
+        public SendVideoNoteParameters WithThumb(InputMedia thumb)
+        {
+            Thumb = thumb;
+            return this;
+        }
+    }
+}

--- a/src/Telegram.Bot/Requests/Parameters/SendVideoParameters.cs
+++ b/src/Telegram.Bot/Requests/Parameters/SendVideoParameters.cs
@@ -1,0 +1,210 @@
+using Telegram.Bot.Types;
+using Telegram.Bot.Types.Enums;
+using Telegram.Bot.Types.InputFiles;
+using Telegram.Bot.Types.ReplyMarkups;
+
+namespace Telegram.Bot.Requests.Parameters
+{
+    /// <summary>
+    ///     Parameters for <see cref="ITelegramBotClient.SendVideoAsync" /> method.
+    /// </summary>
+    public class SendVideoParameters : ParametersBase
+    {
+        /// <summary>
+        /// </summary>
+        public ChatId ChatId { get; set; }
+
+        /// <summary>
+        ///     Video to send.
+        /// </summary>
+        public InputOnlineFile Video { get; set; }
+
+        /// <summary>
+        ///     Duration of sent video in seconds
+        /// </summary>
+        public int Duration { get; set; }
+
+        /// <summary>
+        ///     Video width
+        /// </summary>
+        public int Width { get; set; }
+
+        /// <summary>
+        ///     Video height
+        /// </summary>
+        public int Height { get; set; }
+
+        /// <summary>
+        ///     Video caption
+        /// </summary>
+        public string Caption { get; set; }
+
+        /// <summary>
+        ///     Change, if you want Telegram apps to show bold, italic, fixed-width text or inline
+        ///     URLs in your bot's message.
+        /// </summary>
+        public ParseMode ParseMode { get; set; }
+
+        /// <summary>
+        ///     Pass True, if the uploaded video is suitable for streaming
+        /// </summary>
+        public bool SupportsStreaming { get; set; }
+
+        /// <summary>
+        ///     Sends the message silently. iOS users will not receive a notification,
+        ///     Android users will receive a notification with no sound.
+        /// </summary>
+        public bool DisableNotification { get; set; }
+
+        /// <summary>
+        ///     If the message is a reply, ID of the original message
+        /// </summary>
+        public int ReplyToMessageId { get; set; }
+
+        /// <summary>
+        ///     Additional interface options. A JSON-serialized object for a custom reply keyboard,
+        ///     instructions to hide keyboard or to force a reply from the user.
+        /// </summary>
+        public IReplyMarkup ReplyMarkup { get; set; }
+
+        /// <summary>
+        ///     Thumbnail of the file sent. The thumbnail should be in JPEG format and less than 200 kB
+        ///     in size. A thumbnail's width and height should not exceed 90. Thumbnails can't be reused and can be only
+        ///     uploaded as a new file.
+        /// </summary>
+        public InputMedia Thumb { get; set; }
+
+        /// <summary>
+        ///     Sets <see cref="ChatId" /> property.
+        /// </summary>
+        /// <param name="chatId"></param>
+        public SendVideoParameters WithChatId(ChatId chatId)
+        {
+            ChatId = chatId;
+            return this;
+        }
+
+        /// <summary>
+        ///     Sets <see cref="Video" /> property.
+        /// </summary>
+        /// <param name="video">Video to send.</param>
+        public SendVideoParameters WithVideo(InputOnlineFile video)
+        {
+            Video = video;
+            return this;
+        }
+
+        /// <summary>
+        ///     Sets <see cref="Duration" /> property.
+        /// </summary>
+        /// <param name="duration">Duration of sent video in seconds</param>
+        public SendVideoParameters WithDuration(int duration)
+        {
+            Duration = duration;
+            return this;
+        }
+
+        /// <summary>
+        ///     Sets <see cref="Width" /> property.
+        /// </summary>
+        /// <param name="width">Video width</param>
+        public SendVideoParameters WithWidth(int width)
+        {
+            Width = width;
+            return this;
+        }
+
+        /// <summary>
+        ///     Sets <see cref="Height" /> property.
+        /// </summary>
+        /// <param name="height">Video height</param>
+        public SendVideoParameters WithHeight(int height)
+        {
+            Height = height;
+            return this;
+        }
+
+        /// <summary>
+        ///     Sets <see cref="Caption" /> property.
+        /// </summary>
+        /// <param name="caption">Video caption</param>
+        public SendVideoParameters WithCaption(string caption)
+        {
+            Caption = caption;
+            return this;
+        }
+
+        /// <summary>
+        ///     Sets <see cref="ParseMode" /> property.
+        /// </summary>
+        /// <param name="parseMode">
+        ///     Change, if you want Telegram apps to show bold, italic, fixed-width text or inline
+        ///     URLs in your bot's message.
+        /// </param>
+        public SendVideoParameters WithParseMode(ParseMode parseMode)
+        {
+            ParseMode = parseMode;
+            return this;
+        }
+
+        /// <summary>
+        ///     Sets <see cref="SupportsStreaming" /> property.
+        /// </summary>
+        /// <param name="supportsStreaming">Pass True, if the uploaded video is suitable for streaming</param>
+        public SendVideoParameters WithSupportsStreaming(bool supportsStreaming)
+        {
+            SupportsStreaming = supportsStreaming;
+            return this;
+        }
+
+        /// <summary>
+        ///     Sets <see cref="DisableNotification" /> property.
+        /// </summary>
+        /// <param name="disableNotification">
+        ///     Sends the message silently. iOS users will not receive a notification,
+        ///     Android users will receive a notification with no sound.
+        /// </param>
+        public SendVideoParameters WithDisableNotification(bool disableNotification)
+        {
+            DisableNotification = disableNotification;
+            return this;
+        }
+
+        /// <summary>
+        ///     Sets <see cref="ReplyToMessageId" /> property.
+        /// </summary>
+        /// <param name="replyToMessageId">If the message is a reply, ID of the original message</param>
+        public SendVideoParameters WithReplyToMessageId(int replyToMessageId)
+        {
+            ReplyToMessageId = replyToMessageId;
+            return this;
+        }
+
+        /// <summary>
+        ///     Sets <see cref="ReplyMarkup" /> property.
+        /// </summary>
+        /// <param name="replyMarkup">
+        ///     Additional interface options. A JSON-serialized object for a custom reply keyboard,
+        ///     instructions to hide keyboard or to force a reply from the user.
+        /// </param>
+        public SendVideoParameters WithReplyMarkup(IReplyMarkup replyMarkup)
+        {
+            ReplyMarkup = replyMarkup;
+            return this;
+        }
+
+        /// <summary>
+        ///     Sets <see cref="Thumb" /> property.
+        /// </summary>
+        /// <param name="thumb">
+        ///     Thumbnail of the file sent. The thumbnail should be in JPEG format and less than 200 kB
+        ///     in size. A thumbnail's width and height should not exceed 90. Thumbnails can't be reused and can be only
+        ///     uploaded as a new file.
+        /// </param>
+        public SendVideoParameters WithThumb(InputMedia thumb)
+        {
+            Thumb = thumb;
+            return this;
+        }
+    }
+}

--- a/src/Telegram.Bot/Requests/Parameters/SendVoiceParameters.cs
+++ b/src/Telegram.Bot/Requests/Parameters/SendVoiceParameters.cs
@@ -1,0 +1,143 @@
+using Telegram.Bot.Types;
+using Telegram.Bot.Types.Enums;
+using Telegram.Bot.Types.InputFiles;
+using Telegram.Bot.Types.ReplyMarkups;
+
+namespace Telegram.Bot.Requests.Parameters
+{
+    /// <summary>
+    ///     Parameters for <see cref="ITelegramBotClient.SendVoiceAsync" /> method.
+    /// </summary>
+    public class SendVoiceParameters : ParametersBase
+    {
+        /// <summary>
+        /// </summary>
+        public ChatId ChatId { get; set; }
+
+        /// <summary>
+        ///     Audio file to send.
+        /// </summary>
+        public InputOnlineFile Voice { get; set; }
+
+        /// <summary>
+        ///     Voice message caption, 0-1024 characters
+        /// </summary>
+        public string Caption { get; set; }
+
+        /// <summary>
+        ///     Change, if you want Telegram apps to show bold, italic, fixed-width text or inline URLs in your bot's message.
+        /// </summary>
+        public ParseMode ParseMode { get; set; }
+
+        /// <summary>
+        ///     Duration of sent audio in seconds
+        /// </summary>
+        public int Duration { get; set; }
+
+        /// <summary>
+        ///     Sends the message silently. iOS users will not receive a notification, Android users will receive a notification
+        ///     with no sound.
+        /// </summary>
+        public bool DisableNotification { get; set; }
+
+        /// <summary>
+        ///     If the message is a reply, ID of the original message
+        /// </summary>
+        public int ReplyToMessageId { get; set; }
+
+        /// <summary>
+        ///     Additional interface options. A JSON-serialized object for a custom reply keyboard, instructions to hide keyboard
+        ///     or to force a reply from the user.
+        /// </summary>
+        public IReplyMarkup ReplyMarkup { get; set; }
+
+        /// <summary>
+        ///     Sets <see cref="ChatId" /> property.
+        /// </summary>
+        /// <param name="chatId"></param>
+        public SendVoiceParameters WithChatId(ChatId chatId)
+        {
+            ChatId = chatId;
+            return this;
+        }
+
+        /// <summary>
+        ///     Sets <see cref="Voice" /> property.
+        /// </summary>
+        /// <param name="voice">Audio file to send.</param>
+        public SendVoiceParameters WithVoice(InputOnlineFile voice)
+        {
+            Voice = voice;
+            return this;
+        }
+
+        /// <summary>
+        ///     Sets <see cref="Caption" /> property.
+        /// </summary>
+        /// <param name="caption">Voice message caption, 0-1024 characters</param>
+        public SendVoiceParameters WithCaption(string caption)
+        {
+            Caption = caption;
+            return this;
+        }
+
+        /// <summary>
+        ///     Sets <see cref="ParseMode" /> property.
+        /// </summary>
+        /// <param name="parseMode">
+        ///     Change, if you want Telegram apps to show bold, italic, fixed-width text or inline URLs in your
+        ///     bot's message.
+        /// </param>
+        public SendVoiceParameters WithParseMode(ParseMode parseMode)
+        {
+            ParseMode = parseMode;
+            return this;
+        }
+
+        /// <summary>
+        ///     Sets <see cref="Duration" /> property.
+        /// </summary>
+        /// <param name="duration">Duration of sent audio in seconds</param>
+        public SendVoiceParameters WithDuration(int duration)
+        {
+            Duration = duration;
+            return this;
+        }
+
+        /// <summary>
+        ///     Sets <see cref="DisableNotification" /> property.
+        /// </summary>
+        /// <param name="disableNotification">
+        ///     Sends the message silently. iOS users will not receive a notification, Android users
+        ///     will receive a notification with no sound.
+        /// </param>
+        public SendVoiceParameters WithDisableNotification(bool disableNotification)
+        {
+            DisableNotification = disableNotification;
+            return this;
+        }
+
+        /// <summary>
+        ///     Sets <see cref="ReplyToMessageId" /> property.
+        /// </summary>
+        /// <param name="replyToMessageId">If the message is a reply, ID of the original message</param>
+        public SendVoiceParameters WithReplyToMessageId(int replyToMessageId)
+        {
+            ReplyToMessageId = replyToMessageId;
+            return this;
+        }
+
+        /// <summary>
+        ///     Sets <see cref="ReplyMarkup" /> property.
+        /// </summary>
+        /// <param name="replyMarkup">
+        ///     Additional interface options. A JSON-serialized object for a custom reply keyboard,
+        ///     instructions to hide keyboard or to force a reply from the user.
+        /// </param>
+        public SendVoiceParameters WithReplyMarkup(IReplyMarkup replyMarkup)
+        {
+            ReplyMarkup = replyMarkup;
+            return this;
+        }
+    }
+}

--- a/src/Telegram.Bot/Requests/Parameters/SetChatAdministratorCustomTitleParameters.cs
+++ b/src/Telegram.Bot/Requests/Parameters/SetChatAdministratorCustomTitleParameters.cs
@@ -1,0 +1,55 @@
+using Telegram.Bot.Types;
+
+namespace Telegram.Bot.Requests.Parameters
+{
+    /// <summary>
+    ///     Parameters for <see cref="ITelegramBotClient.SetChatAdministratorCustomTitleAsync" /> method.
+    /// </summary>
+    public class SetChatAdministratorCustomTitleParameters : ParametersBase
+    {
+        /// <summary>
+        ///     Unique identifier for the target chat or username of the target channel
+        /// </summary>
+        public ChatId ChatId { get; set; }
+
+        /// <summary>
+        ///     Unique identifier of the target user
+        /// </summary>
+        public int UserId { get; set; }
+
+        /// <summary>
+        ///     New custom title for the administrator; 0-16 characters, emoji are not allowed
+        /// </summary>
+        public string CustomTitle { get; set; }
+
+        /// <summary>
+        ///     Sets <see cref="ChatId" /> property.
+        /// </summary>
+        /// <param name="chatId">Unique identifier for the target chat or username of the target channel</param>
+        public SetChatAdministratorCustomTitleParameters WithChatId(ChatId chatId)
+        {
+            ChatId = chatId;
+            return this;
+        }
+
+        /// <summary>
+        ///     Sets <see cref="UserId" /> property.
+        /// </summary>
+        /// <param name="userId">Unique identifier of the target user</param>
+        public SetChatAdministratorCustomTitleParameters WithUserId(int userId)
+        {
+            UserId = userId;
+            return this;
+        }
+
+        /// <summary>
+        ///     Sets <see cref="CustomTitle" /> property.
+        /// </summary>
+        /// <param name="customTitle">New custom title for the administrator; 0-16 characters, emoji are not allowed</param>
+        public SetChatAdministratorCustomTitleParameters WithCustomTitle(string customTitle)
+        {
+            CustomTitle = customTitle;
+            return this;
+        }
+    }
+}

--- a/src/Telegram.Bot/Requests/Parameters/SetChatDescriptionParameters.cs
+++ b/src/Telegram.Bot/Requests/Parameters/SetChatDescriptionParameters.cs
@@ -1,0 +1,43 @@
+using Telegram.Bot.Types;
+
+namespace Telegram.Bot.Requests.Parameters
+{
+    /// <summary>
+    ///     Parameters for <see cref="ITelegramBotClient.SetChatDescriptionAsync" /> method.
+    /// </summary>
+    public class SetChatDescriptionParameters : ParametersBase
+    {
+        /// <summary>
+        ///     Unique identifier for the target chat or username of the target channel
+        /// </summary>
+        public ChatId ChatId { get; set; }
+
+        /// <summary>
+        ///     New chat description, 0-255 characters. Defaults to an empty string, which would clear the description.
+        /// </summary>
+        public string Description { get; set; }
+
+        /// <summary>
+        ///     Sets <see cref="ChatId" /> property.
+        /// </summary>
+        /// <param name="chatId">Unique identifier for the target chat or username of the target channel</param>
+        public SetChatDescriptionParameters WithChatId(ChatId chatId)
+        {
+            ChatId = chatId;
+            return this;
+        }
+
+        /// <summary>
+        ///     Sets <see cref="Description" /> property.
+        /// </summary>
+        /// <param name="description">
+        ///     New chat description, 0-255 characters. Defaults to an empty string, which would clear the
+        ///     description.
+        /// </param>
+        public SetChatDescriptionParameters WithDescription(string description)
+        {
+            Description = description;
+            return this;
+        }
+    }
+}

--- a/src/Telegram.Bot/Requests/Parameters/SetChatPermissionsParameters.cs
+++ b/src/Telegram.Bot/Requests/Parameters/SetChatPermissionsParameters.cs
@@ -1,0 +1,40 @@
+using Telegram.Bot.Types;
+
+namespace Telegram.Bot.Requests.Parameters
+{
+    /// <summary>
+    ///     Parameters for <see cref="ITelegramBotClient.SetChatPermissionsAsync" /> method.
+    /// </summary>
+    public class SetChatPermissionsParameters : ParametersBase
+    {
+        /// <summary>
+        ///     Unique identifier for the target chat or username of the target channel
+        /// </summary>
+        public ChatId ChatId { get; set; }
+
+        /// <summary>
+        ///     New default permissions
+        /// </summary>
+        public ChatPermissions Permissions { get; set; }
+
+        /// <summary>
+        ///     Sets <see cref="ChatId" /> property.
+        /// </summary>
+        /// <param name="chatId">Unique identifier for the target chat or username of the target channel</param>
+        public SetChatPermissionsParameters WithChatId(ChatId chatId)
+        {
+            ChatId = chatId;
+            return this;
+        }
+
+        /// <summary>
+        ///     Sets <see cref="Permissions" /> property.
+        /// </summary>
+        /// <param name="permissions">New default permissions</param>
+        public SetChatPermissionsParameters WithPermissions(ChatPermissions permissions)
+        {
+            Permissions = permissions;
+            return this;
+        }
+    }
+}

--- a/src/Telegram.Bot/Requests/Parameters/SetChatPhotoParameters.cs
+++ b/src/Telegram.Bot/Requests/Parameters/SetChatPhotoParameters.cs
@@ -1,0 +1,41 @@
+using Telegram.Bot.Types;
+using Telegram.Bot.Types.InputFiles;
+
+namespace Telegram.Bot.Requests.Parameters
+{
+    /// <summary>
+    ///     Parameters for <see cref="ITelegramBotClient.SetChatPhotoAsync" /> method.
+    /// </summary>
+    public class SetChatPhotoParameters : ParametersBase
+    {
+        /// <summary>
+        ///     Unique identifier for the target chat or username of the target channel
+        /// </summary>
+        public ChatId ChatId { get; set; }
+
+        /// <summary>
+        ///     The new profile picture for the chat.
+        /// </summary>
+        public InputFileStream Photo { get; set; }
+
+        /// <summary>
+        ///     Sets <see cref="ChatId" /> property.
+        /// </summary>
+        /// <param name="chatId">Unique identifier for the target chat or username of the target channel</param>
+        public SetChatPhotoParameters WithChatId(ChatId chatId)
+        {
+            ChatId = chatId;
+            return this;
+        }
+
+        /// <summary>
+        ///     Sets <see cref="Photo" /> property.
+        /// </summary>
+        /// <param name="photo">The new profile picture for the chat.</param>
+        public SetChatPhotoParameters WithPhoto(InputFileStream photo)
+        {
+            Photo = photo;
+            return this;
+        }
+    }
+}

--- a/src/Telegram.Bot/Requests/Parameters/SetChatStickerSetParameters.cs
+++ b/src/Telegram.Bot/Requests/Parameters/SetChatStickerSetParameters.cs
@@ -1,0 +1,43 @@
+using Telegram.Bot.Types;
+
+namespace Telegram.Bot.Requests.Parameters
+{
+    /// <summary>
+    ///     Parameters for <see cref="ITelegramBotClient.SetChatStickerSetAsync" /> method.
+    /// </summary>
+    public class SetChatStickerSetParameters : ParametersBase
+    {
+        /// <summary>
+        ///     Unique identifier for the target chat or username of the target supergroup (in the format @supergroupusername)
+        /// </summary>
+        public ChatId ChatId { get; set; }
+
+        /// <summary>
+        ///     Name of the sticker set to be set as the group sticker set
+        /// </summary>
+        public string StickerSetName { get; set; }
+
+        /// <summary>
+        ///     Sets <see cref="ChatId" /> property.
+        /// </summary>
+        /// <param name="chatId">
+        ///     Unique identifier for the target chat or username of the target supergroup (in the format
+        ///     @supergroupusername)
+        /// </param>
+        public SetChatStickerSetParameters WithChatId(ChatId chatId)
+        {
+            ChatId = chatId;
+            return this;
+        }
+
+        /// <summary>
+        ///     Sets <see cref="StickerSetName" /> property.
+        /// </summary>
+        /// <param name="stickerSetName">Name of the sticker set to be set as the group sticker set</param>
+        public SetChatStickerSetParameters WithStickerSetName(string stickerSetName)
+        {
+            StickerSetName = stickerSetName;
+            return this;
+        }
+    }
+}

--- a/src/Telegram.Bot/Requests/Parameters/SetChatTitleParameters.cs
+++ b/src/Telegram.Bot/Requests/Parameters/SetChatTitleParameters.cs
@@ -1,0 +1,40 @@
+using Telegram.Bot.Types;
+
+namespace Telegram.Bot.Requests.Parameters
+{
+    /// <summary>
+    ///     Parameters for <see cref="ITelegramBotClient.SetChatTitleAsync" /> method.
+    /// </summary>
+    public class SetChatTitleParameters : ParametersBase
+    {
+        /// <summary>
+        ///     Unique identifier for the target chat or username of the target channel
+        /// </summary>
+        public ChatId ChatId { get; set; }
+
+        /// <summary>
+        ///     New chat title, 1-255 characters
+        /// </summary>
+        public string Title { get; set; }
+
+        /// <summary>
+        ///     Sets <see cref="ChatId" /> property.
+        /// </summary>
+        /// <param name="chatId">Unique identifier for the target chat or username of the target channel</param>
+        public SetChatTitleParameters WithChatId(ChatId chatId)
+        {
+            ChatId = chatId;
+            return this;
+        }
+
+        /// <summary>
+        ///     Sets <see cref="Title" /> property.
+        /// </summary>
+        /// <param name="title">New chat title, 1-255 characters</param>
+        public SetChatTitleParameters WithTitle(string title)
+        {
+            Title = title;
+            return this;
+        }
+    }
+}

--- a/src/Telegram.Bot/Requests/Parameters/SetGameScoreInlineParameters.cs
+++ b/src/Telegram.Bot/Requests/Parameters/SetGameScoreInlineParameters.cs
@@ -1,0 +1,89 @@
+namespace Telegram.Bot.Requests.Parameters
+{
+    /// <summary>
+    ///     Parameters for <see cref="ITelegramBotClient.SetGameScoreAsync" /> method.
+    /// </summary>
+    public class SetGameScoreInlineParameters : ParametersBase
+    {
+        /// <summary>
+        ///     Unique identifier of the target user.
+        /// </summary>
+        public int UserId { get; set; }
+
+        /// <summary>
+        ///     The score.
+        /// </summary>
+        public int Score { get; set; }
+
+        /// <summary>
+        ///     Identifier of the inline message.
+        /// </summary>
+        public string InlineMessageId { get; set; }
+
+        /// <summary>
+        ///     Pass True, if the high score is allowed to decrease. This can be useful when fixing mistakes or banning cheaters
+        /// </summary>
+        public bool Force { get; set; }
+
+        /// <summary>
+        ///     Pass True, if the game message should not be automatically edited to include the current scoreboard
+        /// </summary>
+        public bool DisableEditMessage { get; set; }
+
+        /// <summary>
+        ///     Sets <see cref="UserId" /> property.
+        /// </summary>
+        /// <param name="userId">Unique identifier of the target user.</param>
+        public SetGameScoreInlineParameters WithUserId(int userId)
+        {
+            UserId = userId;
+            return this;
+        }
+
+        /// <summary>
+        ///     Sets <see cref="Score" /> property.
+        /// </summary>
+        /// <param name="score">The score.</param>
+        public SetGameScoreInlineParameters WithScore(int score)
+        {
+            Score = score;
+            return this;
+        }
+
+        /// <summary>
+        ///     Sets <see cref="InlineMessageId" /> property.
+        /// </summary>
+        /// <param name="inlineMessageId">Identifier of the inline message.</param>
+        public SetGameScoreInlineParameters WithInlineMessageId(string inlineMessageId)
+        {
+            InlineMessageId = inlineMessageId;
+            return this;
+        }
+
+        /// <summary>
+        ///     Sets <see cref="Force" /> property.
+        /// </summary>
+        /// <param name="force">
+        ///     Pass True, if the high score is allowed to decrease. This can be useful when fixing mistakes or
+        ///     banning cheaters
+        /// </param>
+        public SetGameScoreInlineParameters WithForce(bool force)
+        {
+            Force = force;
+            return this;
+        }
+
+        /// <summary>
+        ///     Sets <see cref="DisableEditMessage" /> property.
+        /// </summary>
+        /// <param name="disableEditMessage">
+        ///     Pass True, if the game message should not be automatically edited to include the
+        ///     current scoreboard
+        /// </param>
+        public SetGameScoreInlineParameters WithDisableEditMessage(bool disableEditMessage)
+        {
+            DisableEditMessage = disableEditMessage;
+            return this;
+        }
+    }
+}

--- a/src/Telegram.Bot/Requests/Parameters/SetGameScoreParameters.cs
+++ b/src/Telegram.Bot/Requests/Parameters/SetGameScoreParameters.cs
@@ -1,0 +1,100 @@
+namespace Telegram.Bot.Requests.Parameters
+{
+    /// <summary>
+    ///     Parameters for <see cref="ITelegramBotClient.SetGameScoreAsync" /> method.
+    /// </summary>
+    public class SetGameScoreParameters : ParametersBase
+    {
+        /// <summary>
+        ///     Unique identifier of the target user.
+        /// </summary>
+        public int UserId { get; set; }
+
+        /// <summary>
+        ///     The score.
+        /// </summary>
+        public int Score { get; set; }
+
+        /// <summary>
+        /// </summary>
+        public long ChatId { get; set; }
+
+        /// <summary>
+        /// </summary>
+        public int MessageId { get; set; }
+
+        /// <summary>
+        ///     Pass True, if the high score is allowed to decrease. This can be useful when fixing mistakes or banning cheaters
+        /// </summary>
+        public bool Force { get; set; }
+
+        /// <summary>
+        ///     Pass True, if the game message should not be automatically edited to include the current scoreboard
+        /// </summary>
+        public bool DisableEditMessage { get; set; }
+
+        /// <summary>
+        ///     Sets <see cref="UserId" /> property.
+        /// </summary>
+        /// <param name="userId">Unique identifier of the target user.</param>
+        public SetGameScoreParameters WithUserId(int userId)
+        {
+            UserId = userId;
+            return this;
+        }
+
+        /// <summary>
+        ///     Sets <see cref="Score" /> property.
+        /// </summary>
+        /// <param name="score">The score.</param>
+        public SetGameScoreParameters WithScore(int score)
+        {
+            Score = score;
+            return this;
+        }
+
+        /// <summary>
+        ///     Sets <see cref="ChatId" /> property.
+        /// </summary>
+        public SetGameScoreParameters WithChatId(long chatId)
+        {
+            ChatId = chatId;
+            return this;
+        }
+
+        /// <summary>
+        ///     Sets <see cref="MessageId" /> property.
+        /// </summary>
+        public SetGameScoreParameters WithMessageId(int messageId)
+        {
+            MessageId = messageId;
+            return this;
+        }
+
+        /// <summary>
+        ///     Sets <see cref="Force" /> property.
+        /// </summary>
+        /// <param name="force">
+        ///     Pass True, if the high score is allowed to decrease. This can be useful when fixing mistakes or
+        ///     banning cheaters
+        /// </param>
+        public SetGameScoreParameters WithForce(bool force)
+        {
+            Force = force;
+            return this;
+        }
+
+        /// <summary>
+        ///     Sets <see cref="DisableEditMessage" /> property.
+        /// </summary>
+        /// <param name="disableEditMessage">
+        ///     Pass True, if the game message should not be automatically edited to include the
+        ///     current scoreboard
+        /// </param>
+        public SetGameScoreParameters WithDisableEditMessage(bool disableEditMessage)
+        {
+            DisableEditMessage = disableEditMessage;
+            return this;
+        }
+    }
+}

--- a/src/Telegram.Bot/Requests/Parameters/SetMyCommandsParameters.cs
+++ b/src/Telegram.Bot/Requests/Parameters/SetMyCommandsParameters.cs
@@ -1,0 +1,26 @@
+using System.Collections.Generic;
+using Telegram.Bot.Types;
+
+namespace Telegram.Bot.Requests.Parameters
+{
+    /// <summary>
+    ///     Parameters for <see cref="ITelegramBotClient.SetMyCommandsAsync" /> method.
+    /// </summary>
+    public class SetMyCommandsParameters : ParametersBase
+    {
+        /// <summary>
+        ///     A list of bot commands to be set
+        /// </summary>
+        public IEnumerable<BotCommand> Commands { get; set; }
+
+        /// <summary>
+        ///     Sets <see cref="Commands" /> property.
+        /// </summary>
+        /// <param name="commands">A list of bot commands to be set</param>
+        public SetMyCommandsParameters WithCommands(IEnumerable<BotCommand> commands)
+        {
+            Commands = commands;
+            return this;
+        }
+    }
+}

--- a/src/Telegram.Bot/Requests/Parameters/SetStickerPositionInSetParameters.cs
+++ b/src/Telegram.Bot/Requests/Parameters/SetStickerPositionInSetParameters.cs
@@ -1,0 +1,38 @@
+namespace Telegram.Bot.Requests.Parameters
+{
+    /// <summary>
+    ///     Parameters for <see cref="ITelegramBotClient.SetStickerPositionInSetAsync" /> method.
+    /// </summary>
+    public class SetStickerPositionInSetParameters : ParametersBase
+    {
+        /// <summary>
+        ///     File identifier of the sticker
+        /// </summary>
+        public string Sticker { get; set; }
+
+        /// <summary>
+        ///     New sticker position in the set, zero-based
+        /// </summary>
+        public int Position { get; set; }
+
+        /// <summary>
+        ///     Sets <see cref="Sticker" /> property.
+        /// </summary>
+        /// <param name="sticker">File identifier of the sticker</param>
+        public SetStickerPositionInSetParameters WithSticker(string sticker)
+        {
+            Sticker = sticker;
+            return this;
+        }
+
+        /// <summary>
+        ///     Sets <see cref="Position" /> property.
+        /// </summary>
+        /// <param name="position">New sticker position in the set, zero-based</param>
+        public SetStickerPositionInSetParameters WithPosition(int position)
+        {
+            Position = position;
+            return this;
+        }
+    }
+}

--- a/src/Telegram.Bot/Requests/Parameters/SetStickerSetThumbParameters.cs
+++ b/src/Telegram.Bot/Requests/Parameters/SetStickerSetThumbParameters.cs
@@ -1,0 +1,55 @@
+using Telegram.Bot.Types.InputFiles;
+
+namespace Telegram.Bot.Requests.Parameters
+{
+    /// <summary>
+    ///     Parameters for <see cref="ITelegramBotClient.SetStickerSetThumbAsync" /> method.
+    /// </summary>
+    public class SetStickerSetThumbParameters : ParametersBase
+    {
+        /// <summary>
+        ///     Sticker set name
+        /// </summary>
+        public string Name { get; set; }
+
+        /// <summary>
+        ///     User identifier of the sticker set owner
+        /// </summary>
+        public int UserId { get; set; }
+
+        /// <summary>
+        ///     A PNG image or a TGS animation with the thumbnail
+        /// </summary>
+        public InputOnlineFile Thumb { get; set; }
+
+        /// <summary>
+        ///     Sets <see cref="Name" /> property.
+        /// </summary>
+        /// <param name="name">Sticker set name</param>
+        public SetStickerSetThumbParameters WithName(string name)
+        {
+            Name = name;
+            return this;
+        }
+
+        /// <summary>
+        ///     Sets <see cref="UserId" /> property.
+        /// </summary>
+        /// <param name="userId">User identifier of the sticker set owner</param>
+        public SetStickerSetThumbParameters WithUserId(int userId)
+        {
+            UserId = userId;
+            return this;
+        }
+
+        /// <summary>
+        ///     Sets <see cref="Thumb" /> property.
+        /// </summary>
+        /// <param name="thumb">A PNG image or a TGS animation with the thumbnail</param>
+        public SetStickerSetThumbParameters WithThumb(InputOnlineFile thumb)
+        {
+            Thumb = thumb;
+            return this;
+        }
+    }
+}

--- a/src/Telegram.Bot/Requests/Parameters/SetWebhookParameters.cs
+++ b/src/Telegram.Bot/Requests/Parameters/SetWebhookParameters.cs
@@ -1,0 +1,83 @@
+using System.Collections.Generic;
+using Telegram.Bot.Types.Enums;
+using Telegram.Bot.Types.InputFiles;
+
+namespace Telegram.Bot.Requests.Parameters
+{
+    /// <summary>
+    ///     Parameters for <see cref="ITelegramBotClient.SetWebhookAsync" /> method.
+    /// </summary>
+    public class SetWebhookParameters : ParametersBase
+    {
+        /// <summary>
+        ///     HTTPS url to send updates to. Use an empty string to remove webhook integration
+        /// </summary>
+        public string Url { get; set; }
+
+        /// <summary>
+        ///     Upload your public key certificate so that the root certificate in use can be checked.
+        ///     See the
+        /// </summary>
+        public InputFileStream Certificate { get; set; }
+
+        /// <summary>
+        ///     Maximum allowed number of simultaneous HTTPS connections to the webhook for update delivery, 1-100. Defaults to 40.
+        ///     Use lower values to limit the load on your bot's server, and higher values to increase your bot's throughput.
+        /// </summary>
+        public int MaxConnections { get; set; }
+
+        /// <summary>
+        ///     List the
+        /// </summary>
+        public IEnumerable<UpdateType> AllowedUpdates { get; set; }
+
+        /// <summary>
+        ///     Sets <see cref="Url" /> property.
+        /// </summary>
+        /// <param name="url">HTTPS url to send updates to. Use an empty string to remove webhook integration</param>
+        public SetWebhookParameters WithUrl(string url)
+        {
+            Url = url;
+            return this;
+        }
+
+        /// <summary>
+        ///     Sets <see cref="Certificate" /> property.
+        /// </summary>
+        /// <param name="certificate">
+        ///     Upload your public key certificate so that the root certificate in use can be checked.
+        ///     See the
+        /// </param>
+        public SetWebhookParameters WithCertificate(InputFileStream certificate)
+        {
+            Certificate = certificate;
+            return this;
+        }
+
+        /// <summary>
+        ///     Sets <see cref="MaxConnections" /> property.
+        /// </summary>
+        /// <param name="maxConnections">
+        ///     Maximum allowed number of simultaneous HTTPS connections to the webhook for update
+        ///     delivery, 1-100. Defaults to 40. Use lower values to limit the load on your bot's server, and higher values to
+        ///     increase your bot's throughput.
+        /// </param>
+        public SetWebhookParameters WithMaxConnections(int maxConnections)
+        {
+            MaxConnections = maxConnections;
+            return this;
+        }
+
+        /// <summary>
+        ///     Sets <see cref="AllowedUpdates" /> property.
+        /// </summary>
+        /// <param name="allowedUpdates">
+        ///     List the
+        /// </param>
+        public SetWebhookParameters WithAllowedUpdates(IEnumerable<UpdateType> allowedUpdates)
+        {
+            AllowedUpdates = allowedUpdates;
+            return this;
+        }
+    }
+}

--- a/src/Telegram.Bot/Requests/Parameters/StartReceivingParameters.cs
+++ b/src/Telegram.Bot/Requests/Parameters/StartReceivingParameters.cs
@@ -1,0 +1,25 @@
+using Telegram.Bot.Types.Enums;
+
+namespace Telegram.Bot.Requests.Parameters
+{
+    /// <summary>
+    ///     Parameters for <see cref="ITelegramBotClient.StartReceiving" /> method.
+    /// </summary>
+    public class StartReceivingParameters : ParametersBase
+    {
+        /// <summary>
+        ///     List the types of updates you want your bot to receive.
+        /// </summary>
+        public UpdateType[] AllowedUpdates { get; set; }
+
+        /// <summary>
+        ///     Sets <see cref="AllowedUpdates" /> property.
+        /// </summary>
+        /// <param name="allowedUpdates">List the types of updates you want your bot to receive.</param>
+        public StartReceivingParameters WithAllowedUpdates(UpdateType[] allowedUpdates)
+        {
+            AllowedUpdates = allowedUpdates;
+            return this;
+        }
+    }
+}

--- a/src/Telegram.Bot/Requests/Parameters/StopMessageLiveLocationInlineParameters.cs
+++ b/src/Telegram.Bot/Requests/Parameters/StopMessageLiveLocationInlineParameters.cs
@@ -1,0 +1,40 @@
+using Telegram.Bot.Types.ReplyMarkups;
+
+namespace Telegram.Bot.Requests.Parameters
+{
+    /// <summary>
+    ///     Parameters for <see cref="ITelegramBotClient.StopMessageLiveLocationAsync" /> method.
+    /// </summary>
+    public class StopMessageLiveLocationInlineParameters : ParametersBase
+    {
+        /// <summary>
+        ///     Identifier of the inline message
+        /// </summary>
+        public string InlineMessageId { get; set; }
+
+        /// <summary>
+        ///     A JSON-serialized object for an inline keyboard.
+        /// </summary>
+        public InlineKeyboardMarkup ReplyMarkup { get; set; }
+
+        /// <summary>
+        ///     Sets <see cref="InlineMessageId" /> property.
+        /// </summary>
+        /// <param name="inlineMessageId">Identifier of the inline message</param>
+        public StopMessageLiveLocationInlineParameters WithInlineMessageId(string inlineMessageId)
+        {
+            InlineMessageId = inlineMessageId;
+            return this;
+        }
+
+        /// <summary>
+        ///     Sets <see cref="ReplyMarkup" /> property.
+        /// </summary>
+        /// <param name="replyMarkup">A JSON-serialized object for an inline keyboard.</param>
+        public StopMessageLiveLocationInlineParameters WithReplyMarkup(InlineKeyboardMarkup replyMarkup)
+        {
+            ReplyMarkup = replyMarkup;
+            return this;
+        }
+    }
+}

--- a/src/Telegram.Bot/Requests/Parameters/StopMessageLiveLocationParameters.cs
+++ b/src/Telegram.Bot/Requests/Parameters/StopMessageLiveLocationParameters.cs
@@ -1,0 +1,52 @@
+using Telegram.Bot.Types;
+using Telegram.Bot.Types.ReplyMarkups;
+
+namespace Telegram.Bot.Requests.Parameters
+{
+    /// <summary>
+    ///     Parameters for <see cref="ITelegramBotClient.StopMessageLiveLocationAsync" /> method.
+    /// </summary>
+    public class StopMessageLiveLocationParameters : ParametersBase
+    {
+        /// <summary>
+        /// </summary>
+        public ChatId ChatId { get; set; }
+
+        /// <summary>
+        /// </summary>
+        public int MessageId { get; set; }
+
+        /// <summary>
+        ///     A JSON-serialized object for an inline keyboard.
+        /// </summary>
+        public InlineKeyboardMarkup ReplyMarkup { get; set; }
+
+        /// <summary>
+        ///     Sets <see cref="ChatId" /> property.
+        /// </summary>
+        public StopMessageLiveLocationParameters WithChatId(ChatId chatId)
+        {
+            ChatId = chatId;
+            return this;
+        }
+
+        /// <summary>
+        ///     Sets <see cref="MessageId" /> property.
+        /// </summary>
+        public StopMessageLiveLocationParameters WithMessageId(int messageId)
+        {
+            MessageId = messageId;
+            return this;
+        }
+
+        /// <summary>
+        ///     Sets <see cref="ReplyMarkup" /> property.
+        /// </summary>
+        /// <param name="replyMarkup">A JSON-serialized object for an inline keyboard.</param>
+        public StopMessageLiveLocationParameters WithReplyMarkup(InlineKeyboardMarkup replyMarkup)
+        {
+            ReplyMarkup = replyMarkup;
+            return this;
+        }
+    }
+}

--- a/src/Telegram.Bot/Requests/Parameters/StopPollParameters.cs
+++ b/src/Telegram.Bot/Requests/Parameters/StopPollParameters.cs
@@ -1,0 +1,55 @@
+using Telegram.Bot.Types;
+using Telegram.Bot.Types.ReplyMarkups;
+
+namespace Telegram.Bot.Requests.Parameters
+{
+    /// <summary>
+    ///     Parameters for <see cref="ITelegramBotClient.StopPollAsync" /> method.
+    /// </summary>
+    public class StopPollParameters : ParametersBase
+    {
+        /// <summary>
+        /// </summary>
+        public ChatId ChatId { get; set; }
+
+        /// <summary>
+        ///     Identifier of the original message with the poll
+        /// </summary>
+        public int MessageId { get; set; }
+
+        /// <summary>
+        ///     A JSON-serialized object for a new message inline keyboard.
+        /// </summary>
+        public InlineKeyboardMarkup ReplyMarkup { get; set; }
+
+        /// <summary>
+        ///     Sets <see cref="ChatId" /> property.
+        /// </summary>
+        /// <param name="chatId"></param>
+        public StopPollParameters WithChatId(ChatId chatId)
+        {
+            ChatId = chatId;
+            return this;
+        }
+
+        /// <summary>
+        ///     Sets <see cref="MessageId" /> property.
+        /// </summary>
+        /// <param name="messageId">Identifier of the original message with the poll</param>
+        public StopPollParameters WithMessageId(int messageId)
+        {
+            MessageId = messageId;
+            return this;
+        }
+
+        /// <summary>
+        ///     Sets <see cref="ReplyMarkup" /> property.
+        /// </summary>
+        /// <param name="replyMarkup">A JSON-serialized object for a new message inline keyboard.</param>
+        public StopPollParameters WithReplyMarkup(InlineKeyboardMarkup replyMarkup)
+        {
+            ReplyMarkup = replyMarkup;
+            return this;
+        }
+    }
+}

--- a/src/Telegram.Bot/Requests/Parameters/UnbanChatMemberParameters.cs
+++ b/src/Telegram.Bot/Requests/Parameters/UnbanChatMemberParameters.cs
@@ -1,0 +1,39 @@
+using Telegram.Bot.Types;
+
+namespace Telegram.Bot.Requests.Parameters
+{
+    /// <summary>
+    ///     Parameters for <see cref="ITelegramBotClient.UnbanChatMemberAsync" /> method.
+    /// </summary>
+    public class UnbanChatMemberParameters : ParametersBase
+    {
+        /// <summary>
+        /// </summary>
+        public ChatId ChatId { get; set; }
+
+        /// <summary>
+        ///     Unique identifier of the target user
+        /// </summary>
+        public int UserId { get; set; }
+
+        /// <summary>
+        ///     Sets <see cref="ChatId" /> property.
+        /// </summary>
+        /// <param name="chatId"></param>
+        public UnbanChatMemberParameters WithChatId(ChatId chatId)
+        {
+            ChatId = chatId;
+            return this;
+        }
+
+        /// <summary>
+        ///     Sets <see cref="UserId" /> property.
+        /// </summary>
+        /// <param name="userId">Unique identifier of the target user</param>
+        public UnbanChatMemberParameters WithUserId(int userId)
+        {
+            UserId = userId;
+            return this;
+        }
+    }
+}

--- a/src/Telegram.Bot/Requests/Parameters/UnpinChatMessageParameters.cs
+++ b/src/Telegram.Bot/Requests/Parameters/UnpinChatMessageParameters.cs
@@ -1,0 +1,25 @@
+using Telegram.Bot.Types;
+
+namespace Telegram.Bot.Requests.Parameters
+{
+    /// <summary>
+    ///     Parameters for <see cref="ITelegramBotClient.UnpinChatMessageAsync" /> method.
+    /// </summary>
+    public class UnpinChatMessageParameters : ParametersBase
+    {
+        /// <summary>
+        ///     Unique identifier for the target chat or username of the target supergroup
+        /// </summary>
+        public ChatId ChatId { get; set; }
+
+        /// <summary>
+        ///     Sets <see cref="ChatId" /> property.
+        /// </summary>
+        /// <param name="chatId">Unique identifier for the target chat or username of the target supergroup</param>
+        public UnpinChatMessageParameters WithChatId(ChatId chatId)
+        {
+            ChatId = chatId;
+            return this;
+        }
+    }
+}

--- a/src/Telegram.Bot/Requests/Parameters/UploadStickerFileParameters.cs
+++ b/src/Telegram.Bot/Requests/Parameters/UploadStickerFileParameters.cs
@@ -1,0 +1,44 @@
+using Telegram.Bot.Types.InputFiles;
+
+namespace Telegram.Bot.Requests.Parameters
+{
+    /// <summary>
+    ///     Parameters for <see cref="ITelegramBotClient.UploadStickerFileAsync" /> method.
+    /// </summary>
+    public class UploadStickerFileParameters : ParametersBase
+    {
+        /// <summary>
+        ///     User identifier of sticker file owner
+        /// </summary>
+        public int UserId { get; set; }
+
+        /// <summary>
+        ///     Png image with the sticker, must be up to 512 kilobytes in size, dimensions must not exceed 512px, and either width
+        ///     or height must be exactly 512px.
+        /// </summary>
+        public InputFileStream PngSticker { get; set; }
+
+        /// <summary>
+        ///     Sets <see cref="UserId" /> property.
+        /// </summary>
+        /// <param name="userId">User identifier of sticker file owner</param>
+        public UploadStickerFileParameters WithUserId(int userId)
+        {
+            UserId = userId;
+            return this;
+        }
+
+        /// <summary>
+        ///     Sets <see cref="PngSticker" /> property.
+        /// </summary>
+        /// <param name="pngSticker">
+        ///     Png image with the sticker, must be up to 512 kilobytes in size, dimensions must not exceed
+        ///     512px, and either width or height must be exactly 512px.
+        /// </param>
+        public UploadStickerFileParameters WithPngSticker(InputFileStream pngSticker)
+        {
+            PngSticker = pngSticker;
+            return this;
+        }
+    }
+}

--- a/src/Telegram.Bot/TelegramBotClient.cs
+++ b/src/Telegram.Bot/TelegramBotClient.cs
@@ -11,6 +11,7 @@ using Telegram.Bot.Args;
 using Telegram.Bot.Exceptions;
 using Telegram.Bot.Requests;
 using Telegram.Bot.Requests.Abstractions;
+using Telegram.Bot.Requests.Parameters;
 using Telegram.Bot.Types;
 using Telegram.Bot.Types.Enums;
 using Telegram.Bot.Types.InlineQueryResults;
@@ -1596,6 +1597,1138 @@ namespace Telegram.Bot
                 new SetStickerSetThumbRequest(name, userId, thumb),
                 cancellationToken
             );
+
+        #endregion
+
+        #region Methods with parameters support
+
+        /// <summary>
+        ///     Send a request to Bot API
+        /// </summary>
+        /// <param name="makeRequestParameters">Request parameters.</param>
+        /// <param name="cancellationToken">A cancellation token that can be used by other objects or threads to receive notice of cancellation.</param>
+        public virtual Task<TResponse> MakeRequestAsync<TResponse>(
+            MakeRequestParameters<TResponse> makeRequestParameters, CancellationToken cancellationToken = default)
+        {
+            return MakeRequestAsync(makeRequestParameters.Request, cancellationToken);
+        }
+
+        /// <summary>
+        ///     Start update receiving
+        /// </summary>
+        /// <param name="startReceivingParameters">Request parameters.</param>
+        /// <param name="cancellationToken">A cancellation token that can be used by other objects or threads to receive notice of cancellation.</param>
+        public virtual void StartReceiving(StartReceivingParameters startReceivingParameters,
+            CancellationToken cancellationToken = default)
+        {
+            StartReceiving(startReceivingParameters.AllowedUpdates, cancellationToken);
+        }
+
+        /// <summary>
+        ///     Use this method to receive incoming updates using long polling (wiki).
+        /// </summary>
+        /// <param name="getUpdatesParameters">Request parameters.</param>
+        /// <param name="cancellationToken">A cancellation token that can be used by other objects or threads to receive notice of cancellation.</param>
+        public virtual Task<Update[]> GetUpdatesAsync(GetUpdatesParameters getUpdatesParameters,
+            CancellationToken cancellationToken = default)
+        {
+            return GetUpdatesAsync(getUpdatesParameters.Offset, getUpdatesParameters.Limit,
+                getUpdatesParameters.Timeout, getUpdatesParameters.AllowedUpdates, cancellationToken);
+        }
+
+        /// <summary>
+        ///     Use this method to specify a url and receive incoming updates via an outgoing webhook.
+        ///     Whenever there is an <see cref="Update" /> for the bot, we will send an HTTPS POST request to the specified url,
+        ///     containing a JSON-serialized Update. In case of an unsuccessful request, we will give up after a reasonable
+        ///     amount of attempts.
+        ///     If you'd like to make sure that the Webhook request comes from Telegram, we recommend using a secret path
+        ///     in the URL, e.g. https://www.example.com/&lt;token&gt;. Since nobody else knows your bot's token, you can be
+        ///     pretty sure it's us.
+        /// </summary>
+        /// <param name="setWebhookParameters">Request parameters.</param>
+        /// <param name="cancellationToken">A cancellation token that can be used by other objects or threads to receive notice of cancellation.</param>
+        public virtual Task SetWebhookAsync(SetWebhookParameters setWebhookParameters,
+            CancellationToken cancellationToken = default)
+        {
+            return SetWebhookAsync(setWebhookParameters.Url, setWebhookParameters.Certificate,
+                setWebhookParameters.MaxConnections, setWebhookParameters.AllowedUpdates, cancellationToken);
+        }
+
+        /// <summary>
+        ///     Use this method to send text messages. On success, the sent Description is returned.
+        /// </summary>
+        /// <param name="sendTextMessageParameters">Request parameters.</param>
+        /// <param name="cancellationToken">A cancellation token that can be used by other objects or threads to receive notice of cancellation.</param>
+        public virtual Task<Message> SendTextMessageAsync(SendTextMessageParameters sendTextMessageParameters,
+            CancellationToken cancellationToken = default)
+        {
+            return SendTextMessageAsync(sendTextMessageParameters.ChatId, sendTextMessageParameters.Text,
+                sendTextMessageParameters.ParseMode, sendTextMessageParameters.DisableWebPagePreview,
+                sendTextMessageParameters.DisableNotification, sendTextMessageParameters.ReplyToMessageId,
+                sendTextMessageParameters.ReplyMarkup, cancellationToken);
+        }
+
+        /// <summary>
+        ///     Use this method to forward messages of any kind. On success, the sent Description is returned.
+        /// </summary>
+        /// <param name="forwardMessageParameters">Request parameters.</param>
+        /// <param name="cancellationToken">A cancellation token that can be used by other objects or threads to receive notice of cancellation.</param>
+        public virtual Task<Message> ForwardMessageAsync(ForwardMessageParameters forwardMessageParameters,
+            CancellationToken cancellationToken = default)
+        {
+            return ForwardMessageAsync(forwardMessageParameters.ChatId, forwardMessageParameters.FromChatId,
+                forwardMessageParameters.MessageId, forwardMessageParameters.DisableNotification, cancellationToken);
+        }
+
+        /// <summary>
+        ///     Use this method to send photos. On success, the sent Description is returned.
+        /// </summary>
+        /// <param name="sendPhotoParameters">Request parameters.</param>
+        /// <param name="cancellationToken">A cancellation token that can be used by other objects or threads to receive notice of cancellation.</param>
+        public virtual Task<Message> SendPhotoAsync(SendPhotoParameters sendPhotoParameters,
+            CancellationToken cancellationToken = default)
+        {
+            return SendPhotoAsync(sendPhotoParameters.ChatId, sendPhotoParameters.Photo, sendPhotoParameters.Caption,
+                sendPhotoParameters.ParseMode, sendPhotoParameters.DisableNotification,
+                sendPhotoParameters.ReplyToMessageId, sendPhotoParameters.ReplyMarkup, cancellationToken);
+        }
+
+        /// <summary>
+        ///     Use this method to send audio files, if you want Telegram clients to display them in the music player. Your
+        ///     audio must be in the .mp3 format. On success, the sent Description is returned. Bots can currently send
+        ///     audio files of up to 50 MB in size, this limit may be changed in the future.
+        /// </summary>
+        /// <param name="sendAudioParameters">Request parameters.</param>
+        /// <param name="cancellationToken">A cancellation token that can be used by other objects or threads to receive notice of cancellation.</param>
+        public virtual Task<Message> SendAudioAsync(SendAudioParameters sendAudioParameters,
+            CancellationToken cancellationToken = default)
+        {
+            return SendAudioAsync(sendAudioParameters.ChatId, sendAudioParameters.Audio, sendAudioParameters.Caption,
+                sendAudioParameters.ParseMode, sendAudioParameters.Duration, sendAudioParameters.Performer,
+                sendAudioParameters.Title, sendAudioParameters.DisableNotification,
+                sendAudioParameters.ReplyToMessageId, sendAudioParameters.ReplyMarkup, thumb: sendAudioParameters.Thumb,
+                cancellationToken: cancellationToken);
+        }
+
+        /// <summary>
+        ///     Use this method to send general files. On success, the sent Description is returned. Bots can send files of
+        ///     any type of up to 50 MB in size.
+        /// </summary>
+        /// <param name="sendDocumentParameters">Request parameters.</param>
+        /// <param name="cancellationToken">A cancellation token that can be used by other objects or threads to receive notice of cancellation.</param>
+        public virtual Task<Message> SendDocumentAsync(SendDocumentParameters sendDocumentParameters,
+            CancellationToken cancellationToken = default)
+        {
+            return SendDocumentAsync(sendDocumentParameters.ChatId, sendDocumentParameters.Document,
+                sendDocumentParameters.Caption, sendDocumentParameters.ParseMode,
+                sendDocumentParameters.DisableNotification, sendDocumentParameters.ReplyToMessageId,
+                sendDocumentParameters.ReplyMarkup, thumb: sendDocumentParameters.Thumb,
+                cancellationToken: cancellationToken);
+        }
+
+        /// <summary>
+        ///     Use this method to send .webp stickers. On success, the sent Description is returned.
+        /// </summary>
+        /// <param name="sendStickerParameters">Request parameters.</param>
+        /// <param name="cancellationToken">A cancellation token that can be used by other objects or threads to receive notice of cancellation.</param>
+        public virtual Task<Message> SendStickerAsync(SendStickerParameters sendStickerParameters,
+            CancellationToken cancellationToken = default)
+        {
+            return SendStickerAsync(sendStickerParameters.ChatId, sendStickerParameters.Sticker,
+                sendStickerParameters.DisableNotification, sendStickerParameters.ReplyToMessageId,
+                sendStickerParameters.ReplyMarkup, cancellationToken);
+        }
+
+        /// <summary>
+        ///     Use this method to send video files, Telegram clients support mp4 videos (other formats may be sent as
+        ///     Document). On success, the sent Description is returned. Bots can send video files of up to 50 MB in size.
+        /// </summary>
+        /// <param name="sendVideoParameters">Request parameters.</param>
+        /// <param name="cancellationToken">A cancellation token that can be used by other objects or threads to receive notice of cancellation.</param>
+        public virtual Task<Message> SendVideoAsync(SendVideoParameters sendVideoParameters,
+            CancellationToken cancellationToken = default)
+        {
+            return SendVideoAsync(sendVideoParameters.ChatId, sendVideoParameters.Video, sendVideoParameters.Duration,
+                sendVideoParameters.Width, sendVideoParameters.Height, sendVideoParameters.Caption,
+                sendVideoParameters.ParseMode, sendVideoParameters.SupportsStreaming,
+                sendVideoParameters.DisableNotification, sendVideoParameters.ReplyToMessageId,
+                sendVideoParameters.ReplyMarkup, thumb: sendVideoParameters.Thumb,
+                cancellationToken: cancellationToken);
+        }
+
+        /// <summary>
+        ///     Use this method to send animation files (GIF or H.264/MPEG-4 AVC video without sound). On success, the sent
+        ///     Message is returned. Bots can currently send animation files of up to 50 MB in size, this limit may be
+        ///     changed in the future.
+        /// </summary>
+        /// <param name="sendAnimationParameters">Request parameters.</param>
+        /// <param name="cancellationToken">A cancellation token that can be used by other objects or threads to receive notice of cancellation.</param>
+        public virtual Task<Message> SendAnimationAsync(SendAnimationParameters sendAnimationParameters,
+            CancellationToken cancellationToken = default)
+        {
+            return SendAnimationAsync(sendAnimationParameters.ChatId, sendAnimationParameters.Animation,
+                sendAnimationParameters.Duration, sendAnimationParameters.Width, sendAnimationParameters.Height,
+                sendAnimationParameters.Thumb, sendAnimationParameters.Caption, sendAnimationParameters.ParseMode,
+                sendAnimationParameters.DisableNotification, sendAnimationParameters.ReplyToMessageId,
+                sendAnimationParameters.ReplyMarkup, cancellationToken);
+        }
+
+        /// <summary>
+        ///     Use this method to send audio files, if you want Telegram clients to display the file as a playable voice message.
+        ///     For this to work, your audio must be in an .ogg file encoded with OPUS (other formats may be sent as Audio or
+        ///     Document). On success, the sent Description is returned. Bots can currently send voice messages of up to 50 MB in
+        ///     size, this limit may be changed in the future.
+        /// </summary>
+        /// <param name="sendVoiceParameters">Request parameters.</param>
+        /// <param name="cancellationToken">A cancellation token that can be used by other objects or threads to receive notice of cancellation.</param>
+        public virtual Task<Message> SendVoiceAsync(SendVoiceParameters sendVoiceParameters,
+            CancellationToken cancellationToken = default)
+        {
+            return SendVoiceAsync(sendVoiceParameters.ChatId, sendVoiceParameters.Voice, sendVoiceParameters.Caption,
+                sendVoiceParameters.ParseMode, sendVoiceParameters.Duration, sendVoiceParameters.DisableNotification,
+                sendVoiceParameters.ReplyToMessageId, sendVoiceParameters.ReplyMarkup, cancellationToken);
+        }
+
+        /// <summary>
+        ///     As of v.4.0, Telegram clients support rounded square mp4 videos of up to 1 minute long. Use this method to
+        ///     send video messages.
+        /// </summary>
+        /// <param name="sendVideoNoteParameters">Request parameters.</param>
+        /// <param name="cancellationToken">A cancellation token that can be used by other objects or threads to receive notice of cancellation.</param>
+        public virtual Task<Message> SendVideoNoteAsync(SendVideoNoteParameters sendVideoNoteParameters,
+            CancellationToken cancellationToken = default)
+        {
+            return SendVideoNoteAsync(sendVideoNoteParameters.ChatId, sendVideoNoteParameters.VideoNote,
+                sendVideoNoteParameters.Duration, sendVideoNoteParameters.Length,
+                sendVideoNoteParameters.DisableNotification, sendVideoNoteParameters.ReplyToMessageId,
+                sendVideoNoteParameters.ReplyMarkup, thumb: sendVideoNoteParameters.Thumb,
+                cancellationToken: cancellationToken);
+        }
+
+        /// <summary>
+        ///     Use this method to send a group of photos or videos as an album. On success, an array of the sent Messages is
+        ///     returned.
+        /// </summary>
+        /// <param name="sendMediaGroupParameters">Request parameters.</param>
+        /// <param name="cancellationToken">A cancellation token that can be used by other objects or threads to receive notice of cancellation.</param>
+        public virtual Task<Message[]> SendMediaGroupAsync(SendMediaGroupParameters sendMediaGroupParameters,
+            CancellationToken cancellationToken = default)
+        {
+            return SendMediaGroupAsync(sendMediaGroupParameters.ChatId, sendMediaGroupParameters.Media,
+                sendMediaGroupParameters.DisableNotification, sendMediaGroupParameters.ReplyToMessageId,
+                cancellationToken);
+        }
+
+        /// <summary>
+        ///     Use this method to send a group of photos or videos as an album. On success, an array of the sent Messages is
+        ///     returned.
+        /// </summary>
+        /// <param name="sendMediaGroupExtendedParameters">Request parameters.</param>
+        /// <param name="cancellationToken">A cancellation token that can be used by other objects or threads to receive notice of cancellation.</param>
+        public virtual Task<Message[]> SendMediaGroupAsync(
+            SendMediaGroupExtendedParameters sendMediaGroupExtendedParameters,
+            CancellationToken cancellationToken = default)
+        {
+            return SendMediaGroupAsync(sendMediaGroupExtendedParameters.InputMedia,
+                sendMediaGroupExtendedParameters.ChatId, sendMediaGroupExtendedParameters.DisableNotification,
+                sendMediaGroupExtendedParameters.ReplyToMessageId, cancellationToken);
+        }
+
+        /// <summary>
+        ///     Use this method to send point on the map. On success, the sent Description is returned.
+        /// </summary>
+        /// <param name="sendLocationParameters">Request parameters.</param>
+        /// <param name="cancellationToken">A cancellation token that can be used by other objects or threads to receive notice of cancellation.</param>
+        public virtual Task<Message> SendLocationAsync(SendLocationParameters sendLocationParameters,
+            CancellationToken cancellationToken = default)
+        {
+            return SendLocationAsync(sendLocationParameters.ChatId, sendLocationParameters.Latitude,
+                sendLocationParameters.Longitude, sendLocationParameters.LivePeriod,
+                sendLocationParameters.DisableNotification, sendLocationParameters.ReplyToMessageId,
+                sendLocationParameters.ReplyMarkup, cancellationToken);
+        }
+
+        /// <summary>
+        ///     Use this method to send information about a venue.
+        /// </summary>
+        /// <param name="sendVenueParameters">Request parameters.</param>
+        /// <param name="cancellationToken">A cancellation token that can be used by other objects or threads to receive notice of cancellation.</param>
+        public virtual Task<Message> SendVenueAsync(SendVenueParameters sendVenueParameters,
+            CancellationToken cancellationToken = default)
+        {
+            return SendVenueAsync(sendVenueParameters.ChatId, sendVenueParameters.Latitude,
+                sendVenueParameters.Longitude, sendVenueParameters.Title, sendVenueParameters.Address,
+                sendVenueParameters.FoursquareId, sendVenueParameters.DisableNotification,
+                sendVenueParameters.ReplyToMessageId, sendVenueParameters.ReplyMarkup,
+                foursquareType: sendVenueParameters.FoursquareType, cancellationToken: cancellationToken);
+        }
+
+        /// <summary>
+        ///     Use this method to send phone contacts.
+        /// </summary>
+        /// <param name="sendContactParameters">Request parameters.</param>
+        /// <param name="cancellationToken">A cancellation token that can be used by other objects or threads to receive notice of cancellation.</param>
+        public virtual Task<Message> SendContactAsync(SendContactParameters sendContactParameters,
+            CancellationToken cancellationToken = default)
+        {
+            return SendContactAsync(sendContactParameters.ChatId, sendContactParameters.PhoneNumber,
+                sendContactParameters.FirstName, sendContactParameters.LastName,
+                sendContactParameters.DisableNotification, sendContactParameters.ReplyToMessageId,
+                sendContactParameters.ReplyMarkup, vCard: sendContactParameters.VCard,
+                cancellationToken: cancellationToken);
+        }
+
+        /// <summary>
+        ///     Use this method to send a native poll. A native poll can't be sent to a private chat. On success, the sent
+        ///     <see cref="Message" /> is returned.
+        /// </summary>
+        /// <param name="sendPollParameters">Request parameters.</param>
+        /// <param name="cancellationToken">A cancellation token that can be used by other objects or threads to receive notice of cancellation.</param>
+        public virtual Task<Message> SendPollAsync(SendPollParameters sendPollParameters,
+            CancellationToken cancellationToken = default)
+        {
+            return SendPollAsync(sendPollParameters.ChatId, sendPollParameters.Question, sendPollParameters.Options,
+                sendPollParameters.DisableNotification, sendPollParameters.ReplyToMessageId,
+                sendPollParameters.ReplyMarkup, isAnonymous: sendPollParameters.IsAnonymous,
+                type: sendPollParameters.Type, allowsMultipleAnswers: sendPollParameters.AllowsMultipleAnswers,
+                correctOptionId: sendPollParameters.CorrectOptionId, isClosed: sendPollParameters.IsClosed,
+                explanation: sendPollParameters.Explanation,
+                explanationParseMode: sendPollParameters.ExplanationParseMode,
+                openPeriod: sendPollParameters.OpenPeriod, closeDate: sendPollParameters.CloseDate,
+                cancellationToken: cancellationToken);
+        }
+
+        /// <summary>
+        ///     Use this request to send a dice, which will have a random value from 1 to 6. On success, the sent
+        ///     <see cref="Message" /> is returned
+        /// </summary>
+        /// <param name="sendDiceParameters">Request parameters.</param>
+        /// <param name="cancellationToken">A cancellation token that can be used by other objects or threads to receive notice of cancellation.</param>
+        public virtual Task<Message> SendDiceAsync(SendDiceParameters sendDiceParameters,
+            CancellationToken cancellationToken = default)
+        {
+            return SendDiceAsync(sendDiceParameters.ChatId, sendDiceParameters.DisableNotification,
+                sendDiceParameters.ReplyToMessageId, sendDiceParameters.ReplyMarkup, emoji: sendDiceParameters.Emoji,
+                cancellationToken: cancellationToken);
+        }
+
+        /// <summary>
+        ///     Use this method when you need to tell the user that something is happening on the bot's side. The status is set for
+        ///     5 seconds or less (when a message arrives from your bot, Telegram clients clear its typing status).
+        /// </summary>
+        /// <param name="sendChatActionParameters">Request parameters.</param>
+        /// <param name="cancellationToken">A cancellation token that can be used by other objects or threads to receive notice of cancellation.</param>
+        public virtual Task SendChatActionAsync(SendChatActionParameters sendChatActionParameters,
+            CancellationToken cancellationToken = default)
+        {
+            return SendChatActionAsync(sendChatActionParameters.ChatId, sendChatActionParameters.ChatAction,
+                cancellationToken);
+        }
+
+        /// <summary>
+        ///     Use this method to get a list of profile pictures for a user. Returns a UserProfilePhotos object.
+        /// </summary>
+        /// <param name="getUserProfilePhotosParameters">Request parameters.</param>
+        /// <param name="cancellationToken">A cancellation token that can be used by other objects or threads to receive notice of cancellation.</param>
+        public virtual Task<UserProfilePhotos> GetUserProfilePhotosAsync(
+            GetUserProfilePhotosParameters getUserProfilePhotosParameters,
+            CancellationToken cancellationToken = default)
+        {
+            return GetUserProfilePhotosAsync(getUserProfilePhotosParameters.UserId,
+                getUserProfilePhotosParameters.Offset, getUserProfilePhotosParameters.Limit, cancellationToken);
+        }
+
+        /// <summary>
+        ///     Use this method to get information about a file. For the moment, bots can download files of up to 20MB in size.
+        /// </summary>
+        /// <param name="getFileParameters">Request parameters.</param>
+        /// <param name="cancellationToken">A cancellation token that can be used by other objects or threads to receive notice of cancellation.</param>
+        public virtual Task<File> GetFileAsync(GetFileParameters getFileParameters,
+            CancellationToken cancellationToken = default)
+        {
+            return GetFileAsync(getFileParameters.FileId, cancellationToken);
+        }
+
+        /// <summary>
+        ///     Use this method to download a file.
+        /// </summary>
+        /// <param name="downloadFileParameters">Request parameters.</param>
+        /// <param name="cancellationToken">A cancellation token that can be used by other objects or threads to receive notice of cancellation.</param>
+        public virtual Task<Stream> DownloadFileAsync(DownloadFileParameters downloadFileParameters,
+            CancellationToken cancellationToken = default)
+        {
+            return DownloadFileAsync(downloadFileParameters.FilePath, cancellationToken);
+        }
+
+        /// <summary>
+        ///     Use this method to download a file.
+        /// </summary>
+        /// <param name="downloadFileExtendedParameters">Request parameters.</param>
+        /// <param name="cancellationToken">A cancellation token that can be used by other objects or threads to receive notice of cancellation.</param>
+        public virtual Task DownloadFileAsync(DownloadFileExtendedParameters downloadFileExtendedParameters,
+            CancellationToken cancellationToken = default)
+        {
+            return DownloadFileAsync(downloadFileExtendedParameters.FilePath,
+                downloadFileExtendedParameters.Destination, cancellationToken);
+        }
+
+        /// <summary>
+        ///     Use this method to get basic info about a file and download it.
+        /// </summary>
+        /// <param name="getInfoAndDownloadFileParameters">Request parameters.</param>
+        /// <param name="cancellationToken">A cancellation token that can be used by other objects or threads to receive notice of cancellation.</param>
+        public virtual Task<File> GetInfoAndDownloadFileAsync(
+            GetInfoAndDownloadFileParameters getInfoAndDownloadFileParameters,
+            CancellationToken cancellationToken = default)
+        {
+            return GetInfoAndDownloadFileAsync(getInfoAndDownloadFileParameters.FileId,
+                getInfoAndDownloadFileParameters.Destination, cancellationToken);
+        }
+
+        /// <summary>
+        ///     Use this method to kick a user from a group or a supergroup. In the case of supergroups, the user will not be able
+        ///     to return to the group on their own using invite links, etc., unless unbanned first. The bot must be an
+        ///     administrator in the group for this to work.
+        /// </summary>
+        /// <param name="kickChatMemberParameters">Request parameters.</param>
+        /// <param name="cancellationToken">A cancellation token that can be used by other objects or threads to receive notice of cancellation.</param>
+        public virtual Task KickChatMemberAsync(KickChatMemberParameters kickChatMemberParameters,
+            CancellationToken cancellationToken = default)
+        {
+            return KickChatMemberAsync(kickChatMemberParameters.ChatId, kickChatMemberParameters.UserId,
+                kickChatMemberParameters.UntilDate, cancellationToken);
+        }
+
+        /// <summary>
+        ///     Use this method for your bot to leave a group, supergroup or channel.
+        /// </summary>
+        /// <param name="leaveChatParameters">Request parameters.</param>
+        /// <param name="cancellationToken">A cancellation token that can be used by other objects or threads to receive notice of cancellation.</param>
+        public virtual Task LeaveChatAsync(LeaveChatParameters leaveChatParameters,
+            CancellationToken cancellationToken = default)
+        {
+            return LeaveChatAsync(leaveChatParameters.ChatId, cancellationToken);
+        }
+
+        /// <summary>
+        ///     Use this method to unban a previously kicked user in a supergroup. The user will not return to the group
+        ///     automatically, but will be able to join via link, etc. The bot must be an administrator in the group for this to
+        ///     work.
+        /// </summary>
+        /// <param name="unbanChatMemberParameters">Request parameters.</param>
+        /// <param name="cancellationToken">A cancellation token that can be used by other objects or threads to receive notice of cancellation.</param>
+        public virtual Task UnbanChatMemberAsync(UnbanChatMemberParameters unbanChatMemberParameters,
+            CancellationToken cancellationToken = default)
+        {
+            return UnbanChatMemberAsync(unbanChatMemberParameters.ChatId, unbanChatMemberParameters.UserId,
+                cancellationToken);
+        }
+
+        /// <summary>
+        ///     Use this method to get up to date information about the chat (current name of the user for one-on-one
+        ///     conversations, current username of a user, group or channel, etc.).
+        /// </summary>
+        /// <param name="getChatParameters">Request parameters.</param>
+        /// <param name="cancellationToken">A cancellation token that can be used by other objects or threads to receive notice of cancellation.</param>
+        public virtual Task<Chat> GetChatAsync(GetChatParameters getChatParameters,
+            CancellationToken cancellationToken = default)
+        {
+            return GetChatAsync(getChatParameters.ChatId, cancellationToken);
+        }
+
+        /// <summary>
+        ///     Use this method to get a list of administrators in a chat.
+        /// </summary>
+        /// <param name="getChatAdministratorsParameters">Request parameters.</param>
+        /// <param name="cancellationToken">A cancellation token that can be used by other objects or threads to receive notice of cancellation.</param>
+        public virtual Task<ChatMember[]> GetChatAdministratorsAsync(
+            GetChatAdministratorsParameters getChatAdministratorsParameters,
+            CancellationToken cancellationToken = default)
+        {
+            return GetChatAdministratorsAsync(getChatAdministratorsParameters.ChatId, cancellationToken);
+        }
+
+        /// <summary>
+        ///     Use this method to get the number of members in a chat.
+        /// </summary>
+        /// <param name="getChatMembersCountParameters">Request parameters.</param>
+        /// <param name="cancellationToken">A cancellation token that can be used by other objects or threads to receive notice of cancellation.</param>
+        public virtual Task<int> GetChatMembersCountAsync(GetChatMembersCountParameters getChatMembersCountParameters,
+            CancellationToken cancellationToken = default)
+        {
+            return GetChatMembersCountAsync(getChatMembersCountParameters.ChatId, cancellationToken);
+        }
+
+        /// <summary>
+        ///     Use this method to get information about a member of a chat.
+        /// </summary>
+        /// <param name="getChatMemberParameters">Request parameters.</param>
+        /// <param name="cancellationToken">A cancellation token that can be used by other objects or threads to receive notice of cancellation.</param>
+        public virtual Task<ChatMember> GetChatMemberAsync(GetChatMemberParameters getChatMemberParameters,
+            CancellationToken cancellationToken = default)
+        {
+            return GetChatMemberAsync(getChatMemberParameters.ChatId, getChatMemberParameters.UserId,
+                cancellationToken);
+        }
+
+        /// <summary>
+        ///     Use this method to send answers to callback queries sent from inline keyboards. The answer will be displayed to the
+        ///     user as a notification at the top of the chat screen or as an alert.
+        /// </summary>
+        /// <param name="answerCallbackQueryParameters">Request parameters.</param>
+        /// <param name="cancellationToken">A cancellation token that can be used by other objects or threads to receive notice of cancellation.</param>
+        public virtual Task AnswerCallbackQueryAsync(AnswerCallbackQueryParameters answerCallbackQueryParameters,
+            CancellationToken cancellationToken = default)
+        {
+            return AnswerCallbackQueryAsync(answerCallbackQueryParameters.CallbackQueryId,
+                answerCallbackQueryParameters.Text, answerCallbackQueryParameters.ShowAlert,
+                answerCallbackQueryParameters.Url, answerCallbackQueryParameters.CacheTime, cancellationToken);
+        }
+
+        /// <summary>
+        ///     Use this method to restrict a user in a supergroup. The bot must be an administrator in the supergroup for this to
+        ///     work and must have the appropriate admin rights.
+        /// </summary>
+        /// <param name="restrictChatMemberParameters">Request parameters.</param>
+        /// <param name="cancellationToken">A cancellation token that can be used by other objects or threads to receive notice of cancellation.</param>
+        public virtual Task RestrictChatMemberAsync(RestrictChatMemberParameters restrictChatMemberParameters,
+            CancellationToken cancellationToken = default)
+        {
+            return RestrictChatMemberAsync(restrictChatMemberParameters.ChatId, restrictChatMemberParameters.UserId,
+                restrictChatMemberParameters.Permissions, restrictChatMemberParameters.UntilDate, cancellationToken);
+        }
+
+        /// <summary>
+        ///     Use this method to promote or demote a user in a supergroup or a channel. The bot must be an administrator in the
+        ///     chat for this to work and must have the appropriate admin rights.
+        /// </summary>
+        /// <param name="promoteChatMemberParameters">Request parameters.</param>
+        /// <param name="cancellationToken">A cancellation token that can be used by other objects or threads to receive notice of cancellation.</param>
+        public virtual Task PromoteChatMemberAsync(PromoteChatMemberParameters promoteChatMemberParameters,
+            CancellationToken cancellationToken = default)
+        {
+            return PromoteChatMemberAsync(promoteChatMemberParameters.ChatId, promoteChatMemberParameters.UserId,
+                promoteChatMemberParameters.CanChangeInfo, promoteChatMemberParameters.CanPostMessages,
+                promoteChatMemberParameters.CanEditMessages, promoteChatMemberParameters.CanDeleteMessages,
+                promoteChatMemberParameters.CanInviteUsers, promoteChatMemberParameters.CanRestrictMembers,
+                promoteChatMemberParameters.CanPinMessages, promoteChatMemberParameters.CanPromoteMembers,
+                cancellationToken);
+        }
+
+        /// <summary>
+        ///     <inheritdoc cref="Telegram.Bot.Requests.SetChatAdministratorCustomTitleRequest" />
+        /// </summary>
+        /// <param name="setChatAdministratorCustomTitleParameters">Request parameters.</param>
+        /// <param name="cancellationToken">A cancellation token that can be used by other objects or threads to receive notice of cancellation.</param>
+        public virtual Task SetChatAdministratorCustomTitleAsync(
+            SetChatAdministratorCustomTitleParameters setChatAdministratorCustomTitleParameters,
+            CancellationToken cancellationToken = default)
+        {
+            return SetChatAdministratorCustomTitleAsync(setChatAdministratorCustomTitleParameters.ChatId,
+                setChatAdministratorCustomTitleParameters.UserId, setChatAdministratorCustomTitleParameters.CustomTitle,
+                cancellationToken);
+        }
+
+        /// <summary>
+        ///     Use this method to set default chat permissions for all members. The bot must be an administrator in the group or a
+        ///     supergroup for this to work and must have the can_restrict_members admin rights. Returns True on success.
+        /// </summary>
+        /// <param name="setChatPermissionsParameters">Request parameters.</param>
+        /// <param name="cancellationToken">A cancellation token that can be used by other objects or threads to receive notice of cancellation.</param>
+        public virtual Task SetChatPermissionsAsync(SetChatPermissionsParameters setChatPermissionsParameters,
+            CancellationToken cancellationToken = default)
+        {
+            return SetChatPermissionsAsync(setChatPermissionsParameters.ChatId,
+                setChatPermissionsParameters.Permissions, cancellationToken);
+        }
+
+        /// <summary>
+        ///     Use this method to change the list of the bot's commands. Returns True on success.
+        /// </summary>
+        /// <param name="setMyCommandsParameters">Request parameters.</param>
+        /// <param name="cancellationToken">A cancellation token that can be used by other objects or threads to receive notice of cancellation.</param>
+        public virtual Task SetMyCommandsAsync(SetMyCommandsParameters setMyCommandsParameters,
+            CancellationToken cancellationToken = default)
+        {
+            return SetMyCommandsAsync(setMyCommandsParameters.Commands, cancellationToken);
+        }
+
+        /// <summary>
+        ///     Use this method to edit text messages sent by the bot or via the bot (for inline bots).
+        /// </summary>
+        /// <param name="editMessageTextParameters">Request parameters.</param>
+        /// <param name="cancellationToken">A cancellation token that can be used by other objects or threads to receive notice of cancellation.</param>
+        public virtual Task<Message> EditMessageTextAsync(EditMessageTextParameters editMessageTextParameters,
+            CancellationToken cancellationToken = default)
+        {
+            return EditMessageTextAsync(editMessageTextParameters.ChatId, editMessageTextParameters.MessageId,
+                editMessageTextParameters.Text, editMessageTextParameters.ParseMode,
+                editMessageTextParameters.DisableWebPagePreview, editMessageTextParameters.ReplyMarkup,
+                cancellationToken);
+        }
+
+        /// <summary>
+        ///     Use this method to edit text messages sent by the bot or via the bot (for inline bots).
+        /// </summary>
+        /// <param name="editMessageTextInlineParameters">Request parameters.</param>
+        /// <param name="cancellationToken">A cancellation token that can be used by other objects or threads to receive notice of cancellation.</param>
+        public virtual Task EditMessageTextAsync(EditMessageTextInlineParameters editMessageTextInlineParameters,
+            CancellationToken cancellationToken = default)
+        {
+            return EditMessageTextAsync(editMessageTextInlineParameters.InlineMessageId,
+                editMessageTextInlineParameters.Text, editMessageTextInlineParameters.ParseMode,
+                editMessageTextInlineParameters.DisableWebPagePreview, editMessageTextInlineParameters.ReplyMarkup,
+                cancellationToken);
+        }
+
+        /// <summary>
+        ///     Use this method to stop updating a live location message sent via the bot (for inline bots) before live_period
+        ///     expires.
+        /// </summary>
+        /// <param name="stopMessageLiveLocationParameters">Request parameters.</param>
+        /// <param name="cancellationToken">A cancellation token that can be used by other objects or threads to receive notice of cancellation.</param>
+        public virtual Task<Message> StopMessageLiveLocationAsync(
+            StopMessageLiveLocationParameters stopMessageLiveLocationParameters,
+            CancellationToken cancellationToken = default)
+        {
+            return StopMessageLiveLocationAsync(stopMessageLiveLocationParameters.ChatId,
+                stopMessageLiveLocationParameters.MessageId, stopMessageLiveLocationParameters.ReplyMarkup,
+                cancellationToken);
+        }
+
+        /// <summary>
+        ///     Use this method to stop updating a live location message sent via the bot (for inline bots) before live_period
+        ///     expires.
+        /// </summary>
+        /// <param name="stopMessageLiveLocationInlineParameters">Request parameters.</param>
+        /// <param name="cancellationToken">A cancellation token that can be used by other objects or threads to receive notice of cancellation.</param>
+        public virtual Task StopMessageLiveLocationAsync(
+            StopMessageLiveLocationInlineParameters stopMessageLiveLocationInlineParameters,
+            CancellationToken cancellationToken = default)
+        {
+            return StopMessageLiveLocationAsync(stopMessageLiveLocationInlineParameters.InlineMessageId,
+                stopMessageLiveLocationInlineParameters.ReplyMarkup, cancellationToken);
+        }
+
+        /// <summary>
+        ///     Use this method to edit captions of messages sent by the bot or via the bot (for inline bots).
+        /// </summary>
+        /// <param name="editMessageCaptionParameters">Request parameters.</param>
+        /// <param name="cancellationToken">A cancellation token that can be used by other objects or threads to receive notice of cancellation.</param>
+        public virtual Task<Message> EditMessageCaptionAsync(EditMessageCaptionParameters editMessageCaptionParameters,
+            CancellationToken cancellationToken = default)
+        {
+            return EditMessageCaptionAsync(editMessageCaptionParameters.ChatId, editMessageCaptionParameters.MessageId,
+                editMessageCaptionParameters.Caption, editMessageCaptionParameters.ReplyMarkup,
+                parseMode: editMessageCaptionParameters.ParseMode, cancellationToken: cancellationToken);
+        }
+
+        /// <summary>
+        ///     Use this method to edit captions of messages sent by the bot or via the bot (for inline bots).
+        /// </summary>
+        /// <param name="editMessageCaptionInlineParameters">Request parameters.</param>
+        /// <param name="cancellationToken">A cancellation token that can be used by other objects or threads to receive notice of cancellation.</param>
+        public virtual Task EditMessageCaptionAsync(
+            EditMessageCaptionInlineParameters editMessageCaptionInlineParameters,
+            CancellationToken cancellationToken = default)
+        {
+            return EditMessageCaptionAsync(editMessageCaptionInlineParameters.InlineMessageId,
+                editMessageCaptionInlineParameters.Caption, editMessageCaptionInlineParameters.ReplyMarkup,
+                parseMode: editMessageCaptionInlineParameters.ParseMode, cancellationToken: cancellationToken);
+        }
+
+        /// <summary>
+        ///     Use this method to edit audio, document, photo, or video inline messages.
+        /// </summary>
+        /// <param name="editMessageMediaParameters">Request parameters.</param>
+        /// <param name="cancellationToken">A cancellation token that can be used by other objects or threads to receive notice of cancellation.</param>
+        public virtual Task<Message> EditMessageMediaAsync(EditMessageMediaParameters editMessageMediaParameters,
+            CancellationToken cancellationToken = default)
+        {
+            return EditMessageMediaAsync(editMessageMediaParameters.ChatId, editMessageMediaParameters.MessageId,
+                editMessageMediaParameters.Media, editMessageMediaParameters.ReplyMarkup, cancellationToken);
+        }
+
+        /// <summary>
+        ///     Use this method to edit audio, document, photo, or video inline messages.
+        /// </summary>
+        /// <param name="editMessageMediaInlineParameters">Request parameters.</param>
+        /// <param name="cancellationToken">A cancellation token that can be used by other objects or threads to receive notice of cancellation.</param>
+        public virtual Task EditMessageMediaAsync(EditMessageMediaInlineParameters editMessageMediaInlineParameters,
+            CancellationToken cancellationToken = default)
+        {
+            return EditMessageMediaAsync(editMessageMediaInlineParameters.InlineMessageId,
+                editMessageMediaInlineParameters.Media, editMessageMediaInlineParameters.ReplyMarkup,
+                cancellationToken);
+        }
+
+        /// <summary>
+        ///     Use this method to edit only the reply markup of messages sent by the bot or via the bot (for inline bots).
+        /// </summary>
+        /// <param name="editMessageReplyMarkupParameters">Request parameters.</param>
+        /// <param name="cancellationToken">A cancellation token that can be used by other objects or threads to receive notice of cancellation.</param>
+        public virtual Task<Message> EditMessageReplyMarkupAsync(
+            EditMessageReplyMarkupParameters editMessageReplyMarkupParameters,
+            CancellationToken cancellationToken = default)
+        {
+            return EditMessageReplyMarkupAsync(editMessageReplyMarkupParameters.ChatId,
+                editMessageReplyMarkupParameters.MessageId, editMessageReplyMarkupParameters.ReplyMarkup,
+                cancellationToken);
+        }
+
+        /// <summary>
+        ///     Use this method to edit only the reply markup of messages sent by the bot or via the bot (for inline bots).
+        /// </summary>
+        /// <param name="editMessageReplyMarkupInlineParameters">Request parameters.</param>
+        /// <param name="cancellationToken">A cancellation token that can be used by other objects or threads to receive notice of cancellation.</param>
+        public virtual Task EditMessageReplyMarkupAsync(
+            EditMessageReplyMarkupInlineParameters editMessageReplyMarkupInlineParameters,
+            CancellationToken cancellationToken = default)
+        {
+            return EditMessageReplyMarkupAsync(editMessageReplyMarkupInlineParameters.InlineMessageId,
+                editMessageReplyMarkupInlineParameters.ReplyMarkup, cancellationToken);
+        }
+
+        /// <summary>
+        ///     Use this method to edit live location messages sent via the bot (for inline bots).
+        /// </summary>
+        /// <param name="editMessageLiveLocationParameters">Request parameters.</param>
+        /// <param name="cancellationToken">A cancellation token that can be used by other objects or threads to receive notice of cancellation.</param>
+        public virtual Task<Message> EditMessageLiveLocationAsync(
+            EditMessageLiveLocationParameters editMessageLiveLocationParameters,
+            CancellationToken cancellationToken = default)
+        {
+            return EditMessageLiveLocationAsync(editMessageLiveLocationParameters.ChatId,
+                editMessageLiveLocationParameters.MessageId, editMessageLiveLocationParameters.Latitude,
+                editMessageLiveLocationParameters.Longitude, editMessageLiveLocationParameters.ReplyMarkup,
+                cancellationToken);
+        }
+
+        /// <summary>
+        ///     Use this method to edit live location messages sent via the bot (for inline bots).
+        /// </summary>
+        /// <param name="editMessageLiveLocationInlineParameters">Request parameters.</param>
+        /// <param name="cancellationToken">A cancellation token that can be used by other objects or threads to receive notice of cancellation.</param>
+        public virtual Task EditMessageLiveLocationAsync(
+            EditMessageLiveLocationInlineParameters editMessageLiveLocationInlineParameters,
+            CancellationToken cancellationToken = default)
+        {
+            return EditMessageLiveLocationAsync(editMessageLiveLocationInlineParameters.InlineMessageId,
+                editMessageLiveLocationInlineParameters.Latitude, editMessageLiveLocationInlineParameters.Longitude,
+                editMessageLiveLocationInlineParameters.ReplyMarkup, cancellationToken);
+        }
+
+        /// <summary>
+        ///     Use this method to send a native poll. A native poll can't be sent to a private chat. On success, the sent
+        ///     <see cref="Message" /> is returned.
+        /// </summary>
+        /// <param name="stopPollParameters">Request parameters.</param>
+        /// <param name="cancellationToken">A cancellation token that can be used by other objects or threads to receive notice of cancellation.</param>
+        public virtual Task<Poll> StopPollAsync(StopPollParameters stopPollParameters,
+            CancellationToken cancellationToken = default)
+        {
+            return StopPollAsync(stopPollParameters.ChatId, stopPollParameters.MessageId,
+                stopPollParameters.ReplyMarkup, cancellationToken);
+        }
+
+        /// <summary>
+        ///     Use this method to delete a message. A message can only be deleted if it was sent less than 48 hours ago. Any such
+        ///     recently sent outgoing message may be deleted. Additionally, if the bot is an administrator in a group chat, it can
+        ///     delete any message. If the bot is an administrator in a supergroup, it can delete messages from any other user and
+        ///     service messages about people joining or leaving the group (other types of service messages may only be removed by
+        ///     the group creator). In channels, bots can only remove their own messages.
+        /// </summary>
+        /// <param name="deleteMessageParameters">Request parameters.</param>
+        /// <param name="cancellationToken">A cancellation token that can be used by other objects or threads to receive notice of cancellation.</param>
+        public virtual Task DeleteMessageAsync(DeleteMessageParameters deleteMessageParameters,
+            CancellationToken cancellationToken = default)
+        {
+            return DeleteMessageAsync(deleteMessageParameters.ChatId, deleteMessageParameters.MessageId,
+                cancellationToken);
+        }
+
+        /// <summary>
+        ///     Use this method to send answers to an inline query.
+        /// </summary>
+        /// <param name="answerInlineQueryParameters">Request parameters.</param>
+        /// <param name="cancellationToken">A cancellation token that can be used by other objects or threads to receive notice of cancellation.</param>
+        public virtual Task AnswerInlineQueryAsync(AnswerInlineQueryParameters answerInlineQueryParameters,
+            CancellationToken cancellationToken = default)
+        {
+            return AnswerInlineQueryAsync(answerInlineQueryParameters.InlineQueryId,
+                answerInlineQueryParameters.Results, answerInlineQueryParameters.CacheTime,
+                answerInlineQueryParameters.IsPersonal, answerInlineQueryParameters.NextOffset,
+                answerInlineQueryParameters.SwitchPmText, answerInlineQueryParameters.SwitchPmParameter,
+                cancellationToken);
+        }
+
+        /// <summary>
+        ///     Use this method to send invoices.
+        /// </summary>
+        /// <param name="sendInvoiceParameters">Request parameters.</param>
+        /// <param name="cancellationToken">A cancellation token that can be used by other objects or threads to receive notice of cancellation.</param>
+        public virtual Task<Message> SendInvoiceAsync(SendInvoiceParameters sendInvoiceParameters,
+            CancellationToken cancellationToken = default)
+        {
+            return SendInvoiceAsync(sendInvoiceParameters.ChatId, sendInvoiceParameters.Title,
+                sendInvoiceParameters.Description, sendInvoiceParameters.Payload, sendInvoiceParameters.ProviderToken,
+                sendInvoiceParameters.StartParameter, sendInvoiceParameters.Currency, sendInvoiceParameters.Prices,
+                sendInvoiceParameters.ProviderData, sendInvoiceParameters.PhotoUrl, sendInvoiceParameters.PhotoSize,
+                sendInvoiceParameters.PhotoWidth, sendInvoiceParameters.PhotoHeight, sendInvoiceParameters.NeedName,
+                sendInvoiceParameters.NeedPhoneNumber, sendInvoiceParameters.NeedEmail,
+                sendInvoiceParameters.NeedShippingAddress, sendInvoiceParameters.IsFlexible,
+                sendInvoiceParameters.DisableNotification, sendInvoiceParameters.ReplyToMessageId,
+                sendInvoiceParameters.ReplyMarkup,
+                sendPhoneNumberToProvider: sendInvoiceParameters.SendPhoneNumberToProvider,
+                sendEmailToProvider: sendInvoiceParameters.SendEmailToProvider, cancellationToken: cancellationToken);
+        }
+
+        /// <summary>
+        ///     Use this method to reply to shipping queries with failure and error message. If you sent an invoice requesting a
+        ///     shipping address and the parameter is_flexible was specified, the Bot API will send an Update with a shipping_query
+        ///     field to the bot.
+        /// </summary>
+        /// <param name="answerShippingQueryParameters">Request parameters.</param>
+        /// <param name="cancellationToken">A cancellation token that can be used by other objects or threads to receive notice of cancellation.</param>
+        public virtual Task AnswerShippingQueryAsync(AnswerShippingQueryParameters answerShippingQueryParameters,
+            CancellationToken cancellationToken = default)
+        {
+            return AnswerShippingQueryAsync(answerShippingQueryParameters.ShippingQueryId,
+                answerShippingQueryParameters.ShippingOptions, cancellationToken);
+        }
+
+        /// <summary>
+        ///     Use this method to reply to shipping queries with failure and error message. If you sent an invoice requesting a
+        ///     shipping address and the parameter is_flexible was specified, the Bot API will send an Update with a shipping_query
+        ///     field to the bot.
+        /// </summary>
+        /// <param name="answerShippingQueryExtendedParameters">Request parameters.</param>
+        /// <param name="cancellationToken">A cancellation token that can be used by other objects or threads to receive notice of cancellation.</param>
+        public virtual Task AnswerShippingQueryAsync(
+            AnswerShippingQueryExtendedParameters answerShippingQueryExtendedParameters,
+            CancellationToken cancellationToken = default)
+        {
+            return AnswerShippingQueryAsync(answerShippingQueryExtendedParameters.ShippingQueryId,
+                answerShippingQueryExtendedParameters.ErrorMessage, cancellationToken);
+        }
+
+        /// <summary>
+        ///     Respond to a pre-checkout query with failure and error message
+        /// </summary>
+        /// <param name="answerPreCheckoutQueryParameters">Request parameters.</param>
+        /// <param name="cancellationToken">A cancellation token that can be used by other objects or threads to receive notice of cancellation.</param>
+        public virtual Task AnswerPreCheckoutQueryAsync(
+            AnswerPreCheckoutQueryParameters answerPreCheckoutQueryParameters,
+            CancellationToken cancellationToken = default)
+        {
+            return AnswerPreCheckoutQueryAsync(answerPreCheckoutQueryParameters.PreCheckoutQueryId, cancellationToken);
+        }
+
+        /// <summary>
+        ///     Respond to a pre-checkout query with failure and error message
+        /// </summary>
+        /// <param name="answerPreCheckoutQueryExtendedParameters">Request parameters.</param>
+        /// <param name="cancellationToken">A cancellation token that can be used by other objects or threads to receive notice of cancellation.</param>
+        public virtual Task AnswerPreCheckoutQueryAsync(
+            AnswerPreCheckoutQueryExtendedParameters answerPreCheckoutQueryExtendedParameters,
+            CancellationToken cancellationToken = default)
+        {
+            return AnswerPreCheckoutQueryAsync(answerPreCheckoutQueryExtendedParameters.PreCheckoutQueryId,
+                answerPreCheckoutQueryExtendedParameters.ErrorMessage, cancellationToken);
+        }
+
+        /// <summary>
+        ///     Use this method to send a game.
+        /// </summary>
+        /// <param name="sendGameParameters">Request parameters.</param>
+        /// <param name="cancellationToken">A cancellation token that can be used by other objects or threads to receive notice of cancellation.</param>
+        public virtual Task<Message> SendGameAsync(SendGameParameters sendGameParameters,
+            CancellationToken cancellationToken = default)
+        {
+            return SendGameAsync(sendGameParameters.ChatId, sendGameParameters.GameShortName,
+                sendGameParameters.DisableNotification, sendGameParameters.ReplyToMessageId,
+                sendGameParameters.ReplyMarkup, cancellationToken);
+        }
+
+        /// <summary>
+        ///     Use this method to set the score of the specified user in a game.
+        /// </summary>
+        /// <param name="setGameScoreParameters">Request parameters.</param>
+        /// <param name="cancellationToken">A cancellation token that can be used by other objects or threads to receive notice of cancellation.</param>
+        public virtual Task<Message> SetGameScoreAsync(SetGameScoreParameters setGameScoreParameters,
+            CancellationToken cancellationToken = default)
+        {
+            return SetGameScoreAsync(setGameScoreParameters.UserId, setGameScoreParameters.Score,
+                setGameScoreParameters.ChatId, setGameScoreParameters.MessageId, setGameScoreParameters.Force,
+                setGameScoreParameters.DisableEditMessage, cancellationToken);
+        }
+
+        /// <summary>
+        ///     Use this method to set the score of the specified user in a game.
+        /// </summary>
+        /// <param name="setGameScoreInlineParameters">Request parameters.</param>
+        /// <param name="cancellationToken">A cancellation token that can be used by other objects or threads to receive notice of cancellation.</param>
+        public virtual Task SetGameScoreAsync(SetGameScoreInlineParameters setGameScoreInlineParameters,
+            CancellationToken cancellationToken = default)
+        {
+            return SetGameScoreAsync(setGameScoreInlineParameters.UserId, setGameScoreInlineParameters.Score,
+                setGameScoreInlineParameters.InlineMessageId, setGameScoreInlineParameters.Force,
+                setGameScoreInlineParameters.DisableEditMessage, cancellationToken);
+        }
+
+        /// <summary>
+        ///     Use this method to get data for high score tables.
+        /// </summary>
+        /// <param name="getGameHighScoresParameters">Request parameters.</param>
+        /// <param name="cancellationToken">A cancellation token that can be used by other objects or threads to receive notice of cancellation.</param>
+        public virtual Task<GameHighScore[]> GetGameHighScoresAsync(
+            GetGameHighScoresParameters getGameHighScoresParameters, CancellationToken cancellationToken = default)
+        {
+            return GetGameHighScoresAsync(getGameHighScoresParameters.UserId, getGameHighScoresParameters.ChatId,
+                getGameHighScoresParameters.MessageId, cancellationToken);
+        }
+
+        /// <summary>
+        ///     Use this method to get data for high score tables.
+        /// </summary>
+        /// <param name="getGameHighScoresInlineParameters">Request parameters.</param>
+        /// <param name="cancellationToken">A cancellation token that can be used by other objects or threads to receive notice of cancellation.</param>
+        public virtual Task<GameHighScore[]> GetGameHighScoresAsync(
+            GetGameHighScoresInlineParameters getGameHighScoresInlineParameters,
+            CancellationToken cancellationToken = default)
+        {
+            return GetGameHighScoresAsync(getGameHighScoresInlineParameters.UserId,
+                getGameHighScoresInlineParameters.InlineMessageId, cancellationToken);
+        }
+
+        /// <summary>
+        ///     Use this method to get a sticker set.
+        /// </summary>
+        /// <param name="getStickerSetParameters">Request parameters.</param>
+        /// <param name="cancellationToken">A cancellation token that can be used by other objects or threads to receive notice of cancellation.</param>
+        public virtual Task<StickerSet> GetStickerSetAsync(GetStickerSetParameters getStickerSetParameters,
+            CancellationToken cancellationToken = default)
+        {
+            return GetStickerSetAsync(getStickerSetParameters.Name, cancellationToken);
+        }
+
+        /// <summary>
+        ///     Use this method to upload a .png file with a sticker for later use in createNewStickerSet and addStickerToSet
+        ///     methods (can be used multiple times).
+        /// </summary>
+        /// <param name="uploadStickerFileParameters">Request parameters.</param>
+        /// <param name="cancellationToken">A cancellation token that can be used by other objects or threads to receive notice of cancellation.</param>
+        public virtual Task<File> UploadStickerFileAsync(UploadStickerFileParameters uploadStickerFileParameters,
+            CancellationToken cancellationToken = default)
+        {
+            return UploadStickerFileAsync(uploadStickerFileParameters.UserId, uploadStickerFileParameters.PngSticker,
+                cancellationToken);
+        }
+
+        /// <summary>
+        ///     Use this method to create new sticker set owned by a user. The bot will be able to edit the created sticker set.
+        /// </summary>
+        /// <param name="createNewStickerSetParameters">Request parameters.</param>
+        /// <param name="cancellationToken">A cancellation token that can be used by other objects or threads to receive notice of cancellation.</param>
+        public virtual Task CreateNewStickerSetAsync(CreateNewStickerSetParameters createNewStickerSetParameters,
+            CancellationToken cancellationToken = default)
+        {
+            return CreateNewStickerSetAsync(createNewStickerSetParameters.UserId, createNewStickerSetParameters.Name,
+                createNewStickerSetParameters.Title, createNewStickerSetParameters.PngSticker,
+                createNewStickerSetParameters.Emojis, createNewStickerSetParameters.IsMasks,
+                createNewStickerSetParameters.MaskPosition, cancellationToken);
+        }
+
+        /// <summary>
+        ///     Use this method to add a new sticker to a set created by the bot.
+        /// </summary>
+        /// <param name="addStickerToSetParameters">Request parameters.</param>
+        /// <param name="cancellationToken">A cancellation token that can be used by other objects or threads to receive notice of cancellation.</param>
+        public virtual Task AddStickerToSetAsync(AddStickerToSetParameters addStickerToSetParameters,
+            CancellationToken cancellationToken = default)
+        {
+            return AddStickerToSetAsync(addStickerToSetParameters.UserId, addStickerToSetParameters.Name,
+                addStickerToSetParameters.PngSticker, addStickerToSetParameters.Emojis,
+                addStickerToSetParameters.MaskPosition, cancellationToken);
+        }
+
+        /// <summary>
+        ///     Use this method to create new sticker set owned by a user. The bot will be able to edit the created sticker set.
+        /// </summary>
+        /// <param name="createNewAnimatedStickerSetParameters">Request parameters.</param>
+        /// <param name="cancellationToken">A cancellation token that can be used by other objects or threads to receive notice of cancellation.</param>
+        public virtual Task CreateNewAnimatedStickerSetAsync(
+            CreateNewAnimatedStickerSetParameters createNewAnimatedStickerSetParameters,
+            CancellationToken cancellationToken = default)
+        {
+            return CreateNewAnimatedStickerSetAsync(createNewAnimatedStickerSetParameters.UserId,
+                createNewAnimatedStickerSetParameters.Name, createNewAnimatedStickerSetParameters.Title,
+                createNewAnimatedStickerSetParameters.TgsSticker, createNewAnimatedStickerSetParameters.Emojis,
+                createNewAnimatedStickerSetParameters.IsMasks, createNewAnimatedStickerSetParameters.MaskPosition,
+                cancellationToken);
+        }
+
+        /// <summary>
+        ///     Use this method to add a new sticker to a set created by the bot.
+        /// </summary>
+        /// <param name="addAnimatedStickerToSetParameters">Request parameters.</param>
+        /// <param name="cancellationToken">A cancellation token that can be used by other objects or threads to receive notice of cancellation.</param>
+        public virtual Task AddAnimatedStickerToSetAsync(
+            AddAnimatedStickerToSetParameters addAnimatedStickerToSetParameters,
+            CancellationToken cancellationToken = default)
+        {
+            return AddAnimatedStickerToSetAsync(addAnimatedStickerToSetParameters.UserId,
+                addAnimatedStickerToSetParameters.Name, addAnimatedStickerToSetParameters.TgsSticker,
+                addAnimatedStickerToSetParameters.Emojis, addAnimatedStickerToSetParameters.MaskPosition,
+                cancellationToken);
+        }
+
+        /// <summary>
+        ///     Use this method to move a sticker in a set created by the bot to a specific position.
+        /// </summary>
+        /// <param name="setStickerPositionInSetParameters">Request parameters.</param>
+        /// <param name="cancellationToken">A cancellation token that can be used by other objects or threads to receive notice of cancellation.</param>
+        public virtual Task SetStickerPositionInSetAsync(
+            SetStickerPositionInSetParameters setStickerPositionInSetParameters,
+            CancellationToken cancellationToken = default)
+        {
+            return SetStickerPositionInSetAsync(setStickerPositionInSetParameters.Sticker,
+                setStickerPositionInSetParameters.Position, cancellationToken);
+        }
+
+        /// <summary>
+        ///     Use this method to delete a sticker from a set created by the bot.
+        /// </summary>
+        /// <param name="deleteStickerFromSetParameters">Request parameters.</param>
+        /// <param name="cancellationToken">A cancellation token that can be used by other objects or threads to receive notice of cancellation.</param>
+        public virtual Task DeleteStickerFromSetAsync(DeleteStickerFromSetParameters deleteStickerFromSetParameters,
+            CancellationToken cancellationToken = default)
+        {
+            return DeleteStickerFromSetAsync(deleteStickerFromSetParameters.Sticker, cancellationToken);
+        }
+
+        /// <summary>
+        ///     Use this method to set the thumbnail of a sticker set. Animated thumbnails can be set for animated sticker sets
+        ///     only. Returns True on success.
+        /// </summary>
+        /// <param name="setStickerSetThumbParameters">Request parameters.</param>
+        /// <param name="cancellationToken">A cancellation token that can be used by other objects or threads to receive notice of cancellation.</param>
+        public virtual Task SetStickerSetThumbAsync(SetStickerSetThumbParameters setStickerSetThumbParameters,
+            CancellationToken cancellationToken = default)
+        {
+            return SetStickerSetThumbAsync(setStickerSetThumbParameters.Name, setStickerSetThumbParameters.UserId,
+                setStickerSetThumbParameters.Thumb, cancellationToken);
+        }
+
+        /// <summary>
+        ///     Use this method to export an invite link to a supergroup or a channel. The bot must be an administrator in the chat
+        ///     for this to work and must have the appropriate admin rights.
+        /// </summary>
+        /// <param name="exportChatInviteLinkParameters">Request parameters.</param>
+        /// <param name="cancellationToken">A cancellation token that can be used by other objects or threads to receive notice of cancellation.</param>
+        public virtual Task<string> ExportChatInviteLinkAsync(
+            ExportChatInviteLinkParameters exportChatInviteLinkParameters,
+            CancellationToken cancellationToken = default)
+        {
+            return ExportChatInviteLinkAsync(exportChatInviteLinkParameters.ChatId, cancellationToken);
+        }
+
+        /// <summary>
+        ///     Use this method to set a new profile photo for the chat. Photos can't be changed for private chats. The bot must be
+        ///     an administrator in the chat for this to work and must have the appropriate admin rights.
+        /// </summary>
+        /// <param name="setChatPhotoParameters">Request parameters.</param>
+        /// <param name="cancellationToken">A cancellation token that can be used by other objects or threads to receive notice of cancellation.</param>
+        public virtual Task SetChatPhotoAsync(SetChatPhotoParameters setChatPhotoParameters,
+            CancellationToken cancellationToken = default)
+        {
+            return SetChatPhotoAsync(setChatPhotoParameters.ChatId, setChatPhotoParameters.Photo, cancellationToken);
+        }
+
+        /// <summary>
+        ///     Use this method to delete a chat photo. Photos can't be changed for private chats. The bot must be an administrator
+        ///     in the chat for this to work and must have the appropriate admin rights.
+        /// </summary>
+        /// <param name="deleteChatPhotoParameters">Request parameters.</param>
+        /// <param name="cancellationToken">A cancellation token that can be used by other objects or threads to receive notice of cancellation.</param>
+        public virtual Task DeleteChatPhotoAsync(DeleteChatPhotoParameters deleteChatPhotoParameters,
+            CancellationToken cancellationToken = default)
+        {
+            return DeleteChatPhotoAsync(deleteChatPhotoParameters.ChatId, cancellationToken);
+        }
+
+        /// <summary>
+        ///     Use this method to change the title of a chat. Titles can't be changed for private chats. The bot must be an
+        ///     administrator in the chat for this to work and must have the appropriate admin rights.
+        /// </summary>
+        /// <param name="setChatTitleParameters">Request parameters.</param>
+        /// <param name="cancellationToken">A cancellation token that can be used by other objects or threads to receive notice of cancellation.</param>
+        public virtual Task SetChatTitleAsync(SetChatTitleParameters setChatTitleParameters,
+            CancellationToken cancellationToken = default)
+        {
+            return SetChatTitleAsync(setChatTitleParameters.ChatId, setChatTitleParameters.Title, cancellationToken);
+        }
+
+        /// <summary>
+        ///     Use this method to change the description of a supergroup or a channel. The bot must be an administrator in the
+        ///     chat for this to work and must have the appropriate admin rights.
+        /// </summary>
+        /// <param name="setChatDescriptionParameters">Request parameters.</param>
+        /// <param name="cancellationToken">A cancellation token that can be used by other objects or threads to receive notice of cancellation.</param>
+        public virtual Task SetChatDescriptionAsync(SetChatDescriptionParameters setChatDescriptionParameters,
+            CancellationToken cancellationToken = default)
+        {
+            return SetChatDescriptionAsync(setChatDescriptionParameters.ChatId,
+                setChatDescriptionParameters.Description, cancellationToken);
+        }
+
+        /// <summary>
+        ///     Use this method to pin a message in a supergroup. The bot must be an administrator in the chat for this to work and
+        ///     must have the appropriate admin rights.
+        /// </summary>
+        /// <param name="pinChatMessageParameters">Request parameters.</param>
+        /// <param name="cancellationToken">A cancellation token that can be used by other objects or threads to receive notice of cancellation.</param>
+        public virtual Task PinChatMessageAsync(PinChatMessageParameters pinChatMessageParameters,
+            CancellationToken cancellationToken = default)
+        {
+            return PinChatMessageAsync(pinChatMessageParameters.ChatId, pinChatMessageParameters.MessageId,
+                pinChatMessageParameters.DisableNotification, cancellationToken);
+        }
+
+        /// <summary>
+        ///     Use this method to unpin a message in a supergroup chat. The bot must be an administrator in the chat for this to
+        ///     work and must have the appropriate admin rights.
+        /// </summary>
+        /// <param name="unpinChatMessageParameters">Request parameters.</param>
+        /// <param name="cancellationToken">A cancellation token that can be used by other objects or threads to receive notice of cancellation.</param>
+        public virtual Task UnpinChatMessageAsync(UnpinChatMessageParameters unpinChatMessageParameters,
+            CancellationToken cancellationToken = default)
+        {
+            return UnpinChatMessageAsync(unpinChatMessageParameters.ChatId, cancellationToken);
+        }
+
+        /// <summary>
+        ///     Use this method to set a new group sticker set for a supergroup.
+        /// </summary>
+        /// <param name="setChatStickerSetParameters">Request parameters.</param>
+        /// <param name="cancellationToken">A cancellation token that can be used by other objects or threads to receive notice of cancellation.</param>
+        public virtual Task SetChatStickerSetAsync(SetChatStickerSetParameters setChatStickerSetParameters,
+            CancellationToken cancellationToken = default)
+        {
+            return SetChatStickerSetAsync(setChatStickerSetParameters.ChatId,
+                setChatStickerSetParameters.StickerSetName, cancellationToken);
+        }
+
+        /// <summary>
+        ///     Use this method to delete a group sticker set from a supergroup.
+        /// </summary>
+        /// <param name="deleteChatStickerSetParameters">Request parameters.</param>
+        /// <param name="cancellationToken">A cancellation token that can be used by other objects or threads to receive notice of cancellation.</param>
+        public virtual Task DeleteChatStickerSetAsync(DeleteChatStickerSetParameters deleteChatStickerSetParameters,
+            CancellationToken cancellationToken = default)
+        {
+            return DeleteChatStickerSetAsync(deleteChatStickerSetParameters.ChatId, cancellationToken);
+        }
 
         #endregion
     }


### PR DESCRIPTION
I've added methods with parameter classes support to **ITelegramBotClient** interface and **TelegramBotClient** class, according to the already existing methods for working with Telegrams Bot Api. All parameter classes corresponds to the argument lists of the corresponding library methods and are contained in **Telegram.Bot.Requests.Parameters** namespace.
This adds some features as:
- Ability to use as parametric methods as methods with arguments, which are already exists.
- Reusing request parameters to reduce code and make it more readable for developers.
- Fluent API - each parameters class corresponds to fluent (builder) pattern and contains methods for setting each parameter in format With**ParameterName** and returns parameters instance with set parameter. E.g With**ChatId**, With**Text**, With**ReplyMarkup**.

This features may simplify bots development and could be used in different cases and mechanisms, so I think they will be useful for developers.
All methods and classes were generated using Roslyn code generation ([Microsoft.CodeAnalysis.CSharp](https://www.nuget.org/packages/Microsoft.CodeAnalysis.CSharp/) package).