### PR TITLE
Api 5.2 

### DIFF
--- a/src/Telegram.Bot/ITelegramBotClient.cs
+++ b/src/Telegram.Bot/ITelegramBotClient.cs
@@ -1422,6 +1422,8 @@ namespace Telegram.Bot
         /// <param name="description">Product description</param>
         /// <param name="payload">Bot-defined invoice payload, 1-128 bytes. This will not be displayed to the user, use for your internal processes.</param>
         /// <param name="providerToken">Payments provider token, obtained via BotFather</param>
+        /// <param name="maxTipAmount">Optional. The maximum accepted amount for tips in the smallest units of the currency (integer, not float/double). For example, for a maximum tip of US$ 1.45 pass max_tip_amount = 145. See the exp parameter in currencies.json, it shows the number of digits past the decimal point for each currency (2 for the majority of currencies). Defaults to 0</param>
+        /// <param name="suggestedTipAmounts">Array of suggested amounts of tips in the smallest units of the currency (integer, not float/double). At most 4 suggested tip amounts can be specified. The suggested tip amounts must be positive, passed in a strictly increased order and must not exceed maxTipAmount.</param>
         /// <param name="startParameter"> Optional. Unique deep-linking parameter. If left empty, forwarded copies of the sent message will have a Pay button, allowing multiple users to pay directly from the forwarded message, using the same invoice. If non-empty, forwarded copies of the sent message will have a URL button with a deep link to the bot (instead of a Pay button), with the value used as the start parameter</param>
         /// <param name="currency">Three-letter ISO 4217 currency code, see more on currencies</param>
         /// <param name="providerData">JSON-encoded data about the invoice, which will be shared with the payment provider. A detailed description of required fields should be provided by the payment provider.</param>
@@ -1452,6 +1454,8 @@ namespace Telegram.Bot
             string providerToken,
             string currency,
             IEnumerable<LabeledPrice> prices,
+            int maxTipAmount = default,
+            int[] suggestedTipAmounts = default,
             string startParameter = default,
             string providerData = default,
             string photoUrl = default,

--- a/src/Telegram.Bot/ITelegramBotClient.cs
+++ b/src/Telegram.Bot/ITelegramBotClient.cs
@@ -1417,9 +1417,9 @@ namespace Telegram.Bot
         /// <summary>
         /// Use this method to send invoices.
         /// </summary>
-        /// <param name="chatId">Unique identifier for the target private chat</param>
-        /// <param name="title">Product name</param>
-        /// <param name="description">Product description</param>
+        /// <param name="chatId">Unique identifier for the target chat or username of the target channel (in the format @channelusername)</param>
+        /// <param name="title">Product name, 1-32 characters</param>
+        /// <param name="description">Product description, 1-255 characters</param>
         /// <param name="payload">Bot-defined invoice payload, 1-128 bytes. This will not be displayed to the user, use for your internal processes.</param>
         /// <param name="providerToken">Payments provider token, obtained via BotFather</param>
         /// <param name="maxTipAmount">Optional. The maximum accepted amount for tips in the smallest units of the currency (integer, not float/double). For example, for a maximum tip of US$ 1.45 pass max_tip_amount = 145. See the exp parameter in currencies.json, it shows the number of digits past the decimal point for each currency (2 for the majority of currencies). Defaults to 0</param>

--- a/src/Telegram.Bot/ITelegramBotClient.cs
+++ b/src/Telegram.Bot/ITelegramBotClient.cs
@@ -1421,8 +1421,8 @@ namespace Telegram.Bot
         /// <param name="title">Product name</param>
         /// <param name="description">Product description</param>
         /// <param name="payload">Bot-defined invoice payload, 1-128 bytes. This will not be displayed to the user, use for your internal processes.</param>
-        /// <param name="providerToken">Payments provider token, obtained via Botfather</param>
-        /// <param name="startParameter">Unique deep-linking parameter that can be used to generate this invoice when used as a start parameter</param>
+        /// <param name="providerToken">Payments provider token, obtained via BotFather</param>
+        /// <param name="startParameter"> Optional. Unique deep-linking parameter. If left empty, forwarded copies of the sent message will have a Pay button, allowing multiple users to pay directly from the forwarded message, using the same invoice. If non-empty, forwarded copies of the sent message will have a URL button with a deep link to the bot (instead of a Pay button), with the value used as the start parameter</param>
         /// <param name="currency">Three-letter ISO 4217 currency code, see more on currencies</param>
         /// <param name="providerData">JSON-encoded data about the invoice, which will be shared with the payment provider. A detailed description of required fields should be provided by the payment provider.</param>
         /// <param name="prices">Price breakdown, a list of components (e.g. product price, tax, discount, delivery cost, delivery tax, bonus, etc.)</param>
@@ -1450,9 +1450,9 @@ namespace Telegram.Bot
             string description,
             string payload,
             string providerToken,
-            string startParameter,
             string currency,
             IEnumerable<LabeledPrice> prices,
+            string startParameter = default,
             string providerData = default,
             string photoUrl = default,
             int photoSize = default,

--- a/src/Telegram.Bot/Requests/Payments/SendInvoiceRequest.cs
+++ b/src/Telegram.Bot/Requests/Payments/SendInvoiceRequest.cs
@@ -49,10 +49,10 @@ namespace Telegram.Bot.Requests
         public string ProviderToken { get; }
 
         /// <summary>
-        /// Unique deep-linking parameter that can be used to generate this invoice when used as a start parameter
+        /// Optional. Unique deep-linking parameter. If left empty, forwarded copies of the sent message will have a Pay button, allowing multiple users to pay directly from the forwarded message, using the same invoice. If non-empty, forwarded copies of the sent message will have a URL button with a deep link to the bot (instead of a Pay button), with the value used as the start parameter
         /// </summary>
-        [JsonProperty(Required = Required.Always)]
-        public string StartParameter { get; }
+        [JsonProperty(DefaultValueHandling = DefaultValueHandling.Ignore)]
+        public string StartParameter { get; set; }
 
         /// <summary>
         /// Three-letter ISO 4217 currency code
@@ -157,14 +157,13 @@ namespace Telegram.Bot.Requests
         public InlineKeyboardMarkup ReplyMarkup { get; set; }
 
         /// <summary>
-        /// Initializes a new request with chatId, title, description, payload, providerToken, sStartParameter, currency and an array of <see cref="LabeledPrice"/>
+        /// Initializes a new request with chatId, title, description, payload, providerToken, currency and an array of <see cref="LabeledPrice"/>
         /// </summary>
         /// <param name="chatId">Unique identifier for the target private chat</param>
         /// <param name="title">Product name, 1-32 characters</param>
         /// <param name="description">Product description, 1-255 characters</param>
         /// <param name="payload">Bot-defined invoice payload, 1-128 bytes</param>
         /// <param name="providerToken">Payments provider token, obtained via Botfather</param>
-        /// <param name="startParameter">Unique deep-linking parameter that can be used to generate this invoice when used as a start parameter</param>
         /// <param name="currency">Three-letter ISO 4217 currency code</param>
         /// <param name="prices">Price breakdown, a list of components (e.g. product price, tax, discount, delivery cost, delivery tax, bonus, etc.)</param>
         public SendInvoiceRequest(
@@ -173,7 +172,6 @@ namespace Telegram.Bot.Requests
             string description,
             string payload,
             string providerToken,
-            string startParameter,
             string currency,
             IEnumerable<LabeledPrice> prices
         )
@@ -184,7 +182,6 @@ namespace Telegram.Bot.Requests
             Description = description;
             Payload = payload;
             ProviderToken = providerToken;
-            StartParameter = startParameter;
             Currency = currency;
             Prices = prices;
         }

--- a/src/Telegram.Bot/Requests/Payments/SendInvoiceRequest.cs
+++ b/src/Telegram.Bot/Requests/Payments/SendInvoiceRequest.cs
@@ -157,6 +157,19 @@ namespace Telegram.Bot.Requests
         public InlineKeyboardMarkup ReplyMarkup { get; set; }
 
         /// <summary>
+        /// Optional. The maximum accepted amount for tips in the smallest units of the currency (integer, not float/double). For example, for a maximum tip of US$ 1.45 pass max_tip_amount = 145. See the exp parameter in currencies.json, it shows the number of digits past the decimal point for each currency (2 for the majority of currencies). Defaults to 0
+        /// </summary>
+        [JsonProperty(DefaultValueHandling = DefaultValueHandling.Ignore)]
+        public int MaxTipAmount { get; set; }
+
+
+        /// <summary>
+        /// Optional. A JSON-serialized array of suggested amounts of tips in the smallest units of the currency (integer, not float/double). At most 4 suggested tip amounts can be specified. The suggested tip amounts must be positive, passed in a strictly increased order and must not exceed max_tip_amount.
+        /// </summary>
+        [JsonProperty(DefaultValueHandling = DefaultValueHandling.Ignore)]
+        public int[] SuggestedTipAmounts { get; set; }
+
+        /// <summary>
         /// Initializes a new request with chatId, title, description, payload, providerToken, currency and an array of <see cref="LabeledPrice"/>
         /// </summary>
         /// <param name="chatId">Unique identifier for the target private chat</param>

--- a/src/Telegram.Bot/TelegramBotClient.cs
+++ b/src/Telegram.Bot/TelegramBotClient.cs
@@ -1405,6 +1405,8 @@ namespace Telegram.Bot
             string providerToken,
             string currency,
             IEnumerable<LabeledPrice> prices,
+            int maxTipAmount = default,
+            int[] suggestedTipAmounts = default,
             string startParameter = default,
             string providerData = default,
             string photoUrl = default,
@@ -1435,7 +1437,8 @@ namespace Telegram.Bot
                 prices
             )
             {
-
+                MaxTipAmount = maxTipAmount,
+                SuggestedTipAmounts = suggestedTipAmounts,
                 StartParameter =  startParameter,
                 ProviderData = providerData,
                 PhotoUrl = photoUrl,

--- a/src/Telegram.Bot/TelegramBotClient.cs
+++ b/src/Telegram.Bot/TelegramBotClient.cs
@@ -1403,9 +1403,9 @@ namespace Telegram.Bot
             string description,
             string payload,
             string providerToken,
-            string startParameter,
             string currency,
             IEnumerable<LabeledPrice> prices,
+            string startParameter = default,
             string providerData = default,
             string photoUrl = default,
             int photoSize = default,
@@ -1430,12 +1430,13 @@ namespace Telegram.Bot
                 description,
                 payload,
                 providerToken,
-                startParameter,
                 currency,
                 // ReSharper disable once PossibleMultipleEnumeration
                 prices
             )
             {
+
+                StartParameter =  startParameter,
                 ProviderData = providerData,
                 PhotoUrl = photoUrl,
                 PhotoSize = photoSize,

--- a/src/Telegram.Bot/Types/Enums/ChatAction.cs
+++ b/src/Telegram.Bot/Types/Enums/ChatAction.cs
@@ -1,4 +1,5 @@
-﻿using System.Runtime.Serialization;
+﻿using System;
+using System.Runtime.Serialization;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Converters;
 
@@ -37,13 +38,26 @@ namespace Telegram.Bot.Types.Enums
         /// Recording an <see cref="Audio"/>
         /// </summary>
         [EnumMember(Value = "record_audio")]
+        [Obsolete("use RecordVoice instead", true)]
         RecordAudio,
+        /// <summary>
+        /// Recording an <see cref="Voice"/>
+        /// </summary>
+        [EnumMember(Value = "record_voice")]
+        RecordVoice,
 
         /// <summary>
         /// Uploading an <see cref="Audio"/>
         /// </summary>
         [EnumMember(Value = "upload_audio")]
+        [Obsolete("use UploadVoice instead", true)]
         UploadAudio,
+
+        /// <summary>
+        /// Uploading an <see cref="Voice"/>
+        /// </summary>
+        [EnumMember(Value = "upload_voice")]
+        UploadVoice,
 
         /// <summary>
         /// Uploading <see cref="Document"/>

--- a/src/Telegram.Bot/Types/Enums/ChatType.cs
+++ b/src/Telegram.Bot/Types/Enums/ChatType.cs
@@ -27,6 +27,11 @@ namespace Telegram.Bot.Types.Enums
         /// <summary>
         /// A supergroup
         /// </summary>
-        Supergroup
+        Supergroup,
+
+        /// <summary>
+        /// “sender” for a private chat with the inline query sender,
+        /// </summary>
+        Sender
     }
 }

--- a/src/Telegram.Bot/Types/Enums/MessageType.cs
+++ b/src/Telegram.Bot/Types/Enums/MessageType.cs
@@ -184,6 +184,12 @@ namespace Telegram.Bot.Types.Enums
         ProximityAlertTriggered,
 
         /// <summary>
+        /// The <see cref="Message"/> contains <see cref="Message.VoiceChatScheduled"/>
+        /// </summary>
+        [EnumMember(Value = "voice_chat_scheduled")]
+        VoiceChatScheduled,
+
+        /// <summary>
         /// The <see cref="Message"/> contains <see cref="Message.VoiceChatStarted"/>
         /// </summary>
         [EnumMember(Value = "voice_chat_started")]
@@ -199,6 +205,6 @@ namespace Telegram.Bot.Types.Enums
         /// The <see cref="Message"/> contains <see cref="Message.VoiceChatParticipantsInvited"/>
         /// </summary>
         [EnumMember(Value = "voice_chat_participants_invited")]
-        VoiceChatParticipantsInvited
+        VoiceChatParticipantsInvited,
     }
 }

--- a/src/Telegram.Bot/Types/InlineQuery.cs
+++ b/src/Telegram.Bot/Types/InlineQuery.cs
@@ -1,5 +1,6 @@
 ﻿using Newtonsoft.Json;
 using Newtonsoft.Json.Serialization;
+using Telegram.Bot.Types.Enums;
 
 namespace Telegram.Bot.Types
 {
@@ -38,5 +39,11 @@ namespace Telegram.Bot.Types
         /// </summary>
         [JsonProperty(Required = Required.Always)]
         public string Offset { get; set; }
+
+        /// <summary>
+        /// Optional. Type of the chat, from which the inline query was sent. Can be either “sender” for a private chat with the inline query sender, “private”, “group”, “supergroup”, or “channel”. The chat type should be always known for requests sent from official clients and most third-party clients, unless the request was sent from a secret chat
+        /// </summary>
+        [JsonProperty(DefaultValueHandling = DefaultValueHandling.Ignore)]
+        public ChatType? ChatType { get; set; }
     }
 }

--- a/src/Telegram.Bot/Types/InlineQueryResults/InputInvoiceMessageContent.cs
+++ b/src/Telegram.Bot/Types/InlineQueryResults/InputInvoiceMessageContent.cs
@@ -1,70 +1,64 @@
 using System.Collections.Generic;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Serialization;
-using Telegram.Bot.Requests.Abstractions;
-using Telegram.Bot.Types;
 using Telegram.Bot.Types.Payments;
-using Telegram.Bot.Types.ReplyMarkups;
 
-// ReSharper disable once CheckNamespace
-namespace Telegram.Bot.Requests
+namespace Telegram.Bot.Types.InlineQueryResults
 {
     /// <summary>
-    /// Send invoices. On success, the sent <see cref="Message"/> is returned.
+    /// Represents the content of an invoice message to be sent as the result of an inline query.
     /// </summary>
     [JsonObject(MemberSerialization.OptIn, NamingStrategyType = typeof(SnakeCaseNamingStrategy))]
-    public class SendInvoiceRequest : RequestBase<Message>,
-                                      INotifiableMessage,
-                                      IReplyMessage,
-                                      IInlineReplyMarkupMessage
+    public class InputInvoiceMessageContent : InputMessageContentBase
     {
-        /// <summary>
-        /// Unique identifier for the target private chat
-        /// </summary>
-        [JsonProperty(Required = Required.Always)]
-        public long ChatId { get; }
-
         /// <summary>
         /// Product name, 1-32 characters
         /// </summary>
         [JsonProperty(Required = Required.Always)]
-        public string Title { get; }
+        public string Title { get; set; }
 
         /// <summary>
         /// Product description, 1-255 characters
         /// </summary>
         [JsonProperty(Required = Required.Always)]
-        public string Description { get; }
+        public string Description { get; set; }
 
         /// <summary>
         /// Bot-defined invoice payload, 1-128 bytes. This will not be displayed to the user, use for your internal processes.
         /// </summary>
         [JsonProperty(Required = Required.Always)]
-        public string Payload { get; }
+        public string Payload { get; set; }
 
         /// <summary>
         /// Payments provider token, obtained via BotFather
         /// </summary>
         [JsonProperty(Required = Required.Always)]
-        public string ProviderToken { get; }
-
-        /// <summary>
-        /// Optional. Unique deep-linking parameter. If left empty, forwarded copies of the sent message will have a Pay button, allowing multiple users to pay directly from the forwarded message, using the same invoice. If non-empty, forwarded copies of the sent message will have a URL button with a deep link to the bot (instead of a Pay button), with the value used as the start parameter
-        /// </summary>
-        [JsonProperty(DefaultValueHandling = DefaultValueHandling.Ignore)]
-        public string StartParameter { get; set; }
+        public string ProviderToken { get; set; }
 
         /// <summary>
         /// Three-letter ISO 4217 currency code
         /// </summary>
         [JsonProperty(Required = Required.Always)]
-        public string Currency { get; }
+        public string Currency { get; set; }
 
         /// <summary>
         /// Price breakdown, a list of components (e.g. product price, tax, discount, delivery cost, delivery tax, bonus, etc.)
         /// </summary>
         [JsonProperty(Required = Required.Always)]
         public IEnumerable<LabeledPrice> Prices { get; }
+
+        /// <summary>
+        /// Optional. The maximum accepted amount for tips in the smallest units of the currency (integer, not float/double). For example, for a maximum tip of US$ 1.45 pass max_tip_amount = 145. See the exp parameter in currencies.json, it shows the number of digits past the decimal point for each currency (2 for the majority of currencies). Defaults to 0
+        /// </summary>
+        [JsonProperty(DefaultValueHandling = DefaultValueHandling.Ignore)]
+        public int MaxTipAmount { get; set; }
+
+
+        /// <summary>
+        /// Optional. A JSON-serialized array of suggested amounts of tips in the smallest units of the currency (integer, not float/double). At most 4 suggested tip amounts can be specified. The suggested tip amounts must be positive, passed in a strictly increased order and must not exceed max_tip_amount.
+        /// </summary>
+        [JsonProperty(DefaultValueHandling = DefaultValueHandling.Ignore)]
+        public int[] SuggestedTipAmounts { get; set; }
 
         /// <summary>
         /// JSON-encoded data about the invoice, which will be shared with the payment provider. A detailed description of required fields should be provided by the payment provider.
@@ -138,59 +132,30 @@ namespace Telegram.Bot.Requests
         [JsonProperty(DefaultValueHandling = DefaultValueHandling.Ignore)]
         public bool IsFlexible { get; set; }
 
-        /// <inheritdoc />
-        [JsonProperty(DefaultValueHandling = DefaultValueHandling.Ignore)]
-        public bool DisableNotification { get; set; }
-
-        /// <inheritdoc />
-        [JsonProperty(DefaultValueHandling = DefaultValueHandling.Ignore)]
-        public int ReplyToMessageId { get; set; }
-
-        /// <inheritdoc />
-        [JsonProperty(DefaultValueHandling = DefaultValueHandling.Ignore)]
-        public bool AllowSendingWithoutReply { get; set; }
-
-        /// <summary>
-        /// A JSON-serialized object for an inline keyboard. If empty, one 'Pay total price' button will be shown. If not empty, the first button must be a Pay button.
-        /// </summary>
-        [JsonProperty(DefaultValueHandling = DefaultValueHandling.Ignore)]
-        public InlineKeyboardMarkup ReplyMarkup { get; set; }
-
-        /// <summary>
-        /// Optional. The maximum accepted amount for tips in the smallest units of the currency (integer, not float/double). For example, for a maximum tip of US$ 1.45 pass max_tip_amount = 145. See the exp parameter in currencies.json, it shows the number of digits past the decimal point for each currency (2 for the majority of currencies). Defaults to 0
-        /// </summary>
-        [JsonProperty(DefaultValueHandling = DefaultValueHandling.Ignore)]
-        public int MaxTipAmount { get; set; }
+        private InputInvoiceMessageContent()
+        {
+        }
 
 
         /// <summary>
-        /// Optional. A JSON-serialized array of suggested amounts of tips in the smallest units of the currency (integer, not float/double). At most 4 suggested tip amounts can be specified. The suggested tip amounts must be positive, passed in a strictly increased order and must not exceed max_tip_amount.
+        /// Initializes with title, description, payload, providerToken, currency and an array of <see cref="LabeledPrice"/>
         /// </summary>
-        [JsonProperty(DefaultValueHandling = DefaultValueHandling.Ignore)]
-        public int[] SuggestedTipAmounts { get; set; }
-
-        /// <summary>
-        /// Initializes a new request with chatId, title, description, payload, providerToken, currency and an array of <see cref="LabeledPrice"/>
-        /// </summary>
-        /// <param name="chatId">Unique identifier for the target private chat</param>
         /// <param name="title">Product name, 1-32 characters</param>
         /// <param name="description">Product description, 1-255 characters</param>
         /// <param name="payload">Bot-defined invoice payload, 1-128 bytes</param>
-        /// <param name="providerToken">Payments provider token, obtained via Botfather</param>
+        /// <param name="providerToken">Payments provider token, obtained via BotFather</param>
         /// <param name="currency">Three-letter ISO 4217 currency code</param>
         /// <param name="prices">Price breakdown, a list of components (e.g. product price, tax, discount, delivery cost, delivery tax, bonus, etc.)</param>
-        public SendInvoiceRequest(
-            long chatId,
+
+        public InputInvoiceMessageContent(
             string title,
             string description,
             string payload,
             string providerToken,
             string currency,
             IEnumerable<LabeledPrice> prices
-        )
-            : base("sendInvoice")
+            )
         {
-            ChatId = chatId;
             Title = title;
             Description = description;
             Payload = payload;

--- a/src/Telegram.Bot/Types/Message.cs
+++ b/src/Telegram.Bot/Types/Message.cs
@@ -352,6 +352,12 @@ namespace Telegram.Bot.Types
         public MessageAutoDeleteTimerChanged MessageAutoDeleteTimerChanged { get; set; }
 
         /// <summary>
+        /// Optional. Service message: voice chat scheduled
+        /// </summary>
+        [JsonProperty(DefaultValueHandling = DefaultValueHandling.Ignore)]
+        public VoiceChatScheduled VoiceChatScheduled { get; set; }
+
+        /// <summary>
         /// Optional. Service message: voice chat started
         /// </summary>
         [JsonProperty(DefaultValueHandling = DefaultValueHandling.Ignore)]
@@ -462,6 +468,9 @@ namespace Telegram.Bot.Types
 
                 if (ProximityAlertTriggered != default)
                     return MessageType.ProximityAlertTriggered;
+
+                if (VoiceChatScheduled != default)
+                    return MessageType.VoiceChatScheduled;
 
                 if (VoiceChatStarted != default)
                     return MessageType.VoiceChatStarted;

--- a/src/Telegram.Bot/Types/VoiceChatScheduled.cs
+++ b/src/Telegram.Bot/Types/VoiceChatScheduled.cs
@@ -1,0 +1,19 @@
+using System;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Converters;
+
+namespace Telegram.Bot.Types
+{
+    /// <summary>
+    /// This object represents a service message about a voice chat scheduled in the chat.
+    /// </summary>
+    public class VoiceChatScheduled
+    {
+        /// <summary>
+        /// Point in time (Unix timestamp) when the voice chat is supposed to be started by a chat administrator
+        /// </summary>
+        [JsonProperty(DefaultValueHandling = DefaultValueHandling.Ignore)]
+        [JsonConverter(typeof(UnixDateTimeConverter))]
+        public DateTime? StartDate { get; set; }
+    }
+}

--- a/test/Telegram.Bot.Tests.Integ/Other/ChatInfoTests.cs
+++ b/test/Telegram.Bot.Tests.Integ/Other/ChatInfoTests.cs
@@ -158,13 +158,13 @@ namespace Telegram.Bot.Tests.Integ.Other
         /// The status is set for 5 seconds or less (when a message arrives from your bot, Telegram clients clear
         /// its typing status)
         /// </remarks>
-        [OrderedFact("Should send action to chat: recording audio")]
+        [OrderedFact("Should send action to chat: recording voice")]
         [Trait(Constants.MethodTraitName, Constants.TelegramBotApiMethods.SendChatAction)]
         public async Task Should_Send_Chat_Action()
         {
             await BotClient.SendChatActionAsync(
                 chatId: _fixture.SupergroupChat.Id,
-                chatAction: ChatAction.RecordAudio
+                chatAction: ChatAction.RecordVoice
             );
 
             await Task.Delay(5_000);


### PR DESCRIPTION
Everything, but without tests.

Note that one parameter from SendInvoiceAsync become optional, so it was moved, so it is breaking change. 


Added the type InputInvoiceMessageContent to support sending invoices as inline query results.
Allowed sending invoices to group, supergroup and channel chats.
Added the fields max_tip_amount and suggested_tip_amounts to the method sendInvoice to allow adding optional tips to the payment.
The parameter start_parameter of the method sendInvoice became optional. If the parameter isn't specified, the invoice can be paid directly from forwarded messages.
Added the field chat_type to the class InlineQuery, containing the type of the chat, from which the inline request was sent.
Added the type VoiceChatScheduled and the field voice_chat_scheduled to the class Message.
Fixed an error in sendChatAction documentation to correctly mention “record_voice” and “upload_voice” instead of “record_audio” and “upload_audio” for related to voice note actions. Old action names will still work for backward compatibility.