### PR TITLE
Fix: net6.0 compiler directives

### DIFF
--- a/src/Telegram.Bot/Extensions/HttpResponseMessageExtensions.cs
+++ b/src/Telegram.Bot/Extensions/HttpResponseMessageExtensions.cs
@@ -76,7 +76,7 @@ internal static class HttpResponseMessageExtensions
         }
         finally
         {
-#if NETCOREAPP3_1_OR_GREATER
+#if NET6_0_OR_GREATER
             if (contentStream is not null)
             {
                 await contentStream.DisposeAsync().ConfigureAwait(false);

--- a/src/Telegram.Bot/Polling/AsyncEnumerableReceivers/BlockingUpdateReceiver.cs
+++ b/src/Telegram.Bot/Polling/AsyncEnumerableReceivers/BlockingUpdateReceiver.cs
@@ -1,4 +1,4 @@
-﻿#if NETCOREAPP3_1_OR_GREATER
+﻿#if NET6_0_OR_GREATER
 using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;

--- a/src/Telegram.Bot/Polling/AsyncEnumerableReceivers/QueuedUpdateReceiver.cs
+++ b/src/Telegram.Bot/Polling/AsyncEnumerableReceivers/QueuedUpdateReceiver.cs
@@ -1,4 +1,4 @@
-﻿#if NETCOREAPP3_1_OR_GREATER
+﻿#if NET6_0_OR_GREATER
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Threading;

--- a/src/Telegram.Bot/Polling/TelegramBotClientExtensions.cs
+++ b/src/Telegram.Bot/Polling/TelegramBotClientExtensions.cs
@@ -29,7 +29,7 @@ internal static class TelegramBotClientExtensions
         var updates = await botClient.MakeRequestAsync(request: request, cancellationToken: cancellationToken)
             .ConfigureAwait(false);
 
-#if NETCOREAPP3_1_OR_GREATER
+#if NET6_0_OR_GREATER
         if (updates.Length > 0) { return updates[^1].Id + 1; }
 #else
         if (updates.Length > 0) { return updates[updates.Length - 1].Id + 1; }

--- a/src/Telegram.Bot/TelegramBotClientOptions.cs
+++ b/src/Telegram.Bot/TelegramBotClientOptions.cs
@@ -89,7 +89,7 @@ public class TelegramBotClientOptions
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         static long? GetIdFromToken(string token)
         {
-#if NETCOREAPP3_1_OR_GREATER
+#if NET6_0_OR_GREATER
             var span = token.AsSpan();
             var index = span.IndexOf(':');
 


### PR DESCRIPTION
Since we moved to `net6.0` TFM we can upgrade preprocessor directives accordingly.