### PR TITLE
update_id need change type to bigger capacity

### DIFF
--- a/src/Telegram.Bot/Types/Update.cs
+++ b/src/Telegram.Bot/Types/Update.cs
@@ -17,7 +17,7 @@ namespace Telegram.Bot.Types
         /// The update's unique identifier. Update identifiers start from a certain positive number and increase sequentially. This ID becomes especially handy if you're using <see href="https://core.telegram.org/bots/api#setwebhook">Webhooks</see>, since it allows you to ignore repeated updates or to restore the correct update sequence, should they get out of order. If there are no new updates for at least a week, then identifier of the next update will be chosen randomly instead of sequentially.
         /// </summary>
         [JsonProperty("update_id", Required = Required.Always)]
-        public int Id { get; set; }
+        public long Id { get; set; }
 
         /// <summary>
         /// Optional. New incoming message of any kind — text, photo, sticker, etc.


### PR DESCRIPTION
update_id is better to make a long type. because in large chatbots the capacity of the int type ends quickly.

