### PR TITLE
Add basic devcontainer config

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,0 +1,37 @@
+ARG DOTNET_VERSION=5.0
+FROM mcr.microsoft.com/dotnet/sdk:${DOTNET_VERSION}-buster-slim
+ARG USERNAME=vscode
+ARG USER_UID=1000
+ARG USER_GID=${USER_UID}
+ENV DEBIAN_FRONTEND=noninteractive
+
+# Install required and misc tools
+RUN apt-get update && apt-get -y install --no-install-recommends apt-utils dialog 2>&1 \
+    && apt-get -y install openssh-client less iproute2 apt-transport-https gnupg2 curl lsb-release \
+    git procps ca-certificates vim nano groff zip file jq wget zsh \
+    # Create a non-root user to use if preferred - see https://aka.ms/vscode-remote/containers/non-root-user.
+    && groupadd --gid $USER_GID $USERNAME \
+    && useradd -s /bin/bash --uid $USER_UID --gid $USER_GID -m $USERNAME \
+    # [Optional] Add sudo support for the non-root user
+    && apt-get install -y sudo \
+    && echo $USERNAME ALL=\(root\) NOPASSWD:ALL > /etc/sudoers.d/$USERNAME\
+    && chmod 0440 /etc/sudoers.d/$USERNAME
+
+# Cleanup APT
+RUN apt-get autoremove -y \
+    && apt-get clean -y \
+    && rm -rf /var/lib/apt/lists/*
+
+RUN chsh -s $(which zsh) ${USERNAME}
+USER ${USERNAME}
+
+RUN sh -c "$(curl -fsSL https://raw.github.com/ohmyzsh/ohmyzsh/master/tools/install.sh)"
+# This is needed for Global Tools to work
+ENV PATH="${PATH}:/home/${USERNAME}/.dotnet/tools"
+# Install .NET Global Tools
+RUN dotnet tool install -g dotnet-format \
+    && dotnet tool install -g microsoft.dotnet-httprepl
+
+ENV DEBIAN_FRONTEND=dialog
+
+WORKDIR /workspace

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,17 @@
+{
+  "name": "Telegram.Bot",
+  "dockerComposeFile": "docker-compose.yml",
+  "service": "devhost",
+  "shutdownAction": "stopCompose",
+  "workspaceFolder": "/workspace",
+  "extensions": [
+    "ms-dotnettools.csharp",
+    "ms-azuretools.vscode-docker",
+    "editorconfig.editorconfig",
+    "eamodio.gitlens",
+    "tintoy.msbuild-project-tools",
+    "logerfo.sln-support",
+    "formulahendry.dotnet-test-explorer"
+  ],
+  "remoteUser": "vscode"
+}

--- a/.devcontainer/docker-compose.yml
+++ b/.devcontainer/docker-compose.yml
@@ -1,0 +1,12 @@
+version: '3'
+services:
+  devhost:
+    user: vscode
+    build: .
+    environment:
+      - DOTNET_ENVIRONMENT=Development
+      - DOTNET_NOLOGO=1
+    volumes:
+      - ..:/workspace
+      - ./persistence/nuget:/vscode/.nuget
+    command: sleep infinity


### PR DESCRIPTION
This PR contains configuration for VS Code's devcontainer feature, which is shared with Github's Codespaces.

It's composed of three files: a Dockerfile that defines the container the editor will run inside of, a docker-compose.yml and a json to tie it all up together.

The Dockerfile is based off Microsoft's .NET 5 SDK image (Debian Buster) and in addition to the required packages it also installs vim, nano, zip, file, jq, wget and zsh (also oh-my-zsh later on). It's configured with a non-root/sudoer user.
Apt lists are cleared during build to avoid dev env divergence (you can't just run apt install inside the container, you're forced to edit the Dockerfile, so devs are more likely to commit changes to the env).
dotnet-format and dotnet-httprepl are also installed as .NET Global Tools.

The docker-compose.yml file defines a service using that container, and mounts both the repo directory as /workspace and an host directory to cache nuget packages upon container rebuilds.

The json file defines some information required for the env to work (service name, username, workspace folder, compose-related stuff) and a set of commonly useful extensions that will be installed in the container at startup.

I also have a second PR ready that defines tasks for building and running tests, but I can't create it until the .vscode folder is removed from .gitignore.