### PR TITLE
Expose bot token

### DIFF
--- a/src/Telegram.Bot/ITelegramBotClient.cs
+++ b/src/Telegram.Bot/ITelegramBotClient.cs
@@ -17,6 +17,9 @@ public interface ITelegramBotClient
     /// <summary><see langword="true"/> when the bot is using local Bot API server</summary>
     bool LocalBotServer { get; }
 
+    /// <summary>API token</summary>
+    string Token { get; }
+
     /// <summary>Unique identifier for the bot from bot token, extracted from the first part of the bot token.
     /// Token format is not public API so this property is optional and may stop working in the future if Telegram changes it's token format.</summary>
     long BotId { get; }

--- a/src/Telegram.Bot/TelegramBotClient.cs
+++ b/src/Telegram.Bot/TelegramBotClient.cs
@@ -23,6 +23,9 @@ public class TelegramBotClient : ITelegramBotClient
     private readonly HttpClient _httpClient;
 
     /// <inheritdoc/>
+    public string Token => _options.Token;
+
+    /// <inheritdoc/>
     public long BotId => _options.BotId;
 
     /// <inheritdoc/>

--- a/test/Telegram.Bot.Tests.Unit/Polling/MockTelegramBotClient.cs
+++ b/test/Telegram.Bot.Tests.Unit/Polling/MockTelegramBotClient.cs
@@ -107,6 +107,7 @@ public class MockTelegramBotClient : ITelegramBotClient
     // NOT IMPLEMENTED
     // ---------------
 
+    public string Token => throw new NotImplementedException();
     public bool LocalBotServer => throw new NotImplementedException();
     public long BotId => throw new NotImplementedException();
     public event AsyncEventHandler<ApiRequestEventArgs>? OnMakingApiRequest;


### PR DESCRIPTION
Bot token is required for WebApp.initData validation and it would be convenient to get token directly from client instance instead of passing token along it into different services. Are there any issues with exposing bot token?