### PR TITLE
Refactor Source Generator

### DIFF
--- a/src/EnumSerializer.Generator/EnumConverterGenerator.Emitter.cs
+++ b/src/EnumSerializer.Generator/EnumConverterGenerator.Emitter.cs
@@ -1,0 +1,19 @@
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.Text;
+using Scriban;
+using System.Text;
+
+namespace EnumSerializer.Generator;
+
+public partial class EnumConverterGenerator
+{
+    private static void EmitSourceFile(SourceProductionContext context, EnumInfo ei)
+    {
+        Template template = Template.Parse(SourceGenerationHelper.ConverterTemplate);
+
+        var result = SourceGenerationHelper.GenerateConverterClass(template, ei);
+        context.AddSource(
+            hintName: $"{ei.Name}Converter.g.cs",
+            sourceText: SourceText.From(result, Encoding.UTF8));
+    }
+}

--- a/src/EnumSerializer.Generator/EnumConverterGenerator.Parser.cs
+++ b/src/EnumSerializer.Generator/EnumConverterGenerator.Parser.cs
@@ -1,0 +1,130 @@
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using System.Text;
+
+namespace EnumSerializer.Generator;
+
+public partial class EnumConverterGenerator
+{
+    private static EnumInfo? GetSemanticTargetForGeneration(GeneratorAttributeSyntaxContext context, CancellationToken cancellationToken)
+    {
+        var enumDef = (EnumDeclarationSyntax)context.TargetNode;
+        BaseNamespaceDeclarationSyntax? ns = enumDef.Parent as BaseNamespaceDeclarationSyntax;
+        if (ns is null)
+        {
+            if (enumDef.Parent is not CompilationUnitSyntax)
+            {
+                // since this generator doesn't know how to generate a nested type...
+                return null;
+            }
+        }
+
+        EnumInfo? enumDeclaration = null;
+        string? nspace = null;
+
+        foreach (AttributeData attribute in context.TargetSymbol.GetAttributes())
+        {
+            if (attribute.AttributeClass?.Name != "JsonConverterAttribute"
+                || attribute.AttributeClass.ToDisplayString() != JsonConverterAttribute)
+            {
+                continue;
+            }
+
+            nspace ??= ConstructNamespace(ns);
+
+            string enumName = enumDef.Identifier.ValueText;
+
+            var enumMembers = enumDef.Members;
+            var members = new List<KeyValuePair<string, string>>(enumMembers.Count);
+            foreach (var member in enumMembers)
+            {
+                string? displayName = null;
+                foreach (var enumAttribute in member.AttributeLists.SelectMany(a => a.Attributes))
+                {
+                    var identifierName = enumAttribute.Name as IdentifierNameSyntax;
+                    if (identifierName?.Identifier.ValueText != "Display")
+                    {
+                        continue;
+                    }
+
+                    foreach (var argument in enumAttribute.ArgumentList?.Arguments)
+                    {
+                        if (argument.Expression is LiteralExpressionSyntax expression)
+                        {
+                            displayName = expression.Token.ValueText;
+                            break;
+                        }
+                    }
+                }
+
+                members.Add(new(
+                    member.Identifier.ValueText,
+                    displayName ?? ToSnakeCase(member.Identifier.ValueText)));
+            }
+
+            enumDeclaration = new(enumName, nspace, members);
+        }
+
+        return enumDeclaration;
+    }
+
+    private static string ConstructNamespace(BaseNamespaceDeclarationSyntax? ns)
+    {
+        if (ns is null)
+            return string.Empty;
+
+        string nspace = ns.Name.ToString();
+        while (true)
+        {
+            ns = ns.Parent as BaseNamespaceDeclarationSyntax;
+            if (ns == null)
+            {
+                break;
+            }
+
+            nspace = $"{ns.Name}.{nspace}";
+        }
+
+        return nspace;
+    }
+
+    static string ToSnakeCase(string name)
+    {
+        StringBuilder sb = new();
+
+        State previous = default;
+
+        for (var index = 0; index < name.Length; index++)
+        {
+            char c = name[index];
+            State current = new(c, char.IsUpper(c));
+
+            if (current.IsUpper)
+            {
+                c = char.ToLowerInvariant(current.Character);
+
+                if (index > 0
+                    && previous.Character != '_'
+                    && !previous.IsUpper)
+                {
+                    sb.Append('_');
+                }
+            }
+
+            sb.Append(c);
+            previous = current;
+        }
+        return sb.ToString();
+    }
+
+    private readonly struct State
+    {
+        public readonly char Character;
+        public readonly bool IsUpper;
+        public State(char character, bool isUpper)
+        {
+            Character = character;
+            IsUpper = isUpper;
+        }
+    }
+}

--- a/src/EnumSerializer.Generator/EnumConverterGenerator.cs
+++ b/src/EnumSerializer.Generator/EnumConverterGenerator.cs
@@ -1,143 +1,21 @@
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
-using Microsoft.CodeAnalysis.Text;
-using Scriban;
-using System.Collections.Immutable;
-using System.Text;
 
 namespace EnumSerializer.Generator;
 
-[Generator]
-public class EnumConverterGenerator : IIncrementalGenerator
+[Generator(LanguageNames.CSharp)]
+public partial class EnumConverterGenerator : IIncrementalGenerator
 {
     const string JsonConverterAttribute = "Newtonsoft.Json.JsonConverterAttribute";
 
     public void Initialize(IncrementalGeneratorInitializationContext context)
     {
-        IncrementalValuesProvider<EnumDeclarationSyntax> enumDeclarations = context.SyntaxProvider
+        IncrementalValuesProvider<EnumInfo> enumDeclarations = context.SyntaxProvider
             .ForAttributeWithMetadataName(JsonConverterAttribute,
                predicate: static (node, _) => node is EnumDeclarationSyntax { AttributeLists.Count: > 0 },
-               transform: static (context, _) => (EnumDeclarationSyntax)context.TargetNode)
+               GetSemanticTargetForGeneration)
            .Where(static m => m is not null)!;
 
-        IncrementalValueProvider<(Compilation, ImmutableArray<EnumDeclarationSyntax>)> compilationAndEnums
-            = context.CompilationProvider.Combine(enumDeclarations.Collect());
-
-        context.RegisterSourceOutput(compilationAndEnums,
-            static (spc, source) => Execute(source.Item1, source.Item2, spc));
+        context.RegisterSourceOutput(enumDeclarations, EmitSourceFile);
     }
-
-    static void Execute(
-        Compilation compilation,
-        ImmutableArray<EnumDeclarationSyntax> enums,
-        SourceProductionContext context)
-    {
-        if (enums.IsDefaultOrEmpty)
-        {
-            // nothing to do yet
-            return;
-        }
-
-        IEnumerable<EnumDeclarationSyntax> distinctEnums = enums.Distinct();
-
-        List<EnumInfo> enumsToProcess = GetTypesToGenerate(compilation, distinctEnums, context.CancellationToken);
-        if (enumsToProcess.Count == 0)
-        {
-            return;
-        }
-
-        Template template = Template.Parse(SourceGenerationHelper.ConverterTemplate);
-        foreach (var enumToProcess in enumsToProcess)
-        {
-            var result = SourceGenerationHelper.GenerateConverterClass(template, enumToProcess);
-            context.AddSource(
-                hintName: $"{enumToProcess.Name}Converter.g.cs",
-                sourceText: SourceText.From(result, Encoding.UTF8)
-            );
-        }
-    }
-
-    static List<EnumInfo> GetTypesToGenerate(
-        Compilation compilation,
-        IEnumerable<EnumDeclarationSyntax> enums, CancellationToken ct)
-    {
-        var enumsToProcess = new List<EnumInfo>();
-        INamedTypeSymbol? enumAttribute = compilation.GetTypeByMetadataName(JsonConverterAttribute);
-        if (enumAttribute is null)
-        {
-            // nothing to do if this type isn't available
-            return enumsToProcess;
-        }
-
-        foreach (var enumDeclarationSyntax in enums)
-        {
-            // stop if we're asked to
-            ct.ThrowIfCancellationRequested();
-
-            SemanticModel semanticModel = compilation.GetSemanticModel(enumDeclarationSyntax.SyntaxTree);
-            if (semanticModel.GetDeclaredSymbol(enumDeclarationSyntax, cancellationToken: ct)
-                is not INamedTypeSymbol enumSymbol)
-            {
-                // report diagnostic, something went wrong
-                continue;
-            }
-
-            string name = enumSymbol.Name;
-            string nameSpace = enumSymbol.ContainingNamespace.IsGlobalNamespace
-                ? string.Empty
-                : enumSymbol.ContainingNamespace.ToString();
-
-            string fullyQualifiedName = enumSymbol.ToString();
-
-            var enumMembers = enumSymbol.GetMembers();
-            var members = new List<KeyValuePair<string, string>>(enumMembers.Length);
-
-            foreach (var member in enumMembers)
-            {
-                if (member is not IFieldSymbol field
-                    || field.ConstantValue is null)
-                {
-                    continue;
-                }
-
-                string? displayName = null;
-                foreach (var attribute in member.GetAttributes())
-                {
-                    if (attribute.AttributeClass is null
-                        || attribute.AttributeClass.Name != "DisplayAttribute")
-                    {
-                        continue;
-                    }
-
-                    foreach (var namedArgument in attribute.NamedArguments)
-                    {
-                        if (namedArgument.Key == "Name" && namedArgument.Value.Value?.ToString() is { } dn)
-                        {
-                            displayName = dn;
-                            break;
-                        }
-                    }
-                }
-
-                members.Add(new(
-                    member.Name,
-                    displayName ?? ToSnakeCase(member.Name)
-                ));
-            }
-
-            enumsToProcess.Add(new(
-                name: name,
-                ns: nameSpace,
-                fullyQualifiedName: fullyQualifiedName,
-                members: members
-            ));
-        }
-        return enumsToProcess;
-    }
-
-    static string ToSnakeCase(string name) =>
-        string.Concat(name.Select((x, i) => i > 0 && char.IsUpper(x)
-            ? $"_{x}"
-            : x.ToString())
-        ).ToLower();
 }

--- a/src/EnumSerializer.Generator/EnumInfo.cs
+++ b/src/EnumSerializer.Generator/EnumInfo.cs
@@ -1,25 +1,20 @@
 namespace EnumSerializer.Generator;
 
-public readonly struct EnumInfo
+public sealed class EnumInfo
 {
-    public readonly string Name;
-    public readonly string FullyQualifiedName;
-    public readonly string Namespace;
+    public string Name { get; }
 
-    /// <summary>
-    /// Key is the enum name.
-    /// </summary>
-    public readonly List<KeyValuePair<string, string>> Members;
+    public string Namespace { get; }
+
+    public IReadOnlyList<KeyValuePair<string, string>> Members { get; }
 
     public EnumInfo(
         string name,
         string ns,
-        string fullyQualifiedName,
         List<KeyValuePair<string, string>> members)
     {
         Name = name;
         Namespace = ns;
         Members = members;
-        FullyQualifiedName = fullyQualifiedName;
     }
 }


### PR DESCRIPTION
I stumbled upon a [Sergio0694](https://github.com/Sergio0694)'s post about Andrew Lock's guide.

> The article is a nice overview, but be warned that (at least part 1) is outdated and extremely inefficient (and not actually incremental). You should never, ever, pass symbols or compilation objects to an output node, and should also ensure all incremental models are fully equatable. Also you should use `ForAttributeWithMetadataName` to find targets using a given attribute, it's like 100x (or more) times faster than trying to resolve symbols for each syntax node and then manually checking whether an attribute is a match.

So I decided to get rid of compilation objects in our source generator (mostly for fun) following this example [EventSourceGenerator](https://github.com/dotnet/runtime/blob/156c373079eba9b7513bad607de3bd3a2b63bb96/src/libraries/System.Private.CoreLib/gen/EventSourceGenerator.cs).