### PR TITLE
Polling: Catch HandleUpdateAsync exceptions and pass them to HandleErrorAsync

### DIFF
--- a/.azure-pipelines/variables.yml
+++ b/.azure-pipelines/variables.yml
@@ -1,7 +1,7 @@
 variables:
   - group: Integration Tests Variables
   - name: versionPrefix
-    value: 21.2.0
+    value: 21.3.0
   - name: versionSuffix
     value: ''
   - name: ciVersionSuffix

--- a/README.md
+++ b/README.md
@@ -1,14 +1,14 @@
 # .NET Client for Telegram Bot API
 
-[![package](https://img.shields.io/badge/dynamic/json?url=https%3A%2F%2Fnuget.voids.site%2Fv3%2Fpackage%2FTelegram.Bot%2Findex.json&query=versions%5B-1%3A%5D&style=flat-square&label=Telegram.Bot&color=d8b541)](https://nuget.voids.site/packages/Telegram.Bot)
+[![Nuget](https://img.shields.io/badge/dynamic/json?url=https%3A%2F%2Fnuget.voids.site%2Fv3%2Fpackage%2FTelegram.Bot%2Findex.json&query=versions%5B-1%3A%5D&style=flat-square&label=Telegram.Bot&color=d8b541)](https://nuget.voids.site/packages/Telegram.Bot)
 [![Bot API Version](https://img.shields.io/badge/Bot%20API-7.5-f36caf.svg?style=flat-square)](https://core.telegram.org/bots/api#march-31-2024)
-[![documentations](https://img.shields.io/badge/Documentations-Book-orange.svg?style=flat-square)](https://telegrambots.github.io/book/)
-[![telegram chat](https://img.shields.io/badge/Support_Chat-Telegram-blue.svg?style=flat-square)](https://t.me/joinchat/B35YY0QbLfd034CFnvCtCA)  
-[![build](https://img.shields.io/azure-devops/build/tgbots/14f9ab3f-313a-4339-8534-e8b96c7763cc/6?style=flat-square&label=master)](https://dev.azure.com/tgbots/Telegram.Bot/_build/latest?definitionId=6&branchName=master)
-[![build](https://img.shields.io/azure-devops/build/tgbots/14f9ab3f-313a-4339-8534-e8b96c7763cc/10/develop?style=flat-square&label=develop)](https://dev.azure.com/tgbots/Telegram.Bot/_build/latest?definitionId=10&branchName=develop)
-[![downloads](https://img.shields.io/nuget/dt/Telegram.Bot.svg?style=flat-square&label=Package%20Downloads)](https://www.nuget.org/packages/Telegram.Bot)
-[![contributors](https://img.shields.io/github/contributors/TelegramBots/Telegram.Bot.svg?style=flat-square&label=Contributors)](https://github.com/TelegramBots/Telegram.Bot/graphs/contributors)
-[![license](https://img.shields.io/github/license/TelegramBots/telegram.bot.svg?style=flat-square&maxAge=2592000&label=License)](https://raw.githubusercontent.com/TelegramBots/telegram.bot/master/LICENSE)
+[![Documentations](https://img.shields.io/badge/Documentations-Book-orange.svg?style=flat-square)](https://telegrambots.github.io/book/)
+[![Telegram Chat](https://img.shields.io/badge/Support_Chat-Telegram-blue.svg?style=flat-square)](https://t.me/joinchat/B35YY0QbLfd034CFnvCtCA)  
+[![Master build](https://img.shields.io/azure-devops/build/tgbots/14f9ab3f-313a-4339-8534-e8b96c7763cc/6?style=flat-square&label=master)](https://dev.azure.com/tgbots/Telegram.Bot/_build/latest?definitionId=6&branchName=master)
+[![Develop build](https://img.shields.io/azure-devops/build/tgbots/14f9ab3f-313a-4339-8534-e8b96c7763cc/10/develop?style=flat-square&label=develop)](https://dev.azure.com/tgbots/Telegram.Bot/_build/latest?definitionId=10&branchName=develop)
+[![Downloads](https://img.shields.io/nuget/dt/Telegram.Bot.svg?style=flat-square&label=Package%20Downloads)](https://www.nuget.org/packages/Telegram.Bot)
+[![Contributors](https://img.shields.io/github/contributors/TelegramBots/Telegram.Bot.svg?style=flat-square&label=Contributors)](https://github.com/TelegramBots/Telegram.Bot/graphs/contributors)
+[![License](https://img.shields.io/github/license/TelegramBots/telegram.bot.svg?style=flat-square&maxAge=2592000&label=License)](https://raw.githubusercontent.com/TelegramBots/telegram.bot/master/LICENSE)
 
 **Telegram.Bot** is the most popular .NET Client for [Telegram Bot API].
 

--- a/src/Telegram.Bot/Exceptions/ApiRequestException.cs
+++ b/src/Telegram.Bot/Exceptions/ApiRequestException.cs
@@ -89,4 +89,13 @@ public class ApiRequestException : RequestException
         ErrorCode = errorCode;
         Parameters = parameters;
     }
+
+    /// <inheritdoc/>>
+    public override string ToString()
+    {
+        var str = base.ToString();
+        if (str.IndexOf(':') is >= 0 and int colon)
+            str = $"Telegram Bot API error {ErrorCode}{str.Substring(colon)}";
+        return str;
+    }
 }

--- a/src/Telegram.Bot/Extend.Types.cs
+++ b/src/Telegram.Bot/Extend.Types.cs
@@ -74,11 +74,21 @@ namespace Telegram.Bot.Types
                 : CaptionEntities?.Select(entity => Caption.Substring(entity.Offset, entity.Length));
     }
 
+    public partial class Chat
+    {
+        /// <inheritdoc/>
+        public override string ToString() => Type switch
+        {
+            ChatType.Private => Username != null ? $"Private chat with @{Username} ({Id})" : $"Private chat with {FirstName}{LastName?.Insert(0, " ")} ({Id})",
+            _ => $"{Type} \"{Title}\" ({Id})"
+        };
+    }
+
     public partial class User
     {
         /// <inheritdoc/>
         public override string ToString() =>
-            $"{(Username is null ? $"{FirstName}{LastName?.Insert(0, " ")}" : $"@{Username}")} ({Id})";
+            Username != null ? $"@{Username} ({Id})" : $"{FirstName}{LastName?.Insert(0, " ")} ({Id})";
     }
 
     public partial class ReplyParameters

--- a/src/Telegram.Bot/Polling/Abstractions/IUpdateHandler.cs
+++ b/src/Telegram.Bot/Polling/Abstractions/IUpdateHandler.cs
@@ -1,4 +1,4 @@
-﻿using System.Threading;
+using System.Threading;
 using System.Threading.Tasks;
 using JetBrains.Annotations;
 
@@ -22,7 +22,6 @@ public interface IUpdateHandler
     /// <param name="cancellationToken">
     /// The <see cref="CancellationToken"/> which will notify that method execution should be cancelled
     /// </param>
-    /// <returns></returns>
     Task HandleUpdateAsync(ITelegramBotClient botClient, Update update, CancellationToken cancellationToken);
 
     /// <summary>
@@ -32,13 +31,20 @@ public interface IUpdateHandler
     /// The <see cref="ITelegramBotClient"/> instance of the bot receiving the <see cref="Exception"/>
     /// </param>
     /// <param name="exception">The <see cref="Exception"/> to handle</param>
+    /// <param name="source">Where the error occured</param>
     /// <param name="cancellationToken">
     /// The <see cref="CancellationToken"/> which will notify that method execution should be cancelled
     /// </param>
-    /// <returns></returns>
-    Task HandlePollingErrorAsync(
-        ITelegramBotClient botClient,
-        Exception exception,
-        CancellationToken cancellationToken
-    );
+    Task HandleErrorAsync(ITelegramBotClient botClient, Exception exception, HandleErrorSource source, CancellationToken cancellationToken);
+}
+
+/// <summary>The source of the error</summary>
+public enum HandleErrorSource
+{
+    /// <summary>Exception occured during GetUpdates. Polling of updates will continue</summary>
+    PollingError,
+    /// <summary>A fatal uncaught exception occured somewhere. Polling of updates will stop</summary>
+    FatalError,
+    /// <summary>Exception was thrown by HandleUpdateAsync. Polling of updates will continue</summary>
+    HandleUpdateError,
 }

--- a/src/Telegram.Bot/Polling/DefaultUpdateReceiver.cs
+++ b/src/Telegram.Bot/Polling/DefaultUpdateReceiver.cs
@@ -84,9 +84,10 @@ public class DefaultUpdateReceiver : IUpdateReceiver
             {
                 try
                 {
-                    await updateHandler.HandlePollingErrorAsync(
+                    await updateHandler.HandleErrorAsync(
                         botClient: _botClient,
                         exception: exception,
+                        source: HandleErrorSource.PollingError,
                         cancellationToken: cancellationToken
                     ).ConfigureAwait(false);
                 }
@@ -111,6 +112,22 @@ public class DefaultUpdateReceiver : IUpdateReceiver
                 catch (OperationCanceledException)
                 {
                     return;
+                }
+                catch (Exception ex)
+                {
+                    try
+                    {
+                        await updateHandler.HandleErrorAsync(
+                            botClient: _botClient,
+                            exception: ex,
+                            source: HandleErrorSource.HandleUpdateError,
+                            cancellationToken: cancellationToken
+                        ).ConfigureAwait(false);
+                    }
+                    catch (OperationCanceledException)
+                    {
+                        // ignored
+                    }
                 }
             }
         }

--- a/src/Telegram.Bot/Polling/DefaultUpdateReceiver.cs
+++ b/src/Telegram.Bot/Polling/DefaultUpdateReceiver.cs
@@ -68,7 +68,6 @@ public class DefaultUpdateReceiver : IUpdateReceiver
             var updates = emptyUpdates;
             try
             {
-
                 updates = await _botClient.MakeRequestAsync(
                     request: request,
                     cancellationToken: cancellationToken
@@ -101,13 +100,13 @@ public class DefaultUpdateReceiver : IUpdateReceiver
             {
                 try
                 {
+                    request.Offset = update.Id + 1;
+
                     await updateHandler.HandleUpdateAsync(
                         botClient: _botClient,
                         update: update,
                         cancellationToken: cancellationToken
                     ).ConfigureAwait(false);
-
-                    request.Offset = update.Id + 1;
                 }
                 catch (OperationCanceledException)
                 {

--- a/test/Telegram.Bot.Tests.Unit/Polling/AsyncEnumerableReceivers/QueuedUpdateReceiverTests.cs
+++ b/test/Telegram.Bot.Tests.Unit/Polling/AsyncEnumerableReceivers/QueuedUpdateReceiverTests.cs
@@ -1,4 +1,4 @@
-﻿#if NET6_0_OR_GREATER
+#if NET6_0_OR_GREATER
 
 using System.Collections.Generic;
 using System.Threading;
@@ -46,7 +46,7 @@ public class QueuedUpdateReceiverTests
     {
         MockTelegramBotClient mockClient = new("foo-bar", "123", "one-two-three", "456");
         QueuedUpdateReceiver receiver = new(mockClient);
-        mockClient.Options.RequestDelay = 250;
+        mockClient.Options.RequestDelay = 500;
 
         Assert.Equal(4, mockClient.MessageGroupsLeft);
         Assert.Equal(0, receiver.PendingUpdates);

--- a/test/Telegram.Bot.Tests.Unit/Polling/MockTelegramBotClient.cs
+++ b/test/Telegram.Bot.Tests.Unit/Polling/MockTelegramBotClient.cs
@@ -27,6 +27,7 @@ public class MockTelegramBotClient : ITelegramBotClient
 {
     readonly Queue<string[]> _messages;
 
+    public int? lastOffsetRequested = null;
     public int MessageGroupsLeft => _messages.Count;
     public MockClientOptions Options { get; }
 
@@ -53,6 +54,9 @@ public class MockTelegramBotClient : ITelegramBotClient
         Options.GlobalCancelToken.ThrowIfCancellationRequested();
         await Task.Delay(Options.RequestDelay, cancellationToken);
 
+        if (getUpdatesRequest.Offset.HasValue && getUpdatesRequest.Offset == lastOffsetRequested && _messages.Count != 0)
+            throw new InvalidOperationException("Repeating same request.Offset is not supported");
+        lastOffsetRequested = getUpdatesRequest.Offset;
         if (Options.ExceptionToThrow is not null) { throw Options.ExceptionToThrow; }
 
         if (Options.HandleNegativeOffset && getUpdatesRequest.Offset == -1)

--- a/test/Telegram.Bot.Tests.Unit/Polling/ReceiveAsyncTests.cs
+++ b/test/Telegram.Bot.Tests.Unit/Polling/ReceiveAsyncTests.cs
@@ -100,7 +100,7 @@ public class ReceiveAsyncTests
             updateHandler: HandleUpdate,
             errorHandler: async (_, ex, source, token) =>
             {
-                if (source == HandleErrorSource.HandleUpdateError) throw ex;
+                if (source is HandleErrorSource.HandleUpdateError or HandleErrorSource.PollingError) throw ex;
                 await Task.Delay(10, token);
             });
 

--- a/test/Telegram.Bot.Tests.Unit/Polling/ReceiveAsyncTests.cs
+++ b/test/Telegram.Bot.Tests.Unit/Polling/ReceiveAsyncTests.cs
@@ -30,7 +30,7 @@ public class ReceiveAsyncTests
 
         DefaultUpdateHandler updateHandler = new(
             updateHandler: HandleUpdate,
-            pollingErrorHandler: async (_, _, token) => await Task.Delay(10, token)
+            errorHandler: async (_, _, token) => await Task.Delay(10, token)
         );
 
         CancellationToken cancellationToken = cancellationTokenSource.Token;
@@ -68,7 +68,7 @@ public class ReceiveAsyncTests
 
         DefaultUpdateHandler updateHandler = new(
             updateHandler: HandleUpdate,
-            pollingErrorHandler: async (_, _, token) => await Task.Delay(10, token)
+            errorHandler: async (_, _, _, token) => await Task.Delay(10, token)
         );
 
         CancellationToken cancellationToken = cancellationTokenSource.Token;
@@ -81,7 +81,7 @@ public class ReceiveAsyncTests
     }
 
     [Fact]
-    public async Task UserExceptionsPropagateToSurface()
+    public async Task UserExceptionsPropagateToSurfaceWhenRethrown()
     {
         MockTelegramBotClient bot = new("foo-bar", "throw");
 
@@ -98,8 +98,11 @@ public class ReceiveAsyncTests
 
         DefaultUpdateHandler updateHandler = new(
             updateHandler: HandleUpdate,
-            pollingErrorHandler: async (_, _, token) => await Task.Delay(10, token)
-        );
+            errorHandler: async (_, ex, source, token) =>
+            {
+                if (source == HandleErrorSource.HandleUpdateError) throw ex;
+                await Task.Delay(10, token);
+            });
 
         try
         {
@@ -113,6 +116,43 @@ public class ReceiveAsyncTests
         }
 
         Assert.Equal(3, updateCount);
+        Assert.Equal(0, bot.MessageGroupsLeft);
+    }
+
+    [Fact]
+    public async Task UserExceptionsPassedToErrorHandler()
+    {
+        using CancellationTokenSource cts = new();
+        MockTelegramBotClient bot = new("foo-bar", "throw", "stop");
+
+        int updateCount = 0;
+        async Task HandleUpdate(ITelegramBotClient botClient, Update update, CancellationToken cancellationToken)
+        {
+            updateCount++;
+            await Task.Delay(10, cancellationToken);
+            if (update.Message?.Text is "throw")
+                throw new InvalidOperationException("Oops");
+            else if (update.Message?.Text is "stop")
+                cts.Cancel();
+        }
+
+        Exception? gotException = null;
+        DefaultUpdateHandler updateHandler = new(
+            updateHandler: HandleUpdate,
+            errorHandler: async (_, ex, source, token) =>
+            {
+                Assert.Null(gotException);
+                gotException = ex;
+                await Task.Delay(10, token);
+            });
+
+        await bot.ReceiveAsync(updateHandler, cancellationToken: cts.Token);
+
+        Assert.True(cts.IsCancellationRequested);
+        Assert.NotNull(gotException);
+        Assert.IsAssignableFrom<InvalidOperationException>(gotException);
+        Assert.Contains("Oops", gotException.Message);
+        Assert.Equal(4, updateCount);
         Assert.Equal(0, bot.MessageGroupsLeft);
     }
 
@@ -140,7 +180,7 @@ public class ReceiveAsyncTests
 
         DefaultUpdateHandler updateHandler = new(
             updateHandler: HandleUpdate,
-            pollingErrorHandler: (_, _, _) => Task.CompletedTask
+            errorHandler: (_, _, _) => Task.CompletedTask
         );
 
         await bot.ReceiveAsync(


### PR DESCRIPTION
Yes, that's potentially a breaking change, but a welcomed one